### PR TITLE
Add animated bear-eye intro for start transition

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1176,6 +1176,44 @@ canvas {
   overflow: hidden;
 }
 
+#darkScreen.start-transition-active {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.start-transition-scene {
+  position: relative;
+  width: min(90vmin, 700px);
+  aspect-ratio: 1;
+  opacity: 0;
+  transform: scale(0.96);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  pointer-events: none;
+}
+
+#darkScreen.start-transition-active .start-transition-scene {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.start-transition-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  user-select: none;
+}
+
+.start-transition-glow {
+  filter: drop-shadow(0 0 36px rgba(168, 85, 247, 0.45));
+}
+
+.start-transition-eyes {
+  filter: drop-shadow(0 0 18px rgba(239, 68, 68, 0.8));
+}
+
 #darkScreen .crash-flyer {
   position: absolute;
   width: 128px;
@@ -1454,4 +1492,3 @@ footer a:hover { color: #e0b0ff; }
 
 .icon-s  { transform: scale(0.875); transform-origin: left center; }
 .icon-xs { transform: scale(0.625); transform-origin: left center; }
-

--- a/index.html
+++ b/index.html
@@ -529,7 +529,13 @@
 </div><!-- #storeScreen -->
 
 <!-- Dark screen (pre-game transition) -->
-<div id="darkScreen"></div>
+<div id="darkScreen">
+  <div class="start-transition-scene" aria-hidden="true">
+    <img src="img/glow.png" class="start-transition-layer start-transition-glow" width="1000" height="1000" decoding="async" alt="">
+    <img src="img/bear.png" class="start-transition-layer start-transition-bear" width="1000" height="1000" decoding="async" alt="">
+    <img src="img/startgame/eyes_1.webp" class="start-transition-layer start-transition-eyes" id="startTransitionEyes" width="1000" height="1000" decoding="async" alt="">
+  </div>
+</div>
 
 <!-- ===== RULES OVERLAY ===== -->
 <div id="rulesScreen">

--- a/js/game.js
+++ b/js/game.js
@@ -6,8 +6,49 @@ let _cachedBgGrad = null;
 const CRASH_FLYER_SRC = "img/bear_pixel_transparent.webp";
 const CRASH_FLYER_FALLBACK_SRC = "img/bear.png";
 const CRASH_FLY_DEFAULT_DURATION_MS = 6000;
+const START_TRANSITION_EYE_FRAMES = Array.from({ length: 12 }, (_, i) => `img/startgame/eyes_${i + 1}.webp`);
+const START_TRANSITION_FRAME_MS = 80;
+
+let startTransitionTimer = null;
+
+function stopStartTransitionAnimation() {
+  if (startTransitionTimer) {
+    clearInterval(startTransitionTimer);
+    startTransitionTimer = null;
+  }
+
+  const darkScreen = document.getElementById("darkScreen");
+  if (!darkScreen) return;
+
+  darkScreen.classList.remove("start-transition-active");
+
+  const eyes = document.getElementById("startTransitionEyes");
+  if (eyes) {
+    eyes.src = START_TRANSITION_EYE_FRAMES[0];
+  }
+}
+
+function playStartTransitionAnimation() {
+  stopStartTransitionAnimation();
+
+  const darkScreen = document.getElementById("darkScreen");
+  const eyes = document.getElementById("startTransitionEyes");
+  if (!darkScreen || !eyes) return;
+
+  darkScreen.classList.add("start-transition-active");
+
+  let frame = 0;
+  eyes.src = START_TRANSITION_EYE_FRAMES[frame];
+
+  startTransitionTimer = setInterval(() => {
+    frame = (frame + 1) % START_TRANSITION_EYE_FRAMES.length;
+    eyes.src = START_TRANSITION_EYE_FRAMES[frame];
+  }, START_TRANSITION_FRAME_MS);
+}
 
 function stopGameOverCrashAnimation() {
+  stopStartTransitionAnimation();
+
   const darkScreen = document.getElementById("darkScreen");
   if (!darkScreen) return;
   darkScreen.classList.remove("gameover-transition");
@@ -122,6 +163,7 @@ async function startGame() {
 
   const darkScreen = document.getElementById("darkScreen");
   darkScreen.style.display = "block";
+  playStartTransitionAnimation();
 
   DOM.gameOver.classList.remove("visible");
 


### PR DESCRIPTION
### Motivation
- Improve the start-game black-screen by placing the main-screen bear over a dark vignette with glow and an animated eye layer to make the pre-game transition visually engaging and match the main menu art.

### Description
- Added a start-transition scene inside `#darkScreen` with layered `glow.png`, `bear.png` and a dedicated `startTransitionEyes` image initialized to `img/startgame/eyes_1.webp` in `index.html`.
- Added CSS to center the scene on the dark screen, animate a soft fade/scale-in, and apply glow/drop-shadow styling to the glow and eyes layers (`css/style.css`).
- Implemented a simple frame-by-frame eyes animation cycling `img/startgame/eyes_1.webp` → `img/startgame/eyes_12.webp` with `START_TRANSITION_FRAME_MS` timing and lifecycle helpers `playStartTransitionAnimation()` / `stopStartTransitionAnimation()` in `js/game.js`.
- Wired the animation into the start flow so it begins when `startGame()` shows `#darkScreen` and is stopped/reset when the transition ends or when other dark-screen animations run (e.g. gameover crash flyer), avoiding resource leaks.

### Testing
- Ran `node --check js/game.js` to verify JS syntax and module-level errors; result: success.
- Started a local server with `python3 -m http.server 4173` and exercised the UI with an automated Playwright script that clicks `#startBtn` and captures a screenshot; result: Playwright script ran and produced the transition screenshot (artifact captured), indicating images load and animation plays.
- Verified the page served required assets (server logs showed successful GETs for `img/startgame/eyes_*.webp`) and there were no runtime exceptions during the transition in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71ffe67288332927226b937a228ae)