### PR TITLE
Fix module init order to prevent startup crashes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,20 +1,20 @@
 import './logger.js';
 import './config.js';
-import './request.js';
-import './api.js';
-import './assets.js';
 import './state.js';
-import './input.js';
 import './audio.js';
+import './request.js';
+import './walletconnect.js';
+import './assets.js';
 import './particles.js';
 import './perf.js';
-import './walletconnect.js';
 import './security.js';
 import './auth.js';
+import './api.js';
 import './ui.js';
 import './store.js';
 import './physics.js';
 import './renderer.js';
+import './input.js';
 import { stabilizeMenuLoad } from './stabilize-menu.js';
 import './game.js';
 


### PR DESCRIPTION
### Motivation
- The app crashed on startup with errors like `Cannot read properties of undefined (reading 'playSFX')` and `Cannot read properties of undefined (reading 'score')` because some modules destructured globals from `window` before those globals were registered.

### Description
- Reordered imports in `js/main.js` so core initializers (`state.js`, `audio.js`) run before modules that depend on `window.gameState` and `window.audioManager`.
- Moved dependent modules such as `input.js` and `api.js` after the foundational modules to prevent them from capturing `undefined` globals during module evaluation.
- This is an initialization-order change only and does not alter gameplay logic or feature behavior.

### Testing
- Ran `npm run check` and all source files passed the syntax check.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2b7026248332bb5dbff5c0592622)