### PR TITLE
Split Shield into Start + Stack, update Spin Alert prices, and align frontend with backend shield effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,10 +245,10 @@
 
   <div class="store-list">
 
-    <!-- === GOLD: Shield (3-tier progressive) === -->
+    <!-- === GOLD: Shield Start (permanent) === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name" id="store-shield-description"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield — start every rides with shield bonus</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield Start — start every rides with shield bonus</span>
         <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
       </div>
       <div class="store-tiers">
@@ -256,6 +256,16 @@
           <div class="store-tier-label">start shield</div>
           <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 400</div>
         </div>
+      </div>
+    </div>
+
+    <!-- === GOLD: Shield Stack (2-tier progressive) === -->
+    <div class="store-item">
+      <div class="store-item-header">
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield Stack — increase max shields</span>
+        <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
+      </div>
+      <div class="store-tiers">
         <div class="store-tier" id="store-shield-1" onclick="buyUpgrade('shield', 1)">
           <div class="store-tier-label">2 shields</div>
           <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 2,000</div>
@@ -286,11 +296,11 @@
       <div class="store-tiers">
         <div class="store-tier" id="store-spinalert-0" onclick="buyUpgrade('spin_alert', 0)">
           <div class="store-tier-label"> Alert</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 1</div>
+          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 1,000</div>
         </div>
         <div class="store-tier" id="store-spinalert-1" onclick="buyUpgrade('spin_alert', 1)">
           <div class="store-tier-label"> Perfect</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 3</div>
+          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 3,000</div>
         </div>
       </div>
     </div>
@@ -599,7 +609,7 @@
         <b>Silver coin upgrades</b> — enhance power-up effects (3 tiers each):<br>
         longer X2 duration, stronger score bonuses, reduced penalties, faster speed boosts, longer magnet, shorter spin cooldown.<br><br>
         <b>Gold coin upgrades</b>:<br>
-        🛡 <b>Shield</b> — start every run with a shield (permanent)<br>
+        🛡 <b>Shield</b> — separate lots for start shield and shield stack cap (2/3)<br>
         🎟 <b>Rides Pack</b> — buy extra rides when you run out
       </div>
     </div>

--- a/js/game.js
+++ b/js/game.js
@@ -243,14 +243,22 @@ function actualStartGame() {
 
       // Apply player upgrades
       if (playerEffects) {
-        if (playerEffects.start_shield_count) {
-          player.shieldCount = playerEffects.start_shield_count;
+        const maxShieldByEffect = Math.max(
+          Number(playerEffects.max_shield_count || 0),
+          Number(playerEffects.shield_max_count || 0),
+          Number(playerEffects.max_shields || 0)
+        );
+        const shieldLevel = Number(playerEffects.shield_level || playerUpgrades?.shield?.currentLevel || 0);
+        const maxShieldByLevel = shieldLevel >= 3 ? 3 : (shieldLevel >= 2 ? 2 : 1);
+        const maxShieldCount = Math.max(1, maxShieldByEffect || maxShieldByLevel);
+
+        const startShieldCountRaw = Number(playerEffects.start_shield_count || 0);
+        const hasStartShield = Boolean(playerEffects.start_with_shield) || shieldLevel >= 1 || startShieldCountRaw > 0;
+
+        if (hasStartShield) {
+          player.shieldCount = Math.max(1, Math.min(startShieldCountRaw || 1, maxShieldCount));
           player.shield = player.shieldCount > 0;
-          console.log(`🛡 Start with ${player.shieldCount} shield(s)`);
-        } else if (playerEffects.start_with_shield) {
-          player.shieldCount = 1;
-          player.shield = true;
-          console.log("🛡 Start with shield");
+          console.log(`🛡 Start with ${player.shieldCount} shield(s), max ${maxShieldCount}`);
         }
         gameState.spinCooldownReduction = playerEffects.spin_cooldown_reduction || 0;
         gameState.invertScoreMultiplier = 1.0;

--- a/js/physics.js
+++ b/js/physics.js
@@ -629,13 +629,14 @@ function applyBonus(bonus) {
 
   const bonusMap = {
     [BONUS_TYPES.SHIELD]: () => {
-      const shieldUpgradeLevel = (playerUpgrades && playerUpgrades.shield)
-        ? playerUpgrades.shield.currentLevel
-        : 0;
-      const canAccumulateShield = shieldUpgradeLevel >= 1;
-      const maxShieldCount = canAccumulateShield
-        ? ((playerEffects && playerEffects.start_shield_count) ? playerEffects.start_shield_count : 1) + 1
-        : 1;
+      const shieldUpgradeLevel = Number(playerUpgrades?.shield?.currentLevel || 0);
+      const maxShieldByEffect = Math.max(
+        Number(playerEffects?.max_shield_count || 0),
+        Number(playerEffects?.shield_max_count || 0),
+        Number(playerEffects?.max_shields || 0)
+      );
+      const maxShieldByLevel = shieldUpgradeLevel >= 3 ? 3 : (shieldUpgradeLevel >= 2 ? 2 : 1);
+      const maxShieldCount = Math.max(1, maxShieldByEffect || maxShieldByLevel);
 
       player.shieldCount = Math.min(player.shieldCount + 1, maxShieldCount);
       player.shield = player.shieldCount > 0;

--- a/js/store.js
+++ b/js/store.js
@@ -197,11 +197,25 @@ function getLevelFromEffects(upgradeKey) {
   if (!playerEffects) return 0;
 
   if (upgradeKey === 'shield') {
-    const shieldCount = parseNumericLevel(playerEffects.start_shield_count);
-    if (shieldCount > 0) return shieldCount;
+    const startShieldCount = parseNumericLevel(playerEffects.start_shield_count);
     const shieldLevel = parseNumericLevel(playerEffects.shield_level);
-    if (shieldLevel > 0) return shieldLevel;
-    return playerEffects.start_with_shield ? 1 : 0;
+    const maxShieldCount = Math.max(
+      parseNumericLevel(playerEffects.max_shield_count),
+      parseNumericLevel(playerEffects.shield_max_count),
+      parseNumericLevel(playerEffects.max_shields)
+    );
+
+    const hasStartShield = Boolean(playerEffects.start_with_shield) || startShieldCount > 0 || shieldLevel >= 1;
+
+    if (maxShieldCount >= 3) return 3;
+    if (maxShieldCount >= 2) return 2;
+    if (shieldLevel > 0) return Math.min(shieldLevel, 3);
+
+    // Legacy backend payloads may encode only start_shield_count without explicit level flags.
+    if (startShieldCount >= 3) return 3;
+    if (startShieldCount >= 2) return 2;
+
+    return hasStartShield ? 1 : 0;
   }
 
   if (upgradeKey === 'spin_alert') {
@@ -320,13 +334,6 @@ function updateStoreUI() {
 
   if (!playerUpgrades) return;
 
-  const shieldDescription = document.getElementById("store-shield-description");
-  if (shieldDescription && playerUpgrades.shield) {
-    const shieldDescriptionText = playerUpgrades.shield.currentLevel >= 1
-      ? "accumulate shield bonus"
-      : "start every rides with shield bonus";
-    shieldDescription.innerHTML = `<span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield — ${shieldDescriptionText}`;
-  }
 
   for (const key in STORE_UPGRADE_ID_MAP) {
     const prefix = STORE_UPGRADE_ID_MAP[key];


### PR DESCRIPTION
### Motivation
- Backend now exposes richer shield effects (`start_with_shield`, `start_shield_count`, `shield_level`, `max_shield_count` / `shield_max_count` / `max_shields`) and the Store should present separate purchase lots for starting with a shield vs increasing shield capacity. 
- UI needed updated prices for `Spin Alert` tiers and clearer rules text to match backend behavior. 
- Gameplay must respect backend-provided max shield caps when applying start-of-run shields and when picking up shield bonuses.

### Description
- Split Store UI for shield into two lots in `index.html`: `Shield Start` (permanent start shield, tier 0, `400` Gold) and `Shield Stack` (capacity upgrades: `2 shields` = `2000` Gold, `3 shields` = `5000` Gold). 
- Updated `Spin Alert` prices in `index.html` to `Alert = 1000 Gold` and `Perfect = 3000 Gold`. 
- Enhanced frontend interpretation of backend `activeEffects` in `js/store.js` by expanding `getLevelFromEffects('shield')` to consider `start_shield_count`, `shield_level`, and the various `max_shield` fields and by removing the old combined shield description block. 
- Normalized `playerUpgrades.shield.currentLevel` from effective data during `loadPlayerUpgrades` so UI clickability matches backend state. 
- Changed gameplay logic in `js/game.js` to compute `maxShieldCount` from backend effects or shield level and to initialize `player.shieldCount` at run start observing the max cap. 
- Adjusted shield pickup handling in `js/physics.js` (`applyBonus`) to cap accumulated shields by the backend-provided max (with safe fallback to upgrade-level mapping). 
- Files changed: `index.html`, `js/store.js`, `js/game.js`, `js/physics.js`.

### Testing
- Ran syntax checks which succeeded: `node --check js/store.js`, `node --check js/physics.js`, and `node --check js/game.js` (all passed). 
- Attempted automated browser validation (Playwright) to capture a store screenshot, but the run timed out in this environment and did not produce an artifact (failed). 
- Attempted remote repository access via `curl`/GitHub API to cross-check backend, but the environment returned a network restriction (`403`), so external backend verification was not possible (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8603694e48332adfe277f375790af)