### PR TITLE
Enforce sequential Shield/Spin Alert upgrades and enhance store currency visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1109,10 +1109,16 @@ canvas {
   gap: 4px;
   font-family: 'Orbitron', sans-serif;
   font-size: 11px;
-  opacity: .6;
+  font-weight: 700;
+  opacity: .95;
+  text-shadow: 0 0 10px rgba(255, 255, 255, .28);
 }
 
-.store-item-currency img { width: 14px; height: 14px; }
+.store-item-currency img {
+  width: 14px;
+  height: 14px;
+  filter: brightness(1.2) saturate(1.15);
+}
 
 .store-tiers { display: flex; gap: 8px; }
 

--- a/js/store.js
+++ b/js/store.js
@@ -233,6 +233,16 @@ async function buyUpgrade(key, tier) {
     return;
   }
 
+  const sequentialOnlyKeys = new Set(["shield", "spin_alert"]);
+  const upgradeState = playerUpgrades && playerUpgrades[key];
+  if (sequentialOnlyKeys.has(key) && upgradeState) {
+    const expectedTier = Number(upgradeState.currentLevel || 0);
+    if (tier !== expectedTier) {
+      alert("⚠️ Buy previous level first");
+      return;
+    }
+  }
+
   const identifier = getAuthIdentifier();
   try {
     const timestamp = Date.now();


### PR DESCRIPTION
### Motivation
- Prevent players from buying tier 2/3 of Shield or Spin Alert before purchasing the previous tier to avoid invalid upgrade sequencing in the UI and accidental purchases. 
- Improve readability and visual prominence of the `GOLD`/`SILVER` currency labels and icons in the store so prices are clearer to users.

### Description
- Added a client-side guard in `buyUpgrade` that blocks purchases for `shield` and `spin_alert` when the requested `tier` does not equal the upgrade's `currentLevel`, showing an alert `"⚠️ Buy previous level first"` and returning early. (`js/store.js`)
- Adjusted store currency styling by increasing font weight, opacity, adding a subtle `text-shadow`, and boosting coin icon brightness/saturation via a CSS `filter` to make the coin and the `GOLD`/`SILVER` text visually stronger. (`css/style.css`)
- This change is a front-end/UI guard and styling improvement only and does not change server-side validation or upgrade semantics.

### Testing
- Ran `node --check js/store.js` to validate there are no syntax errors, which completed successfully. 
- Served the app locally with `python3 -m http.server 4173` and opened the store UI to verify styling and behavior, which loaded without errors. 
- Captured a Playwright screenshot of the store UI after forcing the store to be visible to validate the visual changes; the capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d390de4c8332b88522e6b9624dab)