### PR TITLE
Match Spin Alert active purchase button style to Shield

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,11 +284,11 @@
         <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
       </div>
       <div class="store-tiers">
-        <div class="store-tier store-tier--highlight" id="store-spinalert-0" onclick="buyUpgrade('spin_alert', 0)">
+        <div class="store-tier" id="store-spinalert-0" onclick="buyUpgrade('spin_alert', 0)">
           <div class="store-tier-label"> Alert</div>
           <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 1,000</div>
         </div>
-        <div class="store-tier store-tier--highlight" id="store-spinalert-1" onclick="buyUpgrade('spin_alert', 1)">
+        <div class="store-tier" id="store-spinalert-1" onclick="buyUpgrade('spin_alert', 1)">
           <div class="store-tier-label"> Perfect</div>
           <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 3,000</div>
         </div>


### PR DESCRIPTION
### Motivation
- Ensure visual consistency in the store by making Spin Alert tiers use the same active purchase appearance as Shield instead of a special highlight style.

### Description
- Removed the `store-tier--highlight` class from both `#store-spinalert-0` and `#store-spinalert-1` in `index.html` so the Spin Alert tiers inherit the common `.store-tier.available` styling.

### Testing
- Verified the HTML diff shows only the class removal for Spin Alert and no other markup changes (success).
- Served the site with `python3 -m http.server` and captured a Playwright screenshot for visual confirmation (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7dff3be5483329450fc76d176818d)