### PR TITLE
Fix wallet auth payload mismatches for store purchases and leaderboard saves

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -185,7 +185,8 @@ async function saveResultToLeaderboard() {
         telegramId
       };
     } else {
-      const walletForSignature = String(identifier || "").toLowerCase();
+      const originalWallet = String(identifier || "");
+      const walletForSignature = originalWallet.toLowerCase();
       const messageToSign = `Save game result\nWallet: ${walletForSignature}\nScore: ${score}\nDistance: ${distance}\nGoldCoins: ${goldCoins}\nSilverCoins: ${silverCoins}\nTimestamp: ${timestamp}`;
       legacySigningPayload = {
         wallet: walletForSignature,
@@ -226,6 +227,20 @@ async function saveResultToLeaderboard() {
           method: "POST",
           headers: { "Content-Type": "application/json", "X-Wallet": data.wallet },
           body: JSON.stringify({ ...data, signature: legacySignature })
+        });
+      }
+    }
+
+    if (!response.ok && response.status === 401 && authMode !== "telegram" && originalWallet && originalWallet !== walletForSignature) {
+      const messageToSignOriginalWallet = `Save game result\nWallet: ${originalWallet}\nScore: ${score}\nDistance: ${distance}\nGoldCoins: ${goldCoins}\nSilverCoins: ${silverCoins}\nTimestamp: ${timestamp}`;
+      const signatureOriginalWallet = await signMessage(messageToSignOriginalWallet);
+
+      if (signatureOriginalWallet) {
+        console.warn("⚠️ Retrying leaderboard save with original wallet casing");
+        response = await request(`${BACKEND_URL}/api/leaderboard/save`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Wallet": originalWallet },
+          body: JSON.stringify({ ...data, wallet: originalWallet, signature: signatureOriginalWallet })
         });
       }
     }

--- a/js/store.js
+++ b/js/store.js
@@ -435,23 +435,30 @@ async function buyUpgrade(key, tier) {
     let requestData;
 
     if (authMode === "telegram") {
+      const telegramId = telegramUser?.id || linkedTelegramId || null;
+      if (!telegramId) {
+        alert("❌ Telegram account not detected");
+        return;
+      }
+
       requestData = {
         wallet: primaryId,
         upgradeKey: key,
         tier,
         timestamp,
         authMode: "telegram",
-        telegramId: telegramUser.id
+        telegramId
       };
     } else {
-      const message = `Buy upgrade\nWallet: ${identifier.toLowerCase()}\nUpgrade: ${key}\nTier: ${tier}\nTimestamp: ${timestamp}`;
+      const walletForSignature = String(identifier || "").toLowerCase();
+      const message = `Buy upgrade\nWallet: ${walletForSignature}\nUpgrade: ${key}\nTier: ${tier}\nTimestamp: ${timestamp}`;
       const signature = await signMessage(message);
       if (!signature) {
         alert("❌ Failed to sign transaction");
         return;
       }
       requestData = {
-        wallet: identifier,
+        wallet: walletForSignature,
         upgradeKey: key,
         tier,
         signature,
@@ -461,7 +468,7 @@ async function buyUpgrade(key, tier) {
 
     const response = await request(`${BACKEND_URL}/api/store/buy`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-Wallet": primaryId || identifier },
+      headers: { "Content-Type": "application/json", "X-Wallet": requestData.wallet || primaryId || identifier },
       body: JSON.stringify(requestData)
     });
 


### PR DESCRIPTION
### Motivation
- Backend validation can reject requests when the wallet value used in the signed message doesn't match the `wallet` field or `X-Wallet` header, causing `400/401` errors.    
- Store purchases originating from Telegram may send invalid payloads when a Telegram id is missing.    
- Some backends validate original wallet casing; a retry with original-cased wallet improves resilience.

### Description
- In `js/store.js` normalize the wallet used for signing to a lowercased `walletForSignature` and send that same value in the request body and `X-Wallet` header to avoid signature/body mismatches.    
- Add a guard for Telegram purchases in `js/store.js` that alerts and aborts when no Telegram id is available to prevent invalid `/api/store/buy` payloads.    
- In `js/api.js` preserve the `originalWallet` and if a leaderboard save returns `401` retry by re-signing and resubmitting using the original wallet casing with matching header/body.    
- Add warning logs and clearer alert messages for signing failures and retry paths.

### Testing
- Ran `npm run check`, which executes the legacy build and syntax checks, and the task completed successfully.    
- The legacy build generated `js/legacy-app.generated.js` and the updated `js/api.js` and `js/store.js` were included without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac47609e08332a0c2ba5da4bf1d29)