### PR TITLE
refactor: continue Vite ESM migration for ui/store modules

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1,11 +1,8 @@
 /* ===== RIDES SYSTEM ===== */
-const {
-  BACKEND_URL,
-  request,
-  isAuthenticated,
-  getAuthIdentifier,
-  signMessage
-} = window;
+import { BACKEND_URL } from './config.js';
+import { request } from './request.js';
+import { isAuthenticated, getAuthIdentifier, signMessage } from './api.js';
+import { getAuthState } from './auth.js';
 
 let {
   authMode = null,
@@ -13,7 +10,7 @@ let {
   userWallet = null,
   telegramUser = null,
   linkedTelegramId = null
-} = window;
+} = getAuthState();
 
 function syncAuthGlobals() {
   ({
@@ -22,7 +19,7 @@ function syncAuthGlobals() {
     userWallet = null,
     telegramUser = null,
     linkedTelegramId = null
-  } = window);
+  } = getAuthState());
 }
 
 const ICON_TICKET = '<span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span>';
@@ -655,3 +652,20 @@ Object.assign(window, {
   hideRules,
   updateRulesAudioButtons
 });
+
+export {
+  playerRides,
+  playerUpgrades,
+  playerEffects,
+  playerBalance,
+  loadPlayerRides,
+  useRide,
+  updateRidesDisplay,
+  applyStoreDefaultLockState,
+  loadPlayerUpgrades,
+  updateStoreUI,
+  buyUpgrade,
+  showRules,
+  hideRules,
+  updateRulesAudioButtons
+};

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,20 +1,9 @@
 import { escapeHtml } from './security.js';
-
-const { gameState, DOM, player, CONFIG, coins, syncAllAudioUI } = window;
-
-let {
-  isWalletConnected = false,
-  userWallet = null,
-  primaryId = null
-} = window;
-
-function syncAuthGlobals() {
-  ({
-    isWalletConnected = false,
-    userWallet = null,
-    primaryId = null
-  } = window);
-}
+import { CONFIG } from './config.js';
+import { DOM, gameState, player, coins } from './state.js';
+import { syncAllAudioUI } from './audio.js';
+import { getAuthState } from './auth.js';
+import { applyStoreDefaultLockState, loadPlayerUpgrades, updateStoreUI } from './store.js';
 
 function showBonusText(text) {
   gameState.bonusText = text;
@@ -22,7 +11,7 @@ function showBonusText(text) {
 }
 
 function showStore() {
-  syncAuthGlobals();
+  const { isWalletConnected = false } = getAuthState();
   if (!isWalletConnected) {
     alert("🔗 Connect wallet first!");
     return;
@@ -34,8 +23,8 @@ function showStore() {
   document.getElementById("audioTogglesGlobal").style.display = "none";
 
   syncAllAudioUI();
-  if (typeof window.applyStoreDefaultLockState === "function") window.applyStoreDefaultLockState();
-  window.loadPlayerUpgrades().then(() => { window.updateStoreUI(); });
+  applyStoreDefaultLockState();
+  loadPlayerUpgrades().then(() => { updateStoreUI(); });
   console.log("🛒 Store opened");
 }
 
@@ -89,7 +78,10 @@ function showLeaderboardSkeletons() {
 }
 
 function displayLeaderboard(leaderboard, playerPosition) {
-  syncAuthGlobals();
+  const {
+    userWallet = null,
+    primaryId = null
+  } = getAuthState();
   let html = '';
 
   if (Array.isArray(leaderboard) && leaderboard.length > 0) {


### PR DESCRIPTION
### Motivation

- Remove implicit runtime `window` dependency and progress migration to ESM so modules can be statically analyzed and bundled by Vite.

### Description

- Reworked `js/ui.js` to stop destructuring from `window` and instead import `state`, `config`, `audio`, `auth` and `store` symbols via `import` statements and use `getAuthState()` for auth checks.
- Updated store opening flow in `js/ui.js` to call `applyStoreDefaultLockState`, `loadPlayerUpgrades`, and `updateStoreUI` via direct imports instead of referencing `window` helpers.
- Rewrote `js/store.js` to import `BACKEND_URL`, `request`, and auth helpers from `api`/`auth` modules instead of reading them from `window`, and to rely on `getAuthState()` for current auth values.
- Added named `export` entries to `js/store.js` for rides/state functions and store helpers while preserving `Object.assign(window, ...)` to maintain backward compatibility during the incremental migration.

### Testing

- Ran `npm run check` (syntax/type checks) which completed successfully.
- Ran `npm run build` (Vite production build) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb32d74e2883329a80f2d0327b45b7)