### PR TITLE
Add fallback support for deferred bezel asset loading

### DIFF
--- a/js/assets.js
+++ b/js/assets.js
@@ -33,8 +33,8 @@ class AssetManager {
 
   static getDeferredManifest() {
     return [
-      ['bezel_light', 'img/light_layer_1.png'],
-      ['bezel_metal', 'img/metal_layer_1.png']
+      ['bezel_light', ['img/light_layer_1.png', 'img/light2_layer _1.png']],
+      ['bezel_metal', ['img/metal_layer_1.png']]
     ];
   }
 
@@ -52,7 +52,20 @@ class AssetManager {
     return Promise.all(deferred.map(([name, src]) => this.loadImage(name, src)));
   }
 
-  loadImage(name, src) {
+  async loadImageWithFallback(name, sources) {
+    for (const src of sources) {
+      const loaded = await this.loadImage(name, src, { suppressError: true });
+      if (loaded) return loaded;
+    }
+
+    const [primary] = sources;
+    console.error(`Failed to load ${name}: ${primary}`);
+    return null;
+  }
+
+  loadImage(name, src, options = {}) {
+    if (Array.isArray(src)) return this.loadImageWithFallback(name, src);
+
     if (this.assets[name]) return Promise.resolve(this.assets[name]);
     if (this._queued.has(name)) return Promise.resolve(null);
 
@@ -68,7 +81,7 @@ class AssetManager {
         resolve(img);
       };
       img.onerror = () => {
-        console.error(`Failed to load ${name}: ${src}`);
+        if (!options.suppressError) console.error(`Failed to load ${name}: ${src}`);
         this.loaded++;
         this._queued.delete(name);
         resolve(null);


### PR DESCRIPTION
### Motivation
- The app reported missing bezel images due to inconsistent filenames for the light bezel layer, so a fallback mechanism is needed to handle legacy or alternate paths without failing the whole load flow. 
- Reduce noisy console errors when multiple fallback attempts are performed for the same logical asset. 

### Description
- Updated the deferred asset manifest in `js/assets.js` so `bezel_light` can be defined as multiple candidate sources (`['img/light_layer_1.png', 'img/light2_layer _1.png']`) and `bezel_metal` remains as `['img/metal_layer_1.png']`.
- Added `loadImageWithFallback(name, sources)` which tries each source in order and returns the first successful image or logs a single final error if all attempts fail.
- Extended `loadImage(name, src, options = {})` to accept an array (delegating to the fallback loader) and an `options.suppressError` flag to silence per-attempt errors during fallback attempts.
- Preserved existing single-source loading behavior and queueing logic so other assets are unaffected.

### Testing
- Ran `node --check js/assets.js` to validate JavaScript syntax and it completed without errors. 
- Verified the fallback logic compiles and the updated manifest is recognized by `AssetManager` during static inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babfb00e648332bc049b5f0fac8c90)