### PR TITLE
Fix wallet auth fallback handling for leaderboard and store requests

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -166,6 +166,8 @@ async function saveResultToLeaderboard() {
     let data;
     /** @type {LegacySigningPayload|null} */
     let legacySigningPayload = null;
+    let originalWallet = "";
+    let walletForSignature = "";
     
     if (authMode === "telegram") {
        const telegramId = telegramUser?.id || linkedTelegramId || null;
@@ -185,8 +187,8 @@ async function saveResultToLeaderboard() {
         telegramId
       };
     } else {
-      const originalWallet = String(identifier || "");
-      const walletForSignature = originalWallet.toLowerCase();
+      originalWallet = String(identifier || "");
+      walletForSignature = originalWallet.toLowerCase();
       const messageToSign = `Save game result\nWallet: ${walletForSignature}\nScore: ${score}\nDistance: ${distance}\nGoldCoins: ${goldCoins}\nSilverCoins: ${silverCoins}\nTimestamp: ${timestamp}`;
       legacySigningPayload = {
         wallet: walletForSignature,

--- a/js/store.js
+++ b/js/store.js
@@ -433,6 +433,9 @@ async function buyUpgrade(key, tier) {
   try {
     const timestamp = Date.now();
     let requestData;
+    let originalWallet = "";
+    let walletForSignature = "";
+    let legacyMessagePayload = null;
 
     if (authMode === "telegram") {
       const telegramId = telegramUser?.id || linkedTelegramId || null;
@@ -450,13 +453,19 @@ async function buyUpgrade(key, tier) {
         telegramId
       };
     } else {
-      const walletForSignature = String(identifier || "").toLowerCase();
+      originalWallet = String(identifier || "");
+      walletForSignature = originalWallet.toLowerCase();
       const message = `Buy upgrade\nWallet: ${walletForSignature}\nUpgrade: ${key}\nTier: ${tier}\nTimestamp: ${timestamp}`;
       const signature = await signMessage(message);
       if (!signature) {
         alert("❌ Failed to sign transaction");
         return;
       }
+      legacyMessagePayload = {
+        wallet: walletForSignature,
+        upgradeKey: key,
+        timestamp
+      };
       requestData = {
         wallet: walletForSignature,
         upgradeKey: key,
@@ -466,13 +475,44 @@ async function buyUpgrade(key, tier) {
       };
     }
 
-    const response = await request(`${BACKEND_URL}/api/store/buy`, {
+    let response = await request(`${BACKEND_URL}/api/store/buy`, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-Wallet": requestData.wallet || primaryId || identifier },
       body: JSON.stringify(requestData)
     });
 
-    const data = await response.json();
+    if (!response.ok && (response.status === 400 || response.status === 401) && authMode !== "telegram" && legacyMessagePayload) {
+      const legacyMessage = `Buy upgrade\nWallet: ${legacyMessagePayload.wallet}\nUpgrade: ${legacyMessagePayload.upgradeKey}\nTimestamp: ${legacyMessagePayload.timestamp}`;
+      const legacySignature = await signMessage(legacyMessage);
+      if (legacySignature) {
+        console.warn("⚠️ Retrying purchase with legacy signature payload");
+        response = await request(`${BACKEND_URL}/api/store/buy`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Wallet": requestData.wallet || primaryId || identifier },
+          body: JSON.stringify({ ...requestData, signature: legacySignature })
+        });
+      }
+    }
+
+    if (!response.ok && (response.status === 400 || response.status === 401) && authMode !== "telegram" && originalWallet && originalWallet !== walletForSignature) {
+      const originalWalletMessage = `Buy upgrade\nWallet: ${originalWallet}\nUpgrade: ${key}\nTier: ${tier}\nTimestamp: ${timestamp}`;
+      const originalWalletSignature = await signMessage(originalWalletMessage);
+      if (originalWalletSignature) {
+        console.warn("⚠️ Retrying purchase with original wallet casing");
+        response = await request(`${BACKEND_URL}/api/store/buy`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Wallet": originalWallet },
+          body: JSON.stringify({ ...requestData, wallet: originalWallet, signature: originalWalletSignature })
+        });
+      }
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (_) {
+      data = { success: false, error: await response.text() };
+    }
 
     if (response.ok && data.success) {
       if (data.rides) {


### PR DESCRIPTION
### Motivation
- Fix cases where leaderboard saves returned `401` due to a scoping bug that prevented fallback signing from running. 
- Improve compatibility with older backend signatures for store purchases that returned `400`/`401`. 
- Avoid client-side failures when backend returns non-JSON error bodies for purchase requests.

### Description
- Hoist `originalWallet` and `walletForSignature` in `saveResultToLeaderboard` so the 401 retry logic can reference them outside the wallet-auth block (`js/api.js`).
- Add two compatibility retry paths to `buyUpgrade` in `js/store.js`: retry with a legacy signature payload format (legacy signed message without tier), and retry using the original wallet casing while setting the `X-Wallet` header to the original value.
- Make store error parsing defensive by falling back to `response.text()` when `response.json()` fails, and add warning logs when retry branches are taken.
- Preserve existing behavior on success and keep current conflict handling for already-purchased upgrades.

### Testing
- Ran `npm run check` (which runs the legacy build and syntax checks) and it completed successfully. 
- The legacy build step generated the built artifacts and the `check` script finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacae1140c83328b8f7e28ac3348fe)