### PR TITLE
Fix radar lane warning for upcoming gold coins

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -160,9 +160,21 @@ function spawnCoinPattern() {
   patterns[Math.floor(Math.random() * patterns.length)]();
 }
 
+function addRadarHintForGoldLane(lane) {
+  if (!gameState.radarActive || !isFinite(lane)) return;
+  const existingHint = gameState.radarHints.find(h => h.lane === lane);
+  if (existingHint) {
+    existingHint.timer = 1.8;
+    existingHint.maxTimer = 1.8;
+    return;
+  }
+  gameState.radarHints.push({ lane, z: 1.55, timer: 1.8, maxTimer: 1.8 });
+}
+
 function spawnCoinLine() {
   const lane = CONFIG.LANES[Math.floor(Math.random() * 3)];
   const hasGold = Math.random() < 0.3;
+  if (hasGold) addRadarHintForGoldLane(lane);
   for (let i = 0; i < 3; i++) {
     coins.push({ type: i === 0 && hasGold ? "gold" : "silver", lane, z: 1.55 - i * 0.1, animFrame: 0 });
   }
@@ -171,6 +183,7 @@ function spawnCoinLine() {
 function spawnCoinSnake() {
   const startLane = CONFIG.LANES[Math.floor(Math.random() * 3)];
   const hasGold = Math.random() < 0.3;
+  if (hasGold) addRadarHintForGoldLane(startLane);
   coins.push({ type: hasGold ? "gold" : "silver", lane: startLane, z: 1.55, animFrame: 0 });
   coins.push({ type: "silver", lane: Math.max(-1, Math.min(1, startLane + (Math.random() < 0.5 ? -1 : 1))), z: 1.45, animFrame: 0 });
   coins.push({ type: "silver", lane: startLane, z: 1.35, animFrame: 0 });
@@ -178,6 +191,7 @@ function spawnCoinSnake() {
 
 function spawnCoinDiagonal() {
   const hasGold = Math.random() < 0.3;
+  if (hasGold) addRadarHintForGoldLane(-1);
   [-1, 0, 1].forEach((lane, i) => {
     coins.push({ type: i === 0 && hasGold ? "gold" : "silver", lane, z: 1.55 - i * 0.1, animFrame: 0 });
   });
@@ -227,13 +241,7 @@ function spawnCoinRing() {
   });
 
   // Radar hint for gold lane coins
-  if (gameState.radarActive) {
-    CONFIG.LANES.forEach((lane, i) => {
-      if (i === 1 && hasGold) {
-        gameState.radarHints.push({ lane, z: spawnZ, timer: 0.65 });
-      }
-    });
-  }
+  if (hasGold) addRadarHintForGoldLane(0);
 
   // Spawn 1 combo target at random angle
   const angle = Math.random() * Math.PI * 2;
@@ -243,6 +251,7 @@ function spawnCoinRing() {
 function spawnCoinCluster() {
   const lane = CONFIG.LANES[Math.floor(Math.random() * 3)];
   const hasGold = Math.random() < 0.3;
+  if (hasGold) addRadarHintForGoldLane(lane);
   const count = Math.random() < 0.5 ? 2 : 3;
   for (let i = 0; i < count; i++) {
     coins.push({ type: i === 0 && hasGold ? "gold" : "silver", lane, z: 1.5 - i * 0.08, animFrame: 0 });

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -975,13 +975,19 @@ function drawRadarHints() {
     [0]: canvasW * 0.5,
     [1]: canvasW * 0.75
   };
+  const laneLabels = {
+    [-1]: "LEFT",
+    [0]: "CENTER",
+    [1]: "RIGHT"
+  };
   const topY = canvasH * 0.22;
   const bottomY = canvasH - 36;
 
   ctx.save();
   for (const hint of gameState.radarHints) {
+    const maxTimer = Math.max(0.1, hint.maxTimer || 1.8);
     const pulse = (Math.sin(Date.now() * 0.02) + 1) / 2;
-    const alpha = (0.35 + pulse * 0.65) * Math.max(0, hint.timer / 0.65);
+    const alpha = (0.35 + pulse * 0.65) * Math.max(0, hint.timer / maxTimer);
     const lx = lanePositions[hint.lane] || canvasW / 2;
 
     ctx.globalAlpha = alpha;
@@ -1005,6 +1011,12 @@ function drawRadarHints() {
     ctx.moveTo(lx, topY);
     ctx.lineTo(lx, bottomY);
     ctx.stroke();
+
+    ctx.fillStyle = `rgba(255, 210, 60, ${Math.min(1, alpha + 0.2)})`;
+    ctx.font = "bold 17px Orbitron, Arial";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(`🟡 NEXT GOLD: ${laneLabels[hint.lane] || "CENTER"}`, lx, topY - 8);
   }
   ctx.restore();
 }


### PR DESCRIPTION
### Motivation
- The radar hint was not reliably visible or informative, and it should explicitly warn which lane will contain the next gold coin.

### Description
- Added a helper `addRadarHintForGoldLane` that creates or refreshes a radar hint for a given lane and prevents duplicate stacking by refreshing the existing hint.
- Wired `addRadarHintForGoldLane` into coin spawn paths (`spawnCoinLine`, `spawnCoinSnake`, `spawnCoinDiagonal`, `spawnCoinCluster`, and `spawnCoinRing`) so regular gold spawns trigger radar hints, not only ring-center gold.
- Increased hint lifetime and added `maxTimer` to hints, and updated the renderer to use `maxTimer` for correct fade-out and to draw a clear label `🟡 NEXT GOLD: LEFT/CENTER/RIGHT` above the lane.
- Changes made in `js/physics.js` (spawn logic + helper) and `js/renderer.js` (rendering + label and timer handling).

### Testing
- Ran `node --check js/physics.js` and `node --check js/renderer.js`, both succeeded without syntax errors.
- Attempted an automated Playwright screenshot to validate in-browser rendering, but the browser tool timed out in this environment (screenshot step failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80fa5f0288332bc46690e9c34f61f)