### PR TITLE
Add frontend security helpers and escape user-supplied strings to mitigate DOM XSS

### DIFF
--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,70 @@
+# Security review (client-side) for bageus.github.io
+
+## Scope
+- Static front-end code in this repository (`index.html`, `js/*`).
+- Black-box backend/API behavior is out of scope; findings below include trust-boundary risks observed from frontend usage.
+
+## High-risk findings
+
+### 1) DOM XSS via leaderboard `displayName` (fixed)
+**Where:** `js/ui.js` (`displayLeaderboard`) used backend-provided `entry.displayName` in `innerHTML` without escaping.
+
+**Impact:**
+- An attacker controlling `displayName` (e.g., via backend poisoning, weak validation, or account profile data) could execute arbitrary JavaScript in other players’ browsers.
+- Could steal session context, manipulate game UI, auto-trigger wallet prompts, or phish signatures.
+
+**Fix applied:**
+- Added centralized `escapeHtml` helper (`js/security.js`).
+- Escaped all leaderboard name render paths before interpolation into HTML.
+
+---
+
+### 2) DOM XSS / injection in auth-linked profile blocks (fixed)
+**Where:** `js/auth.js` (`updateAuthUI`) rendered linked Telegram/wallet identity strings inside `innerHTML`.
+
+**Impact:**
+- Malicious `telegramUsername`/`wallet` values from backend could inject HTML/JS into wallet info panel.
+
+**Fix applied:**
+- Escaped `walletShort` and `tgDisplay` with `escapeHtml` prior to rendering.
+
+---
+
+### 3) Injection risk in Telegram-link modal fields (fixed)
+**Where:** `js/auth.js` (`linkTelegram`) interpolated `data.code` and `data.botUsername` directly in modal HTML and links.
+
+**Impact:**
+- If backend response is tampered or weakly validated, attacker could inject script/HTML or malformed `t.me` links.
+
+**Fix applied:**
+- Escape verification code text with `escapeHtml`.
+- Validate/sanitize bot username with strict Telegram handle regex (`sanitizeTelegramHandle`).
+- Build bot URL with `encodeURIComponent`.
+
+## Medium-risk hardening gaps (not yet fixed in this patch)
+
+### 4) Third-party script supply-chain risk
+**Where:** `index.html` loads scripts from CDNs (`telegram.org`, `cdnjs`, `unpkg`) without Subresource Integrity hashes.
+
+**Risk:**
+- If CDN content is compromised, malicious code executes in all clients.
+
+**Recommendation:**
+- Pin exact versions and add `integrity` + `crossorigin="anonymous"` where possible.
+- Prefer self-hosting critical dependencies for deterministic builds.
+
+### 5) Missing restrictive CSP
+**Where:** `index.html` currently relies on inline scripts and inline handlers.
+
+**Risk:**
+- Any XSS bug has maximal impact.
+
+**Recommendation:**
+- Migrate away from inline scripts/`onclick` handlers.
+- Add CSP (`script-src 'self' ...`) with nonces/hashes; block `unsafe-inline` after migration.
+
+## Backend-side validations to ensure
+Even with frontend hardening, backend must enforce:
+- Strict schema/length constraints for all display fields (username/displayName/wallet).
+- Signature verification with anti-replay protections (timestamp window + nonce).
+- Never trusting client-provided score/coins without server-side validation/anti-cheat controls.

--- a/index.html
+++ b/index.html
@@ -661,6 +661,7 @@
 <script src="js/renderer.js"></script>
 <script src="js/physics.js"></script>
 <script src="js/input.js"></script>
+<script src="js/security.js"></script>
 <script src="js/api.js"></script>
 <script src="js/walletconnect.js"></script>
 <script src="js/auth.js"></script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -115,7 +115,8 @@ function updateAuthUI() {
 
     let linkHtml = '';
     if (linkedWallet) {
-      linkHtml = `<div class="wallet-info-row" style="font-size: 10px; opacity: 0.6;"> ${linkedWallet.slice(0, 6)}...${linkedWallet.slice(-4)}</div>`;
+      const walletShort = `${linkedWallet.slice(0, 6)}...${linkedWallet.slice(-4)}`;
+      linkHtml = `<div class="wallet-info-row" style="font-size: 10px; opacity: 0.6;"> ${escapeHtml(walletShort)}</div>`;
     } else {
       linkHtml = `<div class="wallet-info-row"><button class="link-btn" onclick="linkWallet()"> Link Wallet</button></div>`;
     }
@@ -140,7 +141,7 @@ function updateAuthUI() {
     let linkHtml = '';
     if (linkedTelegramId) {
       const tgDisplay = linkedTelegramUsername ? `@${linkedTelegramUsername}` : `TG#${linkedTelegramId}`;
-      linkHtml = `<div class="wallet-info-row" style="font-size: 10px; opacity: 0.6;"> ${tgDisplay}</div>`;
+      linkHtml = `<div class="wallet-info-row" style="font-size: 10px; opacity: 0.6;"> ${escapeHtml(tgDisplay)}</div>`;
     } else {
       linkHtml = `<div class="wallet-info-row"><button class="link-btn" onclick="linkTelegram()"> Link Telegram</button></div>`;
     }
@@ -225,8 +226,10 @@ async function linkTelegram() {
       return;
     }
 
-    const code = data.code;
-    const botUsername = data.botUsername || 'Ursasstube_bot';
+    const code = String(data.code || '----');
+    const botUsername = sanitizeTelegramHandle(data.botUsername, 'Ursasstube_bot');
+    const safeCode = escapeHtml(code);
+    const botLink = `https://t.me/${encodeURIComponent(botUsername)}`;
 
     // Create modal overlay
     const overlay = document.createElement('div');
@@ -253,25 +256,25 @@ async function linkTelegram() {
           background: #0f3460; padding: 16px; border-radius: 12px;
           cursor: pointer; user-select: all; margin-bottom: 8px;
           transition: background 0.2s;
-        ">${code}</div>
+        ">${safeCode}</div>
         <div id="linkCodeHint" style="font-size: 12px; color: #888; margin-bottom: 20px;">
           👆 Tap to copy
         </div>
         <div style="font-size: 14px; color: #ccc; margin-bottom: 20px; line-height: 1.6;">
           1. Copy the code above<br>
-          2. Send it to <a href="https://t.me/${botUsername}" target="_blank" style="
+          2. Send it to <a href="${botLink}" target="_blank" style="
             color: #4fc3f7; text-decoration: none; font-weight: bold;
-          ">@${botUsername}</a><br>
+          ">@${escapeHtml(botUsername)}</a><br>
           3. Done! ✅
         </div>
         <div style="font-size: 12px; color: #666; margin-bottom: 20px;">
           ⏰ Code expires in 10 minutes
         </div>
-        <a href="https://t.me/${botUsername}" target="_blank" style="
+        <a href="${botLink}" target="_blank" style="
           display: inline-block; background: #0088cc; color: #fff;
           padding: 12px 32px; border-radius: 8px; font-size: 16px;
           text-decoration: none; font-weight: bold; margin-bottom: 12px;
-        ">📱 Open @${botUsername}</a>
+        ">📱 Open @${escapeHtml(botUsername)}</a>
         <br>
         <button onclick="document.getElementById('linkTelegramOverlay').remove()" style="
           background: none; border: 1px solid #555; color: #aaa;

--- a/js/security.js
+++ b/js/security.js
@@ -1,0 +1,26 @@
+/* ===== SECURITY HELPERS ===== */
+(function initSecurityHelpers() {
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function sanitizeTelegramHandle(value, fallback = 'Ursasstube_bot') {
+    const raw = String(value ?? '').trim();
+    if (!raw) return fallback;
+
+    const normalized = raw.startsWith('@') ? raw.slice(1) : raw;
+    if (/^[A-Za-z0-9_]{5,32}$/.test(normalized)) {
+      return normalized;
+    }
+
+    return fallback;
+  }
+
+  window.escapeHtml = escapeHtml;
+  window.sanitizeTelegramHandle = sanitizeTelegramHandle;
+})();

--- a/js/ui.js
+++ b/js/ui.js
@@ -95,13 +95,13 @@ function displayLeaderboard(leaderboard, playerPosition) {
         // Use displayName from backend, fallback to wallet formatting
         let name = '';
         if (entry.displayName) {
-          name = entry.displayName;
+          name = escapeHtml(entry.displayName);
         } else if (entry.wallet && entry.wallet.startsWith('0x')) {
-          name = `${entry.wallet.slice(0, 6)}...${entry.wallet.slice(-4)}`;
+          name = escapeHtml(`${entry.wallet.slice(0, 6)}...${entry.wallet.slice(-4)}`);
         } else if (entry.wallet) {
-          name = entry.wallet.length > 14 ? `${entry.wallet.slice(0, 10)}...` : entry.wallet;
+          name = escapeHtml(entry.wallet.length > 14 ? `${entry.wallet.slice(0, 10)}...` : entry.wallet);
         } else {
-          name = 'Unknown';
+          name = escapeHtml('Unknown');
         }
 
         return `


### PR DESCRIPTION
### Motivation
- Harden client-side rendering against DOM XSS by ensuring any backend-driven display values are escaped before insertion into `innerHTML`.
- Fix several observed injection vectors in leaderboard display, auth-linked profile UI, and Telegram linking modal where untrusted fields were interpolated directly.
- Provide a small security review and recommendations for further hardening of third-party dependencies and CSP.

### Description
- Add `js/security.js` which defines and exposes `escapeHtml` and `sanitizeTelegramHandle` helper functions on `window` for centralized escaping and Telegram handle validation.
- Update `js/ui.js` to `escapeHtml` all rendered leaderboard name paths and wallet fallbacks before putting them into HTML.
- Update `js/auth.js` to escape linked wallet and telegram display text, sanitize the bot username with `sanitizeTelegramHandle`, encode bot links with `encodeURIComponent`, and escape the verification code shown in the modal.
- Include the new `js/security.js` in `index.html` and add a new `SECURITY_REVIEW.md` documenting the findings, fixes applied, and additional recommendations.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b867f2c788833291ffa08fd70acfdc)