### PR TITLE
Store: brighten available tiers and block clicks on locked Shield/Spin Alert

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1144,7 +1144,16 @@ canvas {
 
 .store-tier:active { transform: scale(0.96); }
 
-.store-tier.available { border-color: var(--border-accent); cursor: pointer; }
+.store-tier.available {
+  border-color: rgba(140, 80, 255, .72);
+  background: rgba(140, 80, 255, .14);
+  box-shadow: 0 0 16px rgba(140, 80, 255, .24);
+  color: rgba(255, 255, 255, .95);
+  cursor: pointer;
+}
+
+.store-tier.available .store-tier-label { color: #e5b7ff; }
+.store-tier.available .store-tier-price { opacity: .95; }
 
 .store-tier.available:hover {
   border-color: rgba(140, 80, 255, .7);

--- a/js/store.js
+++ b/js/store.js
@@ -180,6 +180,7 @@ function updateStoreUI() {
       el.style.opacity = "";
       el.style.pointerEvents = "";
       el.onclick = null;
+      el.removeAttribute("onclick");
 
       if (i < data.currentLevel) {
         el.classList.add("purchased");
@@ -191,7 +192,6 @@ function updateStoreUI() {
         el.onclick = function() { buyUpgrade(upgradeKey, tierIndex); };
       } else {
         el.classList.add("locked");
-        el.style.opacity = "0.25";
         el.style.pointerEvents = "none";
       }
     }


### PR DESCRIPTION
### Motivation
- Make store upgrades that are currently purchasable visually more prominent (match the emphasis used for gold items like Rides) so players notice available tiers.  
- Ensure sequential upgrades (Shield / Spin Alert) remain non-clickable until the previous level is bought to avoid accidental or misleading clicks.  

### Description
- Updated `.store-tier.available` in `css/style.css` to add stronger border, background, glow, and improved label/price contrast to make available tiers visually brighter.  
- Added `el.removeAttribute("onclick")` and cleared `el.onclick` in `js/store.js` when rendering tiers to ensure previously-attached inline handlers are removed before updating classes.  
- For `locked` tiers the code now preserves `pointer-events: none` and avoids forcing an extra opacity manipulation so locked items remain non-interactive consistent with silver-tier behavior.  

### Testing
- Performed static checks with `node --check js/store.js` and `node --check js/game.js`, both succeeded.  
- Launched a local HTTP server (`python3 -m http.server ...`) and captured a Store screen screenshot via an automated browser run to visually verify the updated available/locked styling (screenshot produced).  
- Manual UI verification confirmed available tiers are noticeably brighter and locked Shield/Spin Alert tiers are not clickable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d7554cb483329f5bb902fc06fdb6)