### PR TITLE
refactor: continue ES module migration for renderer canvas state

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -3,7 +3,7 @@ import { isAuthenticated, saveResultToLeaderboard, loadAndDisplayLeaderboard } f
 import { audioManager, toggleSfxMute, toggleMusicMute, syncAllAudioUI, restoreAudioSettings, initAudioToggles } from './audio.js';
 import { DOM, gameState, curves, player, obstacles, bonuses, coins, spinTargets, ctx, inputQueue } from './state.js';
 import { resetGameSessionState, update } from './physics.js';
-import { resizeCanvas, drawTube, drawTubeDepth, drawTubeCenter, drawSpeedLines, drawNeonLines, drawObjects, drawCoins, drawPlayer, drawTubeBezel, drawRadarHints, drawSpinAlert, drawBonusText } from './renderer.js';
+import { resizeCanvas, drawTube, drawTubeDepth, drawTubeCenter, drawSpeedLines, drawNeonLines, drawObjects, drawCoins, drawPlayer, drawTubeBezel, drawRadarHints, drawSpinAlert, drawBonusText, canvasW, canvasH } from './renderer.js';
 import { particlePool, spawnParticles, updateParticles, drawParticles } from './particles.js';
 import { assetManager } from './assets.js';
 import { showBonusText, showStore, hideStore, updateUI } from './ui.js';
@@ -32,8 +32,8 @@ function syncAuthGlobals() {
 function getCanvasDimensions() {
   const fallbackW = DOM.canvas?.clientWidth || window.innerWidth || 360;
   const fallbackH = DOM.canvas?.clientHeight || window.innerHeight || 640;
-  const width = Number.isFinite(window.canvasW) && window.canvasW > 0 ? window.canvasW : fallbackW;
-  const height = Number.isFinite(window.canvasH) && window.canvasH > 0 ? window.canvasH : fallbackH;
+  const width = Number.isFinite(canvasW) && canvasW > 0 ? canvasW : fallbackW;
+  const height = Number.isFinite(canvasH) && canvasH > 0 ? canvasH : fallbackH;
   return { width, height };
 }
 

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,16 +1,6 @@
-const {
-  DOM,
-  ctx,
-  isMobile,
-  CONFIG,
-  gameState,
-  player,
-  assetManager,
-  obstacles,
-  bonuses,
-  coins,
-  spinTargets
-} = window;
+import { CONFIG, isMobile } from './config.js';
+import { DOM, ctx, gameState, player, obstacles, bonuses, coins, spinTargets } from './state.js';
+import { assetManager } from './assets.js';
 
 
 /* ===== ANIMATIONS ===== */
@@ -27,10 +17,6 @@ const Animations = {
 let canvasW = 0, canvasH = 0;
 let _resizeRetryCount = 0;
 
-Object.assign(window, {
-  canvasW,
-  canvasH
-});
 
 // Cached gradients — invalidated on resize
 let _vignetteCanvas = null;
@@ -88,8 +74,6 @@ function resizeCanvas() {
 
   canvasW = cssW;
   canvasH = cssH;
-  window.canvasW = canvasW;
-  window.canvasH = canvasH;
 
   DOM.canvas.width = Math.round(cssW * dpr);
   DOM.canvas.height = Math.round(cssH * dpr);
@@ -1285,5 +1269,7 @@ export {
   drawBonusText,
   drawRadarHints,
   drawSpinAlert,
-  drawTubeBezel
+  drawTubeBezel,
+  canvasW,
+  canvasH
 };


### PR DESCRIPTION
### Motivation
- Continue migrating legacy code away from runtime `window` globals toward ESM imports to improve modularity and compatibility with Vite.
- Remove implicit global coupling for canvas dimensions (`canvasW`/`canvasH`) so other modules can import them explicitly.

### Description
- Replaced top-level `window` destructuring in `js/renderer.js` with direct ESM imports from `./config.js`, `./state.js`, and `./assets.js`.
- Stopped writing `canvasW`/`canvasH` to `window` and added them as named exports from `js/renderer.js`.
- Updated `js/game.js` to import `canvasW`/`canvasH` from `./renderer.js` and use them in `getCanvasDimensions` instead of reading `window.canvasW`/`window.canvasH`.
- Adjusted the renderer export list to include `canvasW` and `canvasH` so downstream modules can consume them as ESM values.

### Testing
- Ran `npm run check` (which calls `node scripts/check-syntax.mjs`) and all checked files passed.
- Ran `npm run build` (Vite) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb35be1c988332b5c999f69bad4456)