### PR TITLE
Fix radar and spin alert not activating after purchase

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -254,8 +254,13 @@ function actualStartGame() {
         }
         gameState.spinCooldownReduction = playerEffects.spin_cooldown_reduction || 0;
         gameState.invertScoreMultiplier = 1.0;
-        gameState.radarActive = playerEffects.radar_active ? true : false;
-        gameState.spinAlertLevel = playerEffects.spin_alert_level || 0;
+        const radarByEffect = Boolean(playerEffects.radar_active);
+        const radarByUpgrade = Number(playerUpgrades?.radar?.currentLevel || 0) >= 1;
+        gameState.radarActive = radarByEffect || radarByUpgrade;
+
+        const spinAlertByEffect = Number(playerEffects.spin_alert_level || 0);
+        const spinAlertByUpgrade = Number(playerUpgrades?.spin_alert?.currentLevel || 0);
+        gameState.spinAlertLevel = Math.max(spinAlertByEffect, spinAlertByUpgrade);
 
         console.log("✅ Upgrades applied:", {
           shieldCount: player.shieldCount,


### PR DESCRIPTION
### Motivation
- Radar and Spin Alert upgrades bought in the Store were not taking effect at game start because the game only read `playerEffects` (`activeEffects`) from the backend and ignored purchased `playerUpgrades`.

### Description
- Updated `js/game.js` to consider both backend `playerEffects` and purchased `playerUpgrades` when applying upgrades at game start.
- `gameState.radarActive` now becomes `Boolean(playerEffects.radar_active) || (playerUpgrades?.radar?.currentLevel >= 1)` so purchased Radar enables the hint.
- `gameState.spinAlertLevel` is now `Math.max(Number(playerEffects.spin_alert_level || 0), Number(playerUpgrades?.spin_alert?.currentLevel || 0))` so purchased Spin Alert increases the alert level.
- Changes use optional chaining and numeric coercion to be resilient when `playerUpgrades` or `playerEffects` are missing.

### Testing
- Syntax validation: parsed `js/game.js` with `node -e "const fs=require('fs'); new Function(fs.readFileSync('js/game.js','utf8')); console.log('ok')"` which printed `ok`.
- Confirmed updated logic placement via `rg`/`nl` searches to ensure the new checks are present in `js/game.js` and do not break surrounding code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80d8d9ab0833295b91cc3b8ca848f)