### PR TITLE
Fix store upgrade UI sync and perfect spin alert timing/prompt

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -199,7 +199,8 @@ function spawnCoinDiagonal() {
 
 function startSpinAlertCycle() {
   gameState.spinAlertTimer = 3.0;
-  gameState.spinAlertPendingDelay = 3.0;
+  // For Perfect tier: ring should appear right after the "1" tick (no dead pause)
+  gameState.spinAlertPendingDelay = gameState.spinAlertLevel >= 2 ? 2.05 : 3.0;
   gameState.perfectSpinWindow = false;
   gameState.perfectSpinWindowTimer = 0;
   gameState.spinAlertCountdown = gameState.spinAlertLevel >= 2 ? 3.0 : 0;

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1047,7 +1047,7 @@ function drawSpinAlert() {
     ctx.font = "bold 34px Orbitron, Arial";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    ctx.fillText("✨ SPIN!", canvasW / 2, canvasH * 0.18);
+    ctx.fillText("✨ PRESS SPIN!", canvasW / 2, canvasH * 0.18);
   } else if (gameState.spinAlertLevel >= 1) {
     ctx.globalAlpha = Math.min(1, gameState.spinAlertTimer);
     ctx.fillStyle = "rgba(0,0,0,0.7)";

--- a/js/store.js
+++ b/js/store.js
@@ -124,6 +124,12 @@ function parseNumericLevel(value) {
   return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
 }
 
+function getTierElements(prefix) {
+  return Array.from(document.querySelectorAll(`[id^="store-${prefix}-"]`))
+    .filter((el) => /^\d+$/.test(el.id.split('-').pop()))
+    .sort((a, b) => Number(a.id.split('-').pop()) - Number(b.id.split('-').pop()));
+}
+
 function getLevelFromUpgradeState(state = null) {
   if (!state || typeof state !== 'object') return 0;
 
@@ -166,12 +172,18 @@ function getLevelFromEffects(upgradeKey) {
   if (upgradeKey === 'shield') {
     const shieldCount = parseNumericLevel(playerEffects.start_shield_count);
     if (shieldCount > 0) return shieldCount;
+    const shieldLevel = parseNumericLevel(playerEffects.shield_level);
+    if (shieldLevel > 0) return shieldLevel;
     return playerEffects.start_with_shield ? 1 : 0;
   }
 
   if (upgradeKey === 'spin_alert') {
     const directLevel = parseNumericLevel(playerEffects.spin_alert_level);
     if (directLevel > 0) return directLevel;
+
+    const spinAlertMode = String(playerEffects.spin_alert_mode || '').toLowerCase();
+    if (spinAlertMode === 'perfect' || spinAlertMode === 'pro') return 2;
+    if (spinAlertMode === 'alert' || spinAlertMode === 'basic') return 1;
 
     if (playerEffects.spin_alert_perfect || playerEffects.spin_alert_is_perfect) return 2;
     if (playerEffects.spin_alert_active || playerEffects.spin_alert) return 1;
@@ -206,8 +218,7 @@ const STORE_UPGRADE_ID_MAP = {
 
 function applyStoreDefaultLockState() {
   for (const [upgradeKey, prefix] of Object.entries(STORE_UPGRADE_ID_MAP)) {
-    const tiers = Array.from(document.querySelectorAll(`[id^="store-${prefix}-"]`))
-      .sort((a, b) => Number(a.id.split('-').pop()) - Number(b.id.split('-').pop()));
+    const tiers = getTierElements(prefix);
 
     tiers.forEach((el, i) => {
       el.classList.remove("purchased", "locked", "available");
@@ -296,8 +307,7 @@ function updateStoreUI() {
     const data = playerUpgrades[key];
     if (!data) continue;
 
-    const tierElements = Array.from(document.querySelectorAll(`[id^="store-${prefix}-"]`))
-      .sort((a, b) => Number(a.id.split('-').pop()) - Number(b.id.split('-').pop()));
+    const tierElements = getTierElements(prefix);
 
     const currentLevel = getEffectiveUpgradeLevel(key, data);
     const maxLevel = tierElements.length || Number(data.maxLevel || 0);


### PR DESCRIPTION
### Motivation
- Ensure store UI reflects backend active effects immediately so `Shield` and `Spin Alert` purchases appear active without needing a repeat click.
- Remove the dead pause in the Perfect spin alert flow so the coin ring and input window appear right after the countdown hits `1`.
- Make tier selection robust by only treating numeric `store-*-N` elements as actual tiers to avoid accidental ordering from extraneous DOM elements.

### Description
- Added `getTierElements(prefix)` in `js/store.js` and replaced raw `querySelectorAll` usages with it so tier lists only include numeric-indexed elements (`store-...-0/1/2`).
- Extended `getLevelFromEffects` in `js/store.js` to read `playerEffects.shield_level` and `playerEffects.spin_alert_mode` (supports `perfect/pro` and `alert/basic`) so effect-driven levels normalize correctly in the UI.
- Adjusted `startSpinAlertCycle` in `js/physics.js` to set `gameState.spinAlertPendingDelay` to `2.05` when `spinAlertLevel >= 2` so the ring spawns immediately after the final countdown tick.
- Updated the perfect-window overlay text in `js/renderer.js` from `✨ SPIN!` to `✨ PRESS SPIN!` to more clearly prompt player action.

### Testing
- Ran syntax checks with `node --check js/store.js js/physics.js js/renderer.js` and they succeeded.
- Attempted an automated Playwright screenshot to validate the store/alert flow, but the headless browser could not load the local app in this environment and returned `ERR_EMPTY_RESPONSE`/`ERR_FILE_NOT_FOUND`, so UI runtime verification was not captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b83534bd3c8332be9b45b5fce874eb)