### PR TITLE
Spin alert lead-in and Radar lane highlight improvements

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -20,6 +20,8 @@ function resetGameSessionState() {
   gameState.radarHints = [];
   gameState.spinAlertTimer = 0;
   gameState.spinAlertCountdown = 0;
+  gameState.spinAlertPendingDelay = -1;
+  gameState.spinRingPendingCount = 0;
   gameState.perfectSpinWindow = false;
   gameState.perfectSpinWindowTimer = 0;
   gameState.lastSpinAlertRingDist = -999;
@@ -181,6 +183,25 @@ function spawnCoinDiagonal() {
   });
 }
 
+function startSpinAlertCycle() {
+  gameState.spinAlertTimer = 3.0;
+  gameState.spinAlertPendingDelay = 3.0;
+  gameState.perfectSpinWindow = false;
+  gameState.perfectSpinWindowTimer = 0;
+  gameState.spinAlertCountdown = gameState.spinAlertLevel >= 2 ? 3.0 : 0;
+}
+
+function queueCoinRingSpawn() {
+  if (gameState.spinAlertLevel >= 1) {
+    gameState.spinRingPendingCount += 1;
+    if (gameState.spinAlertPendingDelay < 0) {
+      startSpinAlertCycle();
+    }
+    return;
+  }
+  spawnCoinRing();
+}
+
 function spawnCoinRing() {
   const hasGold = Math.random() < 0.35;
   const spawnZ = 1.35;
@@ -209,17 +230,9 @@ function spawnCoinRing() {
   if (gameState.radarActive) {
     CONFIG.LANES.forEach((lane, i) => {
       if (i === 1 && hasGold) {
-        gameState.radarHints.push({ lane, z: spawnZ, timer: 1.0 });
+        gameState.radarHints.push({ lane, z: spawnZ, timer: 0.65 });
       }
     });
-  }
-
-  // Spin alert
-  if (gameState.spinAlertLevel >= 1) {
-    gameState.spinAlertTimer = 3.0;
-    if (gameState.spinAlertLevel >= 2) {
-      gameState.spinAlertCountdown = 3;
-    }
   }
 
   // Spawn 1 combo target at random angle
@@ -277,7 +290,7 @@ function update(delta) {
 
   // Coin ring every 100m
   if (Math.floor(gameState.distance / 100) > Math.floor((gameState.distance - metersDelta) / 100)) {
-    spawnCoinRing();
+    queueCoinRingSpawn();
   }
 
   // Rare coin clusters
@@ -352,11 +365,28 @@ function update(delta) {
   }
   if (gameState.spinAlertCountdown > 0) {
     gameState.spinAlertCountdown -= delta;
-    if (gameState.spinAlertCountdown <= 0) {
+    if (gameState.spinAlertCountdown < 0) {
       gameState.spinAlertCountdown = 0;
+    }
+  }
+
+  if (gameState.spinAlertPendingDelay >= 0) {
+    gameState.spinAlertPendingDelay -= delta;
+    if (gameState.spinAlertPendingDelay <= 0) {
+      gameState.spinAlertPendingDelay = -1;
+
+      if (gameState.spinRingPendingCount > 0) {
+        spawnCoinRing();
+        gameState.spinRingPendingCount -= 1;
+      }
+
       if (gameState.spinAlertLevel >= 2) {
         gameState.perfectSpinWindow = true;
         gameState.perfectSpinWindowTimer = 0.5;
+      }
+
+      if (gameState.spinRingPendingCount > 0 && gameState.spinAlertLevel >= 1) {
+        startSpinAlertCycle();
       }
     }
   }

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -975,29 +975,35 @@ function drawRadarHints() {
     [0]: canvasW * 0.5,
     [1]: canvasW * 0.75
   };
-  const bottomY = canvasH - 40;
+  const topY = canvasH * 0.22;
+  const bottomY = canvasH - 36;
 
   ctx.save();
   for (const hint of gameState.radarHints) {
-    const pulse = (Math.sin(Date.now() * 0.01) + 1) / 2;
-    const alpha = 0.5 + pulse * 0.5;
+    const pulse = (Math.sin(Date.now() * 0.02) + 1) / 2;
+    const alpha = (0.35 + pulse * 0.65) * Math.max(0, hint.timer / 0.65);
     const lx = lanePositions[hint.lane] || canvasW / 2;
 
-    ctx.globalAlpha = alpha * hint.timer;
-    const r = 14 + pulse * 6;
-    const grad = ctx.createRadialGradient(lx, bottomY, 0, lx, bottomY, r * 2);
-    grad.addColorStop(0, "rgba(255, 215, 0, 1)");
-    grad.addColorStop(0.5, "rgba(255, 180, 0, 0.6)");
-    grad.addColorStop(1, "rgba(255, 215, 0, 0)");
-    ctx.fillStyle = grad;
-    ctx.beginPath();
-    ctx.arc(lx, bottomY, r * 2, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.globalAlpha = alpha;
 
-    ctx.strokeStyle = `rgba(255, 215, 0, ${alpha})`;
+    const glowGrad = ctx.createLinearGradient(lx, topY, lx, bottomY);
+    glowGrad.addColorStop(0, 'rgba(255, 225, 90, 0)');
+    glowGrad.addColorStop(0.25, 'rgba(255, 225, 90, 0.25)');
+    glowGrad.addColorStop(0.6, 'rgba(255, 190, 0, 0.55)');
+    glowGrad.addColorStop(1, 'rgba(255, 225, 90, 0.08)');
+
+    ctx.strokeStyle = glowGrad;
+    ctx.lineWidth = 7 + pulse * 3;
+    ctx.beginPath();
+    ctx.moveTo(lx, topY);
+    ctx.lineTo(lx, bottomY);
+    ctx.stroke();
+
+    ctx.strokeStyle = `rgba(255, 235, 120, ${Math.min(1, alpha + 0.15)})`;
     ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.arc(lx, bottomY, r, 0, Math.PI * 2);
+    ctx.moveTo(lx, topY);
+    ctx.lineTo(lx, bottomY);
     ctx.stroke();
   }
   ctx.restore();

--- a/js/state.js
+++ b/js/state.js
@@ -81,6 +81,8 @@ const gameState = {
   spinAlertLevel: 0,
   spinAlertTimer: 0,
   spinAlertCountdown: 0,
+  spinAlertPendingDelay: -1,
+  spinRingPendingCount: 0,
   perfectSpinWindow: false,
   perfectSpinWindowTimer: 0,
   lastSpinAlertRingDist: -999,


### PR DESCRIPTION
### Motivation
- Implement store-bought features so `spin alert (alert)`, `spin alert (perfect)` and `Radar` behave visibly and predictably during gameplay.
- Ensure alerts occur before coin rings so players can react (3s lead), and make radar hints fast but noticeable as lane highlights.

### Description
- Added new game state fields `spinAlertPendingDelay` and `spinRingPendingCount` and reset them in `resetGameSessionState` to support queued ring spawns and stable state between runs (`js/state.js`, `js/physics.js`).
- Reworked ring spawn flow by introducing `queueCoinRingSpawn()` and `startSpinAlertCycle()` so a ring is queued and the spin alert timer/countdown runs for ~3s before actual `spawnCoinRing()` call (`js/physics.js`).
- Synchronized the perfect spin countdown/window so the `spin_alert` tier 2 countdown ends exactly when the ring appears and opens the short `perfectSpinWindow` for auto-collect (`js/physics.js`, `js/renderer.js`).
- Replaced small bottom pulses with a fast vertical lane highlight visual for radar hints and tuned hint lifetime to be short but noticeable (`js/renderer.js`), and shortened radar hint timer at spawn to make the flash quick.

### Testing
- Ran `node --check js/state.js` and it completed successfully.
- Ran `node --check js/physics.js` and it completed successfully.
- Ran `node --check js/renderer.js` and it completed successfully.
- Launched a simple local HTTP server and captured a headless Playwright screenshot for UI verification, which produced an artifact for visual inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f0a9f7c08332a193206159870e3e)