### PR TITLE
Fix leaderboard crash when backend entries have missing/legacy score fields

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -92,17 +92,23 @@ function displayLeaderboard(leaderboard, playerPosition) {
   syncAuthGlobals();
   let html = '';
 
-  if (leaderboard && leaderboard.length > 0) {
+  if (Array.isArray(leaderboard) && leaderboard.length > 0) {
+    const getEntryScore = (entry) => {
+      if (!entry || typeof entry !== 'object') return 0;
+      // Backend historically used both `bestScore` and `score` fields.
+      return parseInt(entry.bestScore ?? entry.score) || 0;
+    };
+
     const sorted = leaderboard
-      .filter(entry => (parseInt(entry.bestScore) || 0) > 0)
-      .sort((a, b) => (parseInt(b.bestScore) || 0) - (parseInt(a.bestScore) || 0))
+      .filter(entry => getEntryScore(entry) > 0)
+      .sort((a, b) => getEntryScore(b) - getEntryScore(a))
       .slice(0, 10);
 
     if (sorted.length === 0) {
       html = '<div class="lb-empty">No results</div>';
     } else {
       html = sorted.map((entry, idx) => {
-        const score = parseInt(entry.bestScore) || 0;
+        const score = getEntryScore(entry);
         const isMe = entry.wallet === userWallet || entry.wallet === primaryId;
 
         let rankClass = '';


### PR DESCRIPTION
### Motivation
- A runtime error `Cannot read properties of undefined (reading 'score')` was observed when leaderboard payloads included null/malformed entries or used a legacy `score` field instead of `bestScore`. 
- The leaderboard renderer must be resilient to inconsistent API payload shapes to avoid crashing the UI.

### Description
- In `js/ui.js` `displayLeaderboard` now verifies `Array.isArray(leaderboard)` before processing to avoid non-array inputs. 
- Added a `getEntryScore(entry)` helper that safely reads `bestScore` or legacy `score` and returns `0` for malformed entries. 
- Updated filtering, sorting and rendering to use the normalized score so entries with missing fields are ignored and `undefined.score` is never accessed.

### Testing
- Ran `npm run check` (which runs `scripts/check-syntax.mjs`) and it completed successfully, reporting OK for `js/ui.js` and all other JS files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2231b6ec8332a5cacdf15ed155c4)