### PR TITLE
Improve mobile/Telegram start screen alignment and leaderboard behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1487,6 +1487,8 @@ footer a:hover { color: #e0b0ff; }
   #gameStart {
     justify-content: flex-start;
     padding-top: max(72px, calc(env(safe-area-inset-top) + 56px));
+    padding-bottom: 0;
+    overflow: hidden;
   }
 
   #walletCorner {
@@ -1494,17 +1496,57 @@ footer a:hover { color: #e0b0ff; }
     right: 14px;
   }
 
-  .bear-wrapper { width: 250vw; max-width: 800px; height: 250vw; max-height: 800px; margin-top: -120px; margin-bottom: -200px; }
-  .new-title { font-size: 28px; margin-top: -8px; min-height: 38px; }
+  .bear-wrapper {
+    width: 250vw;
+    max-width: 800px;
+    height: 250vw;
+    max-height: 800px;
+    margin-top: -70px;
+    margin-bottom: -200px;
+    position: relative;
+    z-index: 6;
+  }
+  .new-title {
+    font-size: 28px;
+    min-height: 38px;
+    position: absolute;
+    top: calc(50% - 132px);
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 0;
+    width: min(92vw, 420px);
+    z-index: 12;
+  }
   .new-buttons {
-    max-width: 90%;
+    max-width: min(90vw, 420px);
     padding: 0 15px;
-    margin-top: clamp(28px, 11vh, 120px);
+    margin-top: 0;
     gap: 12px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 12;
   }
   .btn-new { min-height: 50px; padding: 13px 25px; font-size: 13px; }
-  .lb { max-width: 92%; padding: 15px; margin-top: 20px; }
-   #startLeaderboardWrap { margin-top: 34px; }
+  .lb {
+    max-width: 92%;
+    padding: 12px 14px 10px;
+    margin-top: 20px;
+  }
+  #startLeaderboardWrap {
+    margin-top: 0;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: max(8px, env(safe-area-inset-bottom));
+    width: min(94vw, 430px);
+    z-index: 14;
+  }
+  #startLeaderboardWrap .lb-list {
+    max-height: 124px;
+    overflow-y: auto;
+  }
   .lb-title { font-size: 12px; }
   .lb-row { font-size: 11px; padding: 8px 8px; }
   .toggle-row { padding: 4px 10px; gap: 6px; }
@@ -1520,7 +1562,14 @@ footer a:hover { color: #e0b0ff; }
   .store-title { font-size: 20px; }
   .store-item-name { font-size: 12px; }
   .store-tier { font-size: 9px; padding: 6px 4px; }
-  footer { margin-top: 15px; font-size: 9px; }
+  #gameStart footer {
+    position: absolute;
+    bottom: -240px;
+    left: 0;
+    right: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
   .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
   .rules-title { font-size: 22px; }
@@ -1534,12 +1583,20 @@ footer a:hover { color: #e0b0ff; }
 }
 
 @media (max-width: 480px) {
-  .bear-wrapper { width: 300vw; max-width: 600px; height: 300vw; max-height: 600px; margin-top: -40px; margin-bottom: -130px; }
-  .new-title { font-size: 24px; margin-top: 4px; min-height: 34px; }
-  .new-buttons { margin-top: clamp(36px, 16vh, 160px); }
+  .bear-wrapper { width: 300vw; max-width: 600px; height: 300vw; max-height: 600px; margin-top: -20px; margin-bottom: -130px; }
+  .new-title {
+    font-size: 24px;
+    min-height: 34px;
+    top: calc(50% - 120px);
+  }
+  .new-buttons { margin-top: 0; }
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
-  #startLeaderboardWrap { margin-top: 30px; }
+  #startLeaderboardWrap {
+    margin-top: 0;
+    width: min(96vw, 420px);
+  }
+  #startLeaderboardWrap .lb-list { max-height: 118px; }
   .go-title { font-size: 24px; }
   .go-btn { padding: 10px 20px; font-size: 11px; }
   .store-title { font-size: 18px; }
@@ -1556,9 +1613,14 @@ footer a:hover { color: #e0b0ff; }
 
 @media (max-width: 360px) {
   .bear-wrapper { width: 350vw; max-width: 500px; height: 350vw; max-height: 500px; margin-top: -20px; margin-bottom: -120px; }
-  .new-title { font-size: 20px; margin-top: 8px; min-height: 30px; }
-  .new-buttons { margin-top: clamp(32px, 15vh, 140px); }
+  .new-title {
+    font-size: 20px;
+    min-height: 30px;
+    top: calc(50% - 110px);
+  }
+  .new-buttons { margin-top: 0; }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
+  #startLeaderboardWrap .lb-list { max-height: 112px; }
 }
 
 @supports (padding: max(0px)) {


### PR DESCRIPTION
### Motivation
- Make the start screen work better on mobile / Telegram WebApp by centering the main CTAs and preventing the footer from overlapping the UI. 
- Ensure the leaderboard is pinned to the bottom so only the top ~3 rows are visible and the rest are scrollable. 

### Description
- Updated responsive rules in `css/style.css` under `@media (max-width: 768px)` and smaller breakpoints to modify the start-screen layout and element stacking. 
- Centered the CTA block by making `.new-buttons` absolutely positioned at the viewport center and made `.new-title` absolute so the title sits directly above the `STORE` button. 
- Adjusted `.bear-wrapper` margins and `z-index` so the lower part of the bear is visually overlapped by the title text. 
- Pinned the leaderboard by making `#startLeaderboardWrap` absolute at the bottom with `.lb-list` `max-height` (approximate top-3 visible) and added `overflow-y: auto` for scrolling. 
- Hid the footer on mobile by moving `#gameStart footer` off-screen and disabling pointer events, and set `#gameStart` mobile padding/overflow tweaks. 

### Testing
- Started a local static server with `python3 -m http.server` and confirmed the site served successfully. (succeeded) 
- Captured a mobile viewport screenshot using Playwright (`viewport: 390x844`, `is_mobile: true`) to visually verify alignment and scrolling behavior; screenshot generated successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8710eaf488332bece67b2a8acec1a)