### PR TITLE
Copy runtime `assets/` and `img/` into `dist/` in Vite build to fix 404s

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,32 @@
 import { defineConfig } from 'vite';
+import { cpSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+function copyRuntimeStaticAssets() {
+  const dirsToCopy = ['assets', 'img'];
+
+  return {
+    name: 'copy-runtime-static-assets',
+    closeBundle() {
+      const projectRoot = process.cwd();
+      const outputRoot = path.resolve(projectRoot, 'dist');
+
+      for (const relDir of dirsToCopy) {
+        const sourceDir = path.resolve(projectRoot, relDir);
+        const targetDir = path.resolve(outputRoot, relDir);
+
+        if (!existsSync(sourceDir)) continue;
+
+        cpSync(sourceDir, targetDir, {
+          recursive: true,
+          force: true
+        });
+      }
+    }
+  };
+}
 
 export default defineConfig({
-  base: './'
+  base: './',
+  plugins: [copyRuntimeStaticAssets()]
 });


### PR DESCRIPTION
### Motivation
- The production bundle was serving 404s for images and audio referenced by string paths (for example `assets/*.png`, `assets/sfx/*.wav`, `assets/sound/*.ogg`, `img/*.webp`) because Vite does not include files that are not imported into the module graph.

### Description
- Added a small Vite plugin in `vite.config.js` that copies the `assets/` and `img/` directories into the build output `dist/` during `closeBundle` so runtime-loaded files are shipped with the production build.
- Kept the existing `base: './'` configuration and registered the plugin in the `plugins` array so existing behavior is preserved.
- The change is contained to `vite.config.js` and performs a safe `cpSync(..., { recursive: true, force: true })` only when the source directories exist.

### Testing
- Ran `npm run check`, which executed `legacy:build` and the syntax checks and completed successfully (generated `js/legacy-app.generated.js` and validated `vite.config.js`).
- Attempting `npm run build` in this environment failed to complete because the `vite` binary was not available in the runtime (environment limitation), so a full production build could not be validated here.
- `npm install` could not be performed in this environment due to a registry/network `403 Forbidden`, preventing a local install-and-build verification in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac1399c9c8332b38b789d47690de0)