### PR TITLE
Replace isWalletConnected with isAuthenticated() in startGame

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -125,7 +125,7 @@ async function startGame() {
   }
 
   // Check rides BEFORE dark screen (only if connected)
-  if (isWalletConnected) {
+  if (isAuthenticated()) {
     await loadPlayerRides();
 
     if (playerRides.totalRides <= 0) {


### PR DESCRIPTION
### Motivation
- Align the game start flow with the rest of the store/API authentication checks by using the shared authentication helper instead of a direct wallet flag.

### Description
- Replace the `isWalletConnected` condition with a call to `isAuthenticated()` in `startGame()` within `js/game.js` so ride-loading and usage only run when the unified auth check passes.

### Testing
- Ran `rg "if \(isAuthenticated\(\)\)" -n js/game.js` to verify the condition was updated, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8518ac76c8332a49a9e981156c931)