### PR TITLE
Modularize auth state and decouple api.js from global window variables

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,25 +1,14 @@
 // @ts-check
 
-const { BACKEND_URL, request, DOM, WC, gameState } = window;
+import { BACKEND_URL } from './config.js';
+import { request } from './request.js';
+import { DOM, gameState } from './state.js';
+import { WC } from './walletconnect.js';
+import { showBonusText, showLeaderboardSkeletons, displayLeaderboard } from './ui.js';
+import { getAuthState } from './auth.js';
 
-let {
-  isWalletConnected = false,
-  userWallet = null,
-  authMode = null,
-  primaryId = null,
-  telegramUser = null,
-  linkedTelegramId = null
-} = window;
-
-function syncAuthGlobals() {
-  ({
-    isWalletConnected = false,
-    userWallet = null,
-    authMode = null,
-    primaryId = null,
-    telegramUser = null,
-    linkedTelegramId = null
-  } = window);
+function getCurrentAuthState() {
+  return getAuthState();
 }
 
 /**
@@ -79,19 +68,19 @@ function syncAuthGlobals() {
 /* ===== AUTH HELPERS ===== */
 
 function isAuthenticated() {
-  syncAuthGlobals();
+  const { isWalletConnected = false, userWallet = null, authMode = null, primaryId = null } = getCurrentAuthState();
   return (isWalletConnected && userWallet) || (authMode === "telegram" && primaryId);
 }
 
 function getAuthIdentifier() {
-  syncAuthGlobals();
+  const { userWallet = null, primaryId = null } = getCurrentAuthState();
   return userWallet || primaryId || null;
 }
 
 /* ===== WALLET UI ===== */
 
 async function updateWalletUI() {
-  syncAuthGlobals();
+  const { isWalletConnected = false, primaryId = null } = getCurrentAuthState();
   if (!isWalletConnected || !primaryId) {
     DOM.walletInfo.classList.remove("visible");
     return;
@@ -127,7 +116,7 @@ async function updateWalletUI() {
  * @returns {Promise<string|null>}
  */
 async function signMessage(message) {
-  syncAuthGlobals();
+  const { authMode = null, userWallet = null } = getCurrentAuthState();
   try {
     if (authMode === "telegram") {
       // Telegram users can't sign EIP-191 messages
@@ -152,26 +141,31 @@ async function signMessage(message) {
 
 
 async function loadAndDisplayLeaderboard() {
-  syncAuthGlobals();
-  window.showLeaderboardSkeletons();
+  const { userWallet = null } = getCurrentAuthState();
+  showLeaderboardSkeletons();
   try {
     const url = `${BACKEND_URL}/api/leaderboard/top?wallet=${userWallet || ''}`;
     const response = await request(url);
     /** @type {LeaderboardTopResponse} */
     const data = await response.json();
     if (response.ok) {
-      window.displayLeaderboard(data.leaderboard, data.playerPosition);
+      displayLeaderboard(data.leaderboard, data.playerPosition);
     } else {
-      window.displayLeaderboard([], null);
+      displayLeaderboard([], null);
     }
   } catch (e) {
     console.error("❌ Leaderboard error:", e);
-    window.displayLeaderboard([], null);
+    displayLeaderboard([], null);
   }
 }
 
 async function saveResultToLeaderboard() {
-  syncAuthGlobals();
+  const {
+    authMode = null,
+    primaryId = null,
+    telegramUser = null,
+    linkedTelegramId = null
+  } = getCurrentAuthState();
   if (!isAuthenticated()) {
     console.log("⚪ Not authenticated — result not saved");
     return;
@@ -278,7 +272,7 @@ async function saveResultToLeaderboard() {
     
     if (response.ok) {
       console.log("✅ Result saved!");
-      window.showBonusText("✅ In leaderboard!");
+      showBonusText("✅ In leaderboard!");
       await loadAndDisplayLeaderboard();
       await updateWalletUI();
       return;

--- a/js/auth.js
+++ b/js/auth.js
@@ -28,6 +28,20 @@ function syncAuthWindowState() {
   });
 }
 
+function getAuthState() {
+  return {
+    web3,
+    userWallet,
+    isWalletConnected,
+    authMode,
+    primaryId,
+    telegramUser,
+    linkedTelegramId,
+    linkedTelegramUsername,
+    linkedWallet
+  };
+}
+
 function isTelegramMiniApp() {
   return !!(window.Telegram && window.Telegram.WebApp &&
     window.Telegram.WebApp.initDataUnsafe &&
@@ -448,6 +462,7 @@ Object.assign(window, {
 });
 
 export {
+  getAuthState,
   isTelegramMiniApp,
   getTelegramUserData,
   connectWalletAuth,


### PR DESCRIPTION
### Motivation
- Reduce coupling to `window` globals by centralizing authentication state and separating responsibilities across modules.

### Description
- Added `getAuthState` to `js/auth.js` and exported it for other modules to read auth-related state via `getCurrentAuthState` in `js/api.js` instead of syncing `window` values. 
- Reworked `js/api.js` to import `BACKEND_URL`, `request`, `DOM`, `gameState`, `WC`, and UI helpers from their respective modules and removed the prior `syncAuthGlobals` approach. 
- Updated API functions (`isAuthenticated`, `getAuthIdentifier`, `updateWalletUI`, `signMessage`, `loadAndDisplayLeaderboard`, `saveResultToLeaderboard`) to read auth info from `getCurrentAuthState` and to call imported UI helpers like `showLeaderboardSkeletons`, `displayLeaderboard`, and `showBonusText` instead of `window`-scoped functions. 
- Kept backward-compatible `Object.assign(window, {...})` exports in `js/api.js` so runtime callers on `window` continue to work.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2e0914ec8332b1de1ddeae7294ad)