### PR TITLE
Export security helpers and stabilize canvas sizing across modules

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -1,5 +1,6 @@
+import { escapeHtml, sanitizeTelegramHandle } from './security.js';
 
-const { WC, request, BACKEND_URL, DOM, escapeHtml, sanitizeTelegramHandle } = window;
+const { WC, request, BACKEND_URL, DOM } = window;
 
 let {
   web3 = null,

--- a/js/game.js
+++ b/js/game.js
@@ -15,6 +15,14 @@ function syncAuthGlobals() {
   ({ isWalletConnected: authIsWalletConnected = false, authMode: authCurrentMode = null } = window);
 }
 
+function getCanvasDimensions() {
+  const fallbackW = DOM.canvas?.clientWidth || window.innerWidth || 360;
+  const fallbackH = DOM.canvas?.clientHeight || window.innerHeight || 640;
+  const width = Number.isFinite(window.canvasW) && window.canvasW > 0 ? window.canvasW : fallbackW;
+  const height = Number.isFinite(window.canvasH) && window.canvasH > 0 ? window.canvasH : fallbackH;
+  return { width, height };
+}
+
 function bindUiEventHandlers() {
   const actionHandlers = {
     "toggle-sfx": toggleSfxMute,
@@ -363,6 +371,7 @@ function restartFromGameOver() {
 }
 
 function endGame(reason = "Unknown") {
+  const { width: canvasW, height: canvasH } = getCanvasDimensions();
   resetGameSessionState();
   gameState.running = false;
   audioManager.stopMusic();
@@ -488,6 +497,7 @@ function goToMainMenu() {
 /* ===== GAME LOOP ===== */
 
 async function gameLoop(time) {
+  const { width: canvasW, height: canvasH } = getCanvasDimensions();
    // Если canvas всё ещё 0×0, попробовать resize
   if (DOM.canvas.width === 0 || DOM.canvas.height === 0) {
     resizeCanvas();

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -27,6 +27,11 @@ const Animations = {
 let canvasW = 0, canvasH = 0;
 let _resizeRetryCount = 0;
 
+Object.assign(window, {
+  canvasW,
+  canvasH
+});
+
 // Cached gradients — invalidated on resize
 let _vignetteCanvas = null;
 let _vignetteCanvasW = 0;
@@ -83,6 +88,8 @@ function resizeCanvas() {
 
   canvasW = cssW;
   canvasH = cssH;
+  window.canvasW = canvasW;
+  window.canvasH = canvasH;
 
   DOM.canvas.width = Math.round(cssW * dpr);
   DOM.canvas.height = Math.round(cssH * dpr);

--- a/js/security.js
+++ b/js/security.js
@@ -1,26 +1,28 @@
 /* ===== SECURITY HELPERS ===== */
-(function initSecurityHelpers() {
-  function escapeHtml(value) {
-    return String(value ?? '')
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function sanitizeTelegramHandle(value, fallback = 'Ursasstube_bot') {
+  const raw = String(value ?? '').trim();
+  if (!raw) return fallback;
+
+  const normalized = raw.startsWith('@') ? raw.slice(1) : raw;
+  if (/^[A-Za-z0-9_]{5,32}$/.test(normalized)) {
+    return normalized;
   }
 
-  function sanitizeTelegramHandle(value, fallback = 'Ursasstube_bot') {
-    const raw = String(value ?? '').trim();
-    if (!raw) return fallback;
+  return fallback;
+}
 
-    const normalized = raw.startsWith('@') ? raw.slice(1) : raw;
-    if (/^[A-Za-z0-9_]{5,32}$/.test(normalized)) {
-      return normalized;
-    }
+Object.assign(window, {
+  escapeHtml,
+  sanitizeTelegramHandle
+});
 
-    return fallback;
-  }
-
-  window.escapeHtml = escapeHtml;
-  window.sanitizeTelegramHandle = sanitizeTelegramHandle;
-})();
+export { escapeHtml, sanitizeTelegramHandle };

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,6 @@
-const { gameState, DOM, player, CONFIG, coins, syncAllAudioUI, escapeHtml } = window;
+import { escapeHtml } from './security.js';
+
+const { gameState, DOM, player, CONFIG, coins, syncAllAudioUI } = window;
 
 let {
   isWalletConnected = false,


### PR DESCRIPTION
### Motivation
- Provide `escapeHtml` and `sanitizeTelegramHandle` as ES module exports so code can import them instead of relying on globals.
- Ensure consistent canvas width/height access across modules by exposing renderer-calculated values and adding a safe accessor in the game code.
- Reduce implicit reliance on `window` for security helpers and make canvas dimensions resolution more robust during game lifecycle events.

### Description
- Refactor `js/security.js` to export `escapeHtml` and `sanitizeTelegramHandle`, attach them to `window`, and remove the old IIFE wrapper.
- Update `js/auth.js` and `js/ui.js` to import the security helpers instead of destructuring them from `window`.
- Add `getCanvasDimensions()` to `js/game.js` and use it in `endGame()` and `gameLoop()` to obtain `canvasW`/`canvasH` reliably.
- Update `js/renderer.js` to expose `canvasW` and `canvasH` on `window` and keep them updated inside `resizeCanvas()` so other modules can read them.

### Testing
- Ran lint checks with `npm run lint` and they passed.
- Ran the project's unit test suite with `npm test` and it passed.
- No automated UI tests were added or changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1a26980c83329dacacf39c859b43)