### PR TITLE
Fix shield upgrade tier progression in store UI

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -164,6 +164,15 @@ async function loadPlayerUpgrades() {
       playerBalance = data.balance;
       if (data.rides) playerRides = data.rides;
 
+      // Backend may store first shield purchase as a permanent effect while
+      // currentLevel still comes as 0 in upgrades payload. Keep UI tier state
+      // aligned with actually active effects.
+      const hasShieldEffect = !!(playerEffects && (playerEffects.start_with_shield || Number(playerEffects.start_shield_count || 0) > 0));
+      if (hasShieldEffect && playerUpgrades && playerUpgrades.shield) {
+        const normalizedLevel = Math.max(1, Number(playerUpgrades.shield.currentLevel || 0));
+        playerUpgrades.shield.currentLevel = normalizedLevel;
+      }
+
       console.log("✅ Upgrades loaded:", playerUpgrades);
       console.log("✅ Effects:", playerEffects);
       console.log("✅ Balance:", playerBalance);
@@ -266,9 +275,13 @@ async function buyUpgrade(key, tier) {
   }
 
   const upgradeState = playerUpgrades && playerUpgrades[key];
-  if (upgradeState && Number(upgradeState.maxLevel || 0) > 1) {
+  if (upgradeState) {
     const expectedTier = Number(upgradeState.currentLevel || 0);
-    if (tier !== expectedTier) {
+    if (tier < expectedTier) {
+      alert("❌ Already purchased (permanent)");
+      return;
+    }
+    if (tier > expectedTier) {
       alert("⚠️ Buy previous level first");
       return;
     }


### PR DESCRIPTION
### Motivation
- Prevent the store UI from showing the first `shield` tier as purchasable when a permanent shield effect is already active on the backend. 
- Make `buyUpgrade` validation clearer so clicks on already-owned tiers are rejected with a descriptive message.

### Description
- Normalize shield state after loading upgrades by detecting `playerEffects.start_with_shield` or `start_shield_count > 0` and forcing `playerUpgrades.shield.currentLevel` to at least `1` so the UI reflects the permanent purchase (`js/store.js`).
- Tighten `buyUpgrade()` validation so that if `tier < currentLevel` the user is shown `❌ Already purchased (permanent)` and the request is blocked, and if `tier > currentLevel` the user is shown `⚠️ Buy previous level first` (`js/store.js`).
- Changes are limited to `js/store.js` and only affect UI state normalization and pre-flight purchase validation.

### Testing
- Ran a syntax check with `node --check js/store.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8226b32088332820f850e2a0a14f0)