### PR TITLE
Prevent store purchases while upgrades are loading (fix shield-tier race)

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -110,6 +110,7 @@ function updateRidesDisplay() {
 let playerUpgrades = null;
 let playerEffects = null;
 let playerBalance = { gold: 0, silver: 0 };
+let isStoreDataLoading = false;
 
 const STORE_UPGRADE_ID_MAP = {
   x2_duration: 'x2',
@@ -153,6 +154,7 @@ function applyStoreDefaultLockState() {
 async function loadPlayerUpgrades() {
   if (!isAuthenticated()) return;
   const identifier = getAuthIdentifier();
+  isStoreDataLoading = true;
   try {
     const url = `${BACKEND_URL}/api/store/upgrades/${identifier}`;
     const response = await fetch(url);
@@ -180,6 +182,8 @@ async function loadPlayerUpgrades() {
     }
   } catch (e) {
     console.error("❌ Error loading upgrades:", e);
+  } finally {
+    isStoreDataLoading = false;
   }
 }
 
@@ -269,6 +273,11 @@ function updateStoreUI() {
 }
 
 async function buyUpgrade(key, tier) {
+  if (isStoreDataLoading) {
+    alert("⏳ Store is loading, try again in a moment");
+    return;
+  }
+
   if (!isAuthenticated()) {
     alert("🔗 Authentication required!");
     return;


### PR DESCRIPTION
### Motivation
- Prevent a race where a shield tier (or other upgrade tier) can be clicked before the latest `playerUpgrades` arrive from the backend, producing an incorrect `❌ Already purchased (permanent)` alert instead of activating the next tier.

### Description
- Add `isStoreDataLoading` flag in `js/store.js` and set it to `true` when `loadPlayerUpgrades()` starts and reset in `finally` so the UI knows when upgrade data is being fetched.
- Block `buyUpgrade()` while `isStoreDataLoading` is `true` and show a user-friendly message (`⏳ Store is loading, try again in a moment`) to avoid processing stale clicks.

### Testing
- Run `node --check js/store.js` to validate syntax: succeeded.
- Attempted automatic UI validation with a Playwright screenshot of the store, but the screenshot step timed out in this environment (tooling timeout), so visual verification was partially attempted but failed due to environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b824af27f08332ac51735606281e3a)