### PR TITLE
Fix store tier unlock rendering for Shield and Spin Alert

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -196,9 +196,17 @@ function updateStoreUI() {
     const data = playerUpgrades[key];
     if (!data) continue;
 
-    for (let i = 0; i < data.maxLevel; i++) {
-      const el = document.getElementById(`store-${prefix}-${i}`);
-      if (!el) continue;
+    const tierElements = Array.from(document.querySelectorAll(`[id^="store-${prefix}-"]`))
+      .sort((a, b) => Number(a.id.split('-').pop()) - Number(b.id.split('-').pop()));
+
+    const currentLevel = Number(data.currentLevel || 0);
+    const maxLevel = tierElements.length || Number(data.maxLevel || 0);
+
+    for (let i = 0; i < maxLevel; i++) {
+      const el = tierElements[i] || document.getElementById(`store-${prefix}-${i}`);
+      if (!el) {
+        continue;
+      }
 
       el.classList.remove("purchased", "locked", "available");
       el.style.opacity = "";
@@ -206,10 +214,10 @@ function updateStoreUI() {
       el.onclick = null;
       el.removeAttribute("onclick");
 
-      if (i < data.currentLevel) {
+      if (i < currentLevel) {
         el.classList.add("purchased");
         el.style.pointerEvents = "none";
-      } else if (i === data.currentLevel) {
+      } else if (i === currentLevel) {
         el.classList.add("available");
         const tierIndex = i;
         const upgradeKey = key;


### PR DESCRIPTION
### Motivation
- Shield and Spin Alert next-tier buttons could remain locked after purchasing the previous tier when backend `maxLevel` did not match the number of rendered tier elements, causing incorrect availability in the store UI.

### Description
- Updated `updateStoreUI()` to gather actual tier DOM elements with `document.querySelectorAll(`[id^="store-${prefix}-"]`)` and sort them before rendering state.
- Normalize levels by casting `currentLevel`/`maxLevel` to numbers and prefer the count of rendered `tierElements` when looping over tiers to decide `purchased`, `available`, or `locked` states.
- Make per-tier handling resilient by falling back to `document.getElementById` for missing selectors and preserve the `buyUpgrade` click wiring for the available tier.

### Testing
- Ran `node --check js/store.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b815dca3d083328b2145d7077a6b72)