### PR TITLE
Improve Store upgrade locking flow and Spin Alert visual emphasis

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1161,6 +1161,24 @@ canvas {
   box-shadow: 0 0 14px rgba(140, 80, 255, .2);
 }
 
+.store-tier--highlight.available {
+  border-color: rgba(255, 172, 74, .86);
+  background: linear-gradient(180deg, rgba(255, 172, 74, .24), rgba(255, 132, 64, .16));
+  box-shadow: 0 0 18px rgba(255, 160, 69, .32), inset 0 0 12px rgba(255, 207, 126, .18);
+}
+
+.store-tier--highlight.available .store-tier-label {
+  color: #ffe1b0;
+  text-shadow: 0 0 12px rgba(255, 186, 91, .45);
+}
+
+.store-tier--highlight.available:hover {
+  border-color: rgba(255, 180, 94, .95);
+  background: linear-gradient(180deg, rgba(255, 182, 92, .26), rgba(255, 146, 80, .18));
+  box-shadow: 0 0 20px rgba(255, 171, 80, .36), inset 0 0 14px rgba(255, 218, 150, .2);
+}
+
+
 .store-tier.purchased {
   border-color: rgba(76, 175, 80, .3);
   background: rgba(76, 175, 80, .08);

--- a/index.html
+++ b/index.html
@@ -284,11 +284,11 @@
         <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
       </div>
       <div class="store-tiers">
-        <div class="store-tier" id="store-spinalert-0" onclick="buyUpgrade('spin_alert', 0)">
+        <div class="store-tier store-tier--highlight" id="store-spinalert-0" onclick="buyUpgrade('spin_alert', 0)">
           <div class="store-tier-label"> Alert</div>
           <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 1,000</div>
         </div>
-        <div class="store-tier" id="store-spinalert-1" onclick="buyUpgrade('spin_alert', 1)">
+        <div class="store-tier store-tier--highlight" id="store-spinalert-1" onclick="buyUpgrade('spin_alert', 1)">
           <div class="store-tier-label"> Perfect</div>
           <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 3,000</div>
         </div>

--- a/js/store.js
+++ b/js/store.js
@@ -111,6 +111,45 @@ let playerUpgrades = null;
 let playerEffects = null;
 let playerBalance = { gold: 0, silver: 0 };
 
+const STORE_UPGRADE_ID_MAP = {
+  x2_duration: 'x2',
+  score_plus_300_mult: 'scoreplus300',
+  score_plus_500_mult: 'scoreplus500',
+  score_minus_300_mult: 'scoreminus300',
+  score_minus_500_mult: 'scoreminus500',
+  invert_score: 'invert',
+  speed_up_mult: 'speedup',
+  speed_down_mult: 'speeddown',
+  magnet_duration: 'magnet',
+  spin_cooldown: 'spincooldown',
+  shield: 'shield',
+  spin_alert: 'spinalert'
+};
+
+function applyStoreDefaultLockState() {
+  for (const [upgradeKey, prefix] of Object.entries(STORE_UPGRADE_ID_MAP)) {
+    const tiers = Array.from(document.querySelectorAll(`[id^="store-${prefix}-"]`))
+      .sort((a, b) => Number(a.id.split('-').pop()) - Number(b.id.split('-').pop()));
+
+    tiers.forEach((el, i) => {
+      el.classList.remove("purchased", "locked", "available");
+      el.style.opacity = "";
+      el.onclick = null;
+      el.removeAttribute("onclick");
+
+      if (i === 0) {
+        el.classList.add("available");
+        el.style.pointerEvents = "";
+        const tierIndex = i;
+        el.onclick = function() { buyUpgrade(upgradeKey, tierIndex); };
+      } else {
+        el.classList.add("locked");
+        el.style.pointerEvents = "none";
+      }
+    });
+  }
+}
+
 async function loadPlayerUpgrades() {
   if (!isAuthenticated()) return;
   const identifier = getAuthIdentifier();
@@ -152,23 +191,8 @@ function updateStoreUI() {
     shieldDescription.innerHTML = `<span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield — ${shieldDescriptionText}`;
   }
 
-  const idMap = {
-    x2_duration: 'x2',
-    score_plus_300_mult: 'scoreplus300',
-    score_plus_500_mult: 'scoreplus500',
-    score_minus_300_mult: 'scoreminus300',
-    score_minus_500_mult: 'scoreminus500',
-    invert_score: 'invert',
-    speed_up_mult: 'speedup',
-    speed_down_mult: 'speeddown',
-    magnet_duration: 'magnet',
-    spin_cooldown: 'spincooldown',
-    shield: 'shield',
-    spin_alert: 'spinalert'
-  };
-
-  for (const key in idMap) {
-    const prefix = idMap[key];
+  for (const key in STORE_UPGRADE_ID_MAP) {
+    const prefix = STORE_UPGRADE_ID_MAP[key];
     const data = playerUpgrades[key];
     if (!data) continue;
 
@@ -233,9 +257,8 @@ async function buyUpgrade(key, tier) {
     return;
   }
 
-  const sequentialOnlyKeys = new Set(["shield", "spin_alert"]);
   const upgradeState = playerUpgrades && playerUpgrades[key];
-  if (sequentialOnlyKeys.has(key) && upgradeState) {
+  if (upgradeState && Number(upgradeState.maxLevel || 0) > 1) {
     const expectedTier = Number(upgradeState.currentLevel || 0);
     if (tier !== expectedTier) {
       alert("⚠️ Buy previous level first");
@@ -335,3 +358,5 @@ function hideRules() {
 function updateRulesAudioButtons() {
   if (typeof syncAllAudioUI === 'function') syncAllAudioUI();
 }
+
+document.addEventListener("DOMContentLoaded", applyStoreDefaultLockState);

--- a/js/ui.js
+++ b/js/ui.js
@@ -15,6 +15,7 @@ function showStore() {
   document.getElementById("audioTogglesGlobal").style.display = "none";
 
   syncAllAudioUI();
+  if (typeof applyStoreDefaultLockState === "function") applyStoreDefaultLockState();
   loadPlayerUpgrades().then(() => { updateStoreUI(); });
   console.log("🛒 Store opened");
 }


### PR DESCRIPTION
### Motivation
- Ensure store tiers behave consistently: first tier of every multi-level upgrade is interactable by default and higher tiers are non-clickable until previous tiers are purchased to prevent premature clicks before backend data arrives. 
- Make the Spin Alert upgrade visually more prominent so it matches other highlighted upgrades.

### Description
- Added a shared `STORE_UPGRADE_ID_MAP` and `applyStoreDefaultLockState()` which marks tier 0 as `available` and higher tiers as `locked` (non-clickable) on page load and when opening the Store. 
- Updated `updateStoreUI()` to iterate the shared map so multi-tier upgrades are handled uniformly, and generalized sequential purchase validation to require previous tier purchase for any upgrade with `maxLevel > 1`. 
- Added a `store-tier--highlight` class to the Spin Alert tier nodes in `index.html` and complementary styles in `css/style.css` to create a brighter, glowing available state.

### Testing
- Verified identifiers and new symbols are present using `rg` searches for `applyStoreDefaultLockState`, `STORE_UPGRADE_ID_MAP`, and `store-tier--highlight`, which returned the expected locations. 
- Served the site with `python -m http.server 8000` and captured a full-page screenshot of the Store UI with a Playwright script to confirm Spin Alert styling and default lock state, and the screenshot generation succeeded. 
- Confirmed the modified files contain the new logic and styles by inspecting diffs of the changed files, and the automated patch application completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7dcbdcdc483329eb079da4343d498)