### PR TITLE
Adjust mobile start screen layout and scrolling behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1487,8 +1487,9 @@ footer a:hover { color: #e0b0ff; }
   #gameStart {
     justify-content: flex-start;
     padding-top: max(72px, calc(env(safe-area-inset-top) + 56px));
-    padding-bottom: 0;
-    overflow: hidden;
+    padding-bottom: max(28px, env(safe-area-inset-bottom));
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   #walletCorner {
@@ -1504,6 +1505,8 @@ footer a:hover { color: #e0b0ff; }
     margin-top: -70px;
     margin-bottom: -200px;
     position: relative;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 6;
   }
   .new-title {
@@ -1528,6 +1531,17 @@ footer a:hover { color: #e0b0ff; }
     transform: translate(-50%, -50%);
     z-index: 12;
   }
+
+  #ridesInfo {
+    position: absolute;
+    left: 50%;
+    bottom: calc(188px + env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    margin-top: 0;
+    width: min(92vw, 420px);
+    min-height: 0;
+  }
+
   .btn-new { min-height: 50px; padding: 13px 25px; font-size: 13px; }
   .lb {
     max-width: 92%;
@@ -1539,7 +1553,7 @@ footer a:hover { color: #e0b0ff; }
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    bottom: max(8px, env(safe-area-inset-bottom));
+    bottom: max(10px, env(safe-area-inset-bottom));
     width: min(94vw, 430px);
     z-index: 14;
   }
@@ -1563,12 +1577,12 @@ footer a:hover { color: #e0b0ff; }
   .store-item-name { font-size: 12px; }
   .store-tier { font-size: 9px; padding: 6px 4px; }
   #gameStart footer {
-    position: absolute;
-    bottom: -240px;
+    position: relative;
+    margin-top: calc(100dvh + 80px);
     left: 0;
     right: 0;
-    opacity: 0;
-    pointer-events: none;
+    opacity: .6;
+    pointer-events: auto;
   }
   .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
@@ -1597,6 +1611,7 @@ footer a:hover { color: #e0b0ff; }
     width: min(96vw, 420px);
   }
   #startLeaderboardWrap .lb-list { max-height: 118px; }
+  #ridesInfo { bottom: calc(176px + env(safe-area-inset-bottom)); }
   .go-title { font-size: 24px; }
   .go-btn { padding: 10px 20px; font-size: 11px; }
   .store-title { font-size: 18px; }
@@ -1621,6 +1636,7 @@ footer a:hover { color: #e0b0ff; }
   .new-buttons { margin-top: 0; }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
   #startLeaderboardWrap .lb-list { max-height: 112px; }
+  #ridesInfo { bottom: calc(168px + env(safe-area-inset-bottom)); }
 }
 
 @supports (padding: max(0px)) {


### PR DESCRIPTION
### Motivation
- Improve mobile start-screen UX so footer and leaderboard are reachable only by scrolling while keeping primary actions centered and visible first; this matches the requested behavior where the footer and Telegram/socials start off-screen and the leaderboard shows only top entries until scrolled. 
- Ensure the bear hero and action buttons (`STORE` / `START GAME`) are horizontally centered and that the rides/timer block sits immediately above those buttons on small viewports. 
- Preserve an inner-scroll for the leaderboard so only the top rows are visible initially and the rest are accessible via its own scroll.

### Description
- Updated `css/style.css` mobile rules (`@media (max-width: 768px)` and narrower) to allow vertical scrolling on `#gameStart` by setting `padding-bottom: max(28px, env(safe-area-inset-bottom))`, `overflow-y: auto`, and `overflow-x: hidden`. 
- Centered the bear by adding `left: 50%` and `transform: translateX(-50%)` to `.bear-wrapper` under the mobile breakpoint. 
- Pinned `#ridesInfo` above the action buttons by making it `position: absolute` and centering it horizontally with bottom offsets tuned for `<=768px`, `<=480px`, and `<=360px`. 
- Kept the leaderboard docked to the bottom (`#startLeaderboardWrap`) with a constrained inner list (`.lb-list` max-height + `overflow-y: auto`) and adjusted its bottom offset for mobile, and moved the footer below the initial viewport using `margin-top: calc(100dvh + 80px)` so it becomes visible only after scrolling. 

### Testing
- Launched a local static server with `python3 -m http.server 4173 --bind 0.0.0.0`, which served the site for verification. (succeeded) 
- Verified mobile rendering with a Playwright run using a `390x844` mobile viewport and produced a screenshot artifact at `browser:/tmp/codex_browser_invocations/3b7c98a354cb69e9/artifacts/artifacts/mobile-start-screen.png`. (succeeded) 
- No automated unit tests were present or modified; visual/manual checks above were used to validate layout adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b873a7cca883328508581b1d0b2505)