### PR TITLE
Fix mobile main menu layout overlap on start screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1484,9 +1484,24 @@ footer a:hover { color: #e0b0ff; }
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 768px) {
+  #gameStart {
+    justify-content: flex-start;
+    padding-top: max(72px, calc(env(safe-area-inset-top) + 56px));
+  }
+
+  #walletCorner {
+    top: max(8px, env(safe-area-inset-top));
+    right: 14px;
+  }
+
   .bear-wrapper { width: 250vw; max-width: 800px; height: 250vw; max-height: 800px; margin-top: -120px; margin-bottom: -200px; }
-  .new-title { font-size: 28px; margin-top: -26px; min-height: 38px; }
-  .new-buttons { max-width: 90%; padding: 0 15px; margin-top: 10px; gap: 12px; }
+  .new-title { font-size: 28px; margin-top: -8px; min-height: 38px; }
+  .new-buttons {
+    max-width: 90%;
+    padding: 0 15px;
+    margin-top: clamp(28px, 11vh, 120px);
+    gap: 12px;
+  }
   .btn-new { min-height: 50px; padding: 13px 25px; font-size: 13px; }
   .lb { max-width: 92%; padding: 15px; margin-top: 20px; }
    #startLeaderboardWrap { margin-top: 34px; }
@@ -1519,8 +1534,9 @@ footer a:hover { color: #e0b0ff; }
 }
 
 @media (max-width: 480px) {
-  .bear-wrapper { width: 300vw; max-width: 600px; height: 300vw; max-height: 600px; margin-top: -100px; margin-bottom: -170px; }
-  .new-title { font-size: 24px; margin-top: -4px; min-height: 34px; }
+  .bear-wrapper { width: 300vw; max-width: 600px; height: 300vw; max-height: 600px; margin-top: -40px; margin-bottom: -130px; }
+  .new-title { font-size: 24px; margin-top: 4px; min-height: 34px; }
+  .new-buttons { margin-top: clamp(36px, 16vh, 160px); }
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap { margin-top: 30px; }
@@ -1539,8 +1555,9 @@ footer a:hover { color: #e0b0ff; }
 }
 
 @media (max-width: 360px) {
-  .bear-wrapper { width: 350vw; max-width: 500px; height: 350vw; max-height: 500px; margin-top: -80px; margin-bottom: -140px; }
-  .new-title { font-size: 20px; margin-top: -2px; min-height: 30px; }
+  .bear-wrapper { width: 350vw; max-width: 500px; height: 350vw; max-height: 500px; margin-top: -20px; margin-bottom: -120px; }
+  .new-title { font-size: 20px; margin-top: 8px; min-height: 30px; }
+  .new-buttons { margin-top: clamp(32px, 15vh, 140px); }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
 }
 


### PR DESCRIPTION
### Motivation
- Mobile start screen elements (bear, wallet menu, and action buttons) were colliding and positioned too high on phones, causing the UI to look broken and wallet info to overlap the `STORE` / `START GAME` buttons.
- The goal is to push the hero/bear and title slightly down, make the wallet corner safe-area aware, and place the action buttons nearer to the middle of the viewport on small screens.

### Description
- Updated `css/style.css` to add mobile (`@media (max-width: 768px)`) rules that set `#gameStart` to `justify-content: flex-start` and add a `padding-top` that respects `env(safe-area-inset-top)` so content starts below the status/safe area.
- Adjusted `#walletCorner` positioning on mobile to `top: max(8px, env(safe-area-inset-top))` and `right: 14px` to reduce overlap with central content.
- Tuned hero/title/button layout by reducing negative top margins on `.bear-wrapper` and `.new-title`, and introducing a responsive `margin-top` for `.new-buttons` using `clamp(...)` to push action buttons toward the screen center on `<=768px`, `<=480px`, and `<=360px` breakpoints.
- All changes are contained in `css/style.css` and target only responsive rules for smaller viewports.

### Testing
- Started a local static server with `python3 -m http.server 4173` and served the site for verification, which ran successfully.
- Executed an automated Playwright script (mobile viewport `390x844`) that navigated to the local server and saved a screenshot `mobile-home-after-fix.png`, which completed successfully and shows the adjusted layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86e6835f88332b40d88c014d3b8a5)