### PR TITLE
Add start-game transition overlay with animated bear vignette and eyes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1176,6 +1176,46 @@ canvas {
   overflow: hidden;
 }
 
+#darkScreen.start-transition-active {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.start-transition-vignette {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, transparent 40%, rgba(0, 0, 0, .6) 100%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+#darkScreen.start-transition-active .start-transition-vignette {
+  opacity: 1;
+}
+
+.start-transition-bear-wrapper {
+  margin: 0;
+  opacity: 0;
+  transform: scale(0.96);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+  z-index: 1;
+}
+
+#darkScreen.start-transition-active .start-transition-bear-wrapper {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.start-transition-glow {
+  filter: blur(70px);
+}
+
+.start-transition-eyes {
+  filter: drop-shadow(0 0 18px rgba(239, 68, 68, 0.8));
+}
+
 #darkScreen .crash-flyer {
   position: absolute;
   width: 128px;
@@ -1454,4 +1494,3 @@ footer a:hover { color: #e0b0ff; }
 
 .icon-s  { transform: scale(0.875); transform-origin: left center; }
 .icon-xs { transform: scale(0.625); transform-origin: left center; }
-

--- a/index.html
+++ b/index.html
@@ -529,7 +529,14 @@
 </div><!-- #storeScreen -->
 
 <!-- Dark screen (pre-game transition) -->
-<div id="darkScreen"></div>
+<div id="darkScreen">
+  <div class="start-transition-vignette" aria-hidden="true"></div>
+  <div class="bear-wrapper start-transition-bear-wrapper" aria-hidden="true">
+    <img src="img/glow.png" class="layer glow start-transition-glow" width="1000" height="1000" decoding="async" alt="">
+    <img src="img/bear.png" class="layer bear start-transition-bear" width="1000" height="1000" decoding="async" alt="">
+    <img src="img/startgame/eyes_1.webp" class="layer eyes start-transition-eyes" id="startTransitionEyes" width="1000" height="1000" decoding="async" alt="">
+  </div>
+</div>
 
 <!-- ===== RULES OVERLAY ===== -->
 <div id="rulesScreen">

--- a/js/game.js
+++ b/js/game.js
@@ -6,8 +6,49 @@ let _cachedBgGrad = null;
 const CRASH_FLYER_SRC = "img/bear_pixel_transparent.webp";
 const CRASH_FLYER_FALLBACK_SRC = "img/bear.png";
 const CRASH_FLY_DEFAULT_DURATION_MS = 6000;
+const START_TRANSITION_EYE_FRAMES = Array.from({ length: 12 }, (_, i) => `img/startgame/eyes_${i + 1}.webp`);
+const START_TRANSITION_FRAME_MS = 80;
+
+let startTransitionTimer = null;
+
+function stopStartTransitionAnimation() {
+  if (startTransitionTimer) {
+    clearInterval(startTransitionTimer);
+    startTransitionTimer = null;
+  }
+
+  const darkScreen = document.getElementById("darkScreen");
+  if (!darkScreen) return;
+
+  darkScreen.classList.remove("start-transition-active");
+
+  const eyes = document.getElementById("startTransitionEyes");
+  if (eyes) {
+    eyes.src = START_TRANSITION_EYE_FRAMES[0];
+  }
+}
+
+function playStartTransitionAnimation() {
+  stopStartTransitionAnimation();
+
+  const darkScreen = document.getElementById("darkScreen");
+  const eyes = document.getElementById("startTransitionEyes");
+  if (!darkScreen || !eyes) return;
+
+  darkScreen.classList.add("start-transition-active");
+
+  let frame = 0;
+  eyes.src = START_TRANSITION_EYE_FRAMES[frame];
+
+  startTransitionTimer = setInterval(() => {
+    frame = (frame + 1) % START_TRANSITION_EYE_FRAMES.length;
+    eyes.src = START_TRANSITION_EYE_FRAMES[frame];
+  }, START_TRANSITION_FRAME_MS);
+}
 
 function stopGameOverCrashAnimation() {
+  stopStartTransitionAnimation();
+
   const darkScreen = document.getElementById("darkScreen");
   if (!darkScreen) return;
   darkScreen.classList.remove("gameover-transition");
@@ -122,6 +163,7 @@ async function startGame() {
 
   const darkScreen = document.getElementById("darkScreen");
   darkScreen.style.display = "block";
+  playStartTransitionAnimation();
 
   DOM.gameOver.classList.remove("visible");
 


### PR DESCRIPTION
### Motivation

- Introduce a pre-game visual transition to enhance the game start experience and bridge from menus to gameplay.

### Description

- Add CSS for a `#darkScreen.start-transition-active` state and supporting classes (`.start-transition-vignette`, `.start-transition-bear-wrapper`, `.start-transition-glow`, `.start-transition-eyes`) to create a vignette, glow and scale animation for the bear graphic.
- Insert markup into `index.html` under `#darkScreen` to include the vignette and layered bear image elements including an eyes image with id `startTransitionEyes` for frame animation.
- Add JavaScript in `js/game.js` to animate the eyes by introducing `START_TRANSITION_EYE_FRAMES`, `START_TRANSITION_FRAME_MS`, and functions `playStartTransitionAnimation` and `stopStartTransitionAnimation`, and integrate `playStartTransitionAnimation` into the existing `startGame` flow while ensuring `stopStartTransitionAnimation` is invoked from `stopGameOverCrashAnimation`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71ffe67288332927226b937a228ae)