### PR TITLE
Refactor globals into ES modules and add known-identifier matching for leaderboard

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,6 +1,9 @@
 // @ts-check
 
-const { BACKEND_URL, request, DOM, WC, gameState } = window;
+import { BACKEND_URL } from './config.js';
+import { request } from './request.js';
+import { DOM, gameState } from './state.js';
+import { WC } from './walletconnect.js';
 
 let {
   isWalletConnected = false,
@@ -86,6 +89,24 @@ function isAuthenticated() {
 function getAuthIdentifier() {
   syncAuthGlobals();
   return userWallet || primaryId || null;
+}
+
+function getKnownAuthIdentifiers() {
+  syncAuthGlobals();
+  const identifiers = new Set();
+
+  const pushIdentifier = (value) => {
+    if (!value) return;
+    const normalized = String(value).trim();
+    if (normalized) identifiers.add(normalized);
+  };
+
+  pushIdentifier(primaryId);
+  pushIdentifier(userWallet);
+  pushIdentifier(linkedTelegramId);
+  pushIdentifier(window.linkedWallet);
+
+  return identifiers;
 }
 
 /* ===== WALLET UI ===== */
@@ -299,6 +320,7 @@ async function saveResultToLeaderboard() {
 Object.assign(window, {
   isAuthenticated,
   getAuthIdentifier,
+  getKnownAuthIdentifiers,
   updateWalletUI,
   signMessage,
   loadAndDisplayLeaderboard,
@@ -308,6 +330,7 @@ Object.assign(window, {
 export {
   isAuthenticated,
   getAuthIdentifier,
+  getKnownAuthIdentifiers,
   updateWalletUI,
   signMessage,
   loadAndDisplayLeaderboard,

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,6 +1,10 @@
 import { escapeHtml, sanitizeTelegramHandle } from './security.js';
-
-const { WC, request, BACKEND_URL, DOM } = window;
+import { WC } from './walletconnect.js';
+import { request } from './request.js';
+import { BACKEND_URL } from './config.js';
+import { DOM } from './state.js';
+import { updateWalletUI, loadAndDisplayLeaderboard } from './api.js';
+import { loadPlayerUpgrades, updateRidesDisplay } from './store.js';
 
 let {
   web3 = null,
@@ -94,10 +98,10 @@ async function connectWalletAuth() {
       console.log("✅ Wallet auth OK:", primaryId);
 
       updateAuthUI();
-      await window.updateWalletUI();
-      await window.loadPlayerUpgrades();
-      await window.loadAndDisplayLeaderboard();
-      window.updateRidesDisplay();
+      await updateWalletUI();
+      await loadPlayerUpgrades();
+      await loadAndDisplayLeaderboard();
+      updateRidesDisplay();
 
       if (DOM.storeBtn) DOM.storeBtn.classList.remove("menu-hidden");
     }
@@ -238,10 +242,10 @@ async function initAuth() {
 
         console.log("✅ Telegram auth OK:", primaryId);
         updateAuthUI();
-        await window.updateWalletUI();
-        await window.loadPlayerUpgrades();
-        await window.loadAndDisplayLeaderboard();
-        window.updateRidesDisplay();
+        await updateWalletUI();
+        await loadPlayerUpgrades();
+        await loadAndDisplayLeaderboard();
+        updateRidesDisplay();
       }
     } catch (e) {
       console.error("❌ Telegram auth error:", e);
@@ -422,8 +426,8 @@ async function linkWallet() {
       }
 
       updateAuthUI();
-      await window.updateWalletUI();
-      await window.loadPlayerUpgrades();
+      await updateWalletUI();
+      await loadPlayerUpgrades();
     } else {
       alert(`❌ ${data.error}`);
     }

--- a/js/input.js
+++ b/js/input.js
@@ -1,5 +1,9 @@
+import { gameState, player, inputQueue, coins, DOM } from './state.js';
+import { CONFIG } from './config.js';
+import { audioManager } from './audio.js';
+import { spawnParticles } from './particles.js';
+
 /* ===== INPUT HANDLERS ===== */
-const { gameState, player, inputQueue, coins, CONFIG, audioManager, spawnParticles, DOM } = window;
 
 function isInteractiveElement(el) {
   if (!el) return false;
@@ -84,3 +88,5 @@ function triggerSpin() {
 }
 
 Object.assign(window, { isInteractiveElement, triggerSpin });
+
+export { isInteractiveElement, triggerSpin };

--- a/js/physics.js
+++ b/js/physics.js
@@ -1,18 +1,7 @@
-const {
-  player,
-  gameState,
-  spinTargets,
-  CONFIG,
-  BONUS_TYPES,
-  obstacles,
-  bonuses,
-  coins,
-  inputQueue,
-  audioManager,
-  spawnParticles,
-  DOM,
-  curves
-} = window;
+import { player, gameState, spinTargets, obstacles, bonuses, coins, inputQueue, DOM, curves } from './state.js';
+import { CONFIG, BONUS_TYPES } from './config.js';
+import { audioManager } from './audio.js';
+import { spawnParticles } from './particles.js';
 
 let laneCooldown = window.laneCooldown || 0;
 let { playerEffects = null, playerUpgrades = null } = window;

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,17 +1,6 @@
-const {
-  DOM,
-  ctx,
-  isMobile,
-  CONFIG,
-  gameState,
-  player,
-  assetManager,
-  obstacles,
-  bonuses,
-  coins,
-  spinTargets
-} = window;
-
+import { DOM, ctx, gameState, player, obstacles, bonuses, coins, spinTargets } from './state.js';
+import { CONFIG, isMobile } from './config.js';
+import { assetManager } from './assets.js';
 
 /* ===== ANIMATIONS ===== */
 const Animations = {

--- a/js/store.js
+++ b/js/store.js
@@ -1,11 +1,9 @@
+import { BACKEND_URL } from './config.js';
+import { request } from './request.js';
+import { isAuthenticated, getAuthIdentifier, signMessage } from './api.js';
+import { syncAllAudioUI } from './audio.js';
+
 /* ===== RIDES SYSTEM ===== */
-const {
-  BACKEND_URL,
-  request,
-  isAuthenticated,
-  getAuthIdentifier,
-  signMessage
-} = window;
 
 let {
   authMode = null,
@@ -632,7 +630,7 @@ function hideRules() {
 }
 
 function updateRulesAudioButtons() {
-  if (typeof window.syncAllAudioUI === 'function') window.syncAllAudioUI();
+  syncAllAudioUI();
 }
 
 syncStoreGlobals();
@@ -655,3 +653,17 @@ Object.assign(window, {
   hideRules,
   updateRulesAudioButtons
 });
+
+
+export {
+  loadPlayerRides,
+  useRide,
+  updateRidesDisplay,
+  applyStoreDefaultLockState,
+  loadPlayerUpgrades,
+  updateStoreUI,
+  buyUpgrade,
+  showRules,
+  hideRules,
+  updateRulesAudioButtons
+};

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,20 +1,9 @@
 import { escapeHtml } from './security.js';
-
-const { gameState, DOM, player, CONFIG, coins, syncAllAudioUI } = window;
-
-let {
-  isWalletConnected = false,
-  userWallet = null,
-  primaryId = null
-} = window;
-
-function syncAuthGlobals() {
-  ({
-    isWalletConnected = false,
-    userWallet = null,
-    primaryId = null
-  } = window);
-}
+import { gameState, DOM, player, coins } from './state.js';
+import { CONFIG } from './config.js';
+import { syncAllAudioUI } from './audio.js';
+import { loadPlayerUpgrades, updateStoreUI, applyStoreDefaultLockState } from './store.js';
+import { isAuthenticated, getKnownAuthIdentifiers } from './api.js';
 
 function showBonusText(text) {
   gameState.bonusText = text;
@@ -22,8 +11,7 @@ function showBonusText(text) {
 }
 
 function showStore() {
-  syncAuthGlobals();
-  if (!isWalletConnected) {
+  if (!isAuthenticated()) {
     alert("🔗 Connect wallet first!");
     return;
   }
@@ -34,8 +22,10 @@ function showStore() {
   document.getElementById("audioTogglesGlobal").style.display = "none";
 
   syncAllAudioUI();
-  if (typeof window.applyStoreDefaultLockState === "function") window.applyStoreDefaultLockState();
-  window.loadPlayerUpgrades().then(() => { window.updateStoreUI(); });
+  applyStoreDefaultLockState();
+  loadPlayerUpgrades().then(() => {
+    updateStoreUI();
+  });
   console.log("🛒 Store opened");
 }
 
@@ -89,7 +79,7 @@ function showLeaderboardSkeletons() {
 }
 
 function displayLeaderboard(leaderboard, playerPosition) {
-  syncAuthGlobals();
+  const myIdentifiers = getKnownAuthIdentifiers();
   let html = '';
 
   if (leaderboard && leaderboard.length > 0) {
@@ -103,7 +93,8 @@ function displayLeaderboard(leaderboard, playerPosition) {
     } else {
       html = sorted.map((entry, idx) => {
         const score = parseInt(entry.bestScore) || 0;
-        const isMe = entry.wallet === userWallet || entry.wallet === primaryId;
+        const entryWallet = String(entry.wallet || '').trim();
+        const isMe = entryWallet ? myIdentifiers.has(entryWallet) : false;
 
         let rankClass = '';
         if (idx === 0) rankClass = 'gold';
@@ -112,7 +103,6 @@ function displayLeaderboard(leaderboard, playerPosition) {
 
         const rowClass = isMe ? 'lb-row lb-row--me' : 'lb-row';
 
-        // Use displayName from backend, fallback to wallet formatting
         let name = '';
         if (entry.displayName) {
           name = escapeHtml(entry.displayName);


### PR DESCRIPTION
### Motivation
- Move app code away from relying on `window` globals toward ES module imports for clearer dependencies and easier testing.
- Improve leaderboard personal-highlighting by matching multiple possible auth identifiers (wallet, primaryId, linked IDs).

### Description
- Replaced many `window` global usages with explicit imports across files including `js/api.js`, `js/auth.js`, `js/input.js`, `js/physics.js`, `js/renderer.js`, `js/store.js`, and `js/ui.js` and wired in modules like `config.js`, `request.js`, `state.js`, `walletconnect.js`, `audio.js`, `particles.js`, and `assets.js`.
- Added `getKnownAuthIdentifiers()` to `js/api.js` and exported it for use by UI logic to detect the current user in leaderboard entries.
- Updated `displayLeaderboard` in `js/ui.js` to use `getKnownAuthIdentifiers()` instead of fragile `userWallet`/`primaryId` checks and adjusted name formatting logic.
- Exported store functions from `js/store.js`, converted several `window.*` calls to direct imports, and updated auth flows in `js/auth.js` to call imported helpers like `updateWalletUI`, `loadPlayerUpgrades`, and `updateRidesDisplay`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb232fa66483329205bb4c60d49e7b)