### PR TITLE
Fix wallet leaderboard save signature mismatch

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -120,20 +120,16 @@ async function saveResultToLeaderboard() {
         telegramId
       };
     } else {
-       const messageToSign = `Save game result
-        Wallet: ${identifier}
-        Score: ${score}
-        Distance: ${distance}
-        Timestamp: ${timestamp}`;
+      const walletForSignature = String(identifier || "").toLowerCase();
+      const messageToSign = `Save game result\nWallet: ${walletForSignature}\nScore: ${score}\nDistance: ${distance}\nGoldCoins: ${goldCoins}\nSilverCoins: ${silverCoins}\nTimestamp: ${timestamp}`;
       const signature = await signMessage(messageToSign);
-      if (!signature) { console.error("❌ Failed to get signature"); return; }
       if (!signature) {
         console.error("❌ Failed to get signature");
         return;
       }
       
       data = {
-        wallet: identifier,
+        wallet: walletForSignature,
         score,
         distance,
         goldCoins,
@@ -145,7 +141,7 @@ async function saveResultToLeaderboard() {
 
     const response = await fetch(`${BACKEND_URL}/api/leaderboard/save`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-Wallet": primaryId || identifier },
+      headers: { "Content-Type": "application/json", "X-Wallet": data.wallet },
       body: JSON.stringify(data)
     });
 
@@ -168,4 +164,3 @@ async function saveResultToLeaderboard() {
     console.error("❌ Error sending result:", error);
   }
 }
-


### PR DESCRIPTION
### Motivation
- The client was receiving 401 `Invalid signature` responses when saving wallet-mode leaderboard results due to mismatches between the signed message and the submitted payload.
- The mismatch likely came from wallet case differences, message formatting (indentation/newlines), and missing fields in the signed payload compared to the submitted data.

### Description
- Normalize the wallet identifier to lowercase before composing the signed message and submitting the payload so the signed value matches the transmitted `wallet` field. 
- Rebuild the `Save game result` message as an exact newline-delimited string and include `GoldCoins` and `SilverCoins` so the signature covers all submitted fields. 
- Set the `X-Wallet` request header to the actual payload `data.wallet` to ensure header identity matches the payload. 
- Remove a duplicate signature null-check to keep a single guard after obtaining the signature.

### Testing
- Ran `node --check js/api.js` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e0eb21b08332af08514fcacfef93)