### PR TITLE
Require Shield upgrade for shield bonus stacking

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -589,7 +589,15 @@ function applyBonus(bonus) {
 
   const bonusMap = {
     [BONUS_TYPES.SHIELD]: () => {
-      player.shieldCount = Math.min(player.shieldCount + 1, (playerEffects && playerEffects.start_shield_count ? playerEffects.start_shield_count : 1) + 1);
+      const shieldUpgradeLevel = (playerUpgrades && playerUpgrades.shield)
+        ? playerUpgrades.shield.currentLevel
+        : 0;
+      const canAccumulateShield = shieldUpgradeLevel >= 1;
+      const maxShieldCount = canAccumulateShield
+        ? ((playerEffects && playerEffects.start_shield_count) ? playerEffects.start_shield_count : 1) + 1
+        : 1;
+
+      player.shieldCount = Math.min(player.shieldCount + 1, maxShieldCount);
       player.shield = player.shieldCount > 0;
       showBonusText(`🛡 Shield! (${player.shieldCount})`);
       audioManager.playSFX("good_bonus");


### PR DESCRIPTION
### Motivation
- Fix a bug where shield bonuses always stacked during a run even if the Shield upgrade was not bought; stacking should be allowed only when the player purchased the Shield upgrade, and backend changes are not required as long as `playerUpgrades`/`playerEffects` are served correctly.

### Description
- Change `applyBonus` shield handler in `js/physics.js` to read `playerUpgrades.shield.currentLevel` and compute `maxShieldCount` as `((playerEffects && playerEffects.start_shield_count) ? playerEffects.start_shield_count : 1) + 1` when the upgrade is purchased, or `1` otherwise, then cap `player.shieldCount` with `Math.min(..., maxShieldCount)`.

### Testing
- Static verification performed: inspected the updated diff and confirmed the new logic lines in `js/physics.js` with `nl -ba js/physics.js | sed -n '584,612p'`; no automated unit tests exist for this area, so runtime playtesting in-browser is recommended to fully validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7dbe24ea88332a70640ce5dbdfd3f)