### PR TITLE
Refactor physics module to use direct ES module imports

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -773,3 +773,5 @@ window.addEventListener('resize', () => {
 });
 
 Object.assign(window, { endGame });
+
+export { endGame };

--- a/js/input.js
+++ b/js/input.js
@@ -1,4 +1,4 @@
-import { gameState, player, inputQueue, coins, DOM } from './state.js';
+import { gameState, player, inputQueue, coins, DOM, getLaneCooldown } from './state.js';
 import { CONFIG } from './config.js';
 import { audioManager } from './audio.js';
 import { spawnParticles } from './particles.js';
@@ -60,7 +60,7 @@ document.addEventListener("keydown", e => {
 });
 
 function triggerSpin() {
-  if (gameState.spinCooldown > 0 || gameState.spinActive || player.isLaneTransition || (window.laneCooldown || 0) > 0) return;
+  if (gameState.spinCooldown > 0 || gameState.spinActive || player.isLaneTransition || getLaneCooldown() > 0) return;
 
   // Perfect spin window — auto-collect coins near active ring
   if (gameState.perfectSpinWindow) {

--- a/js/physics.js
+++ b/js/physics.js
@@ -1,25 +1,13 @@
-const {
-  player,
-  gameState,
-  spinTargets,
-  CONFIG,
-  BONUS_TYPES,
-  obstacles,
-  bonuses,
-  coins,
-  inputQueue,
-  audioManager,
-  spawnParticles,
-  DOM,
-  curves
-} = window;
+import { CONFIG, BONUS_TYPES } from './config.js';
+import { player, gameState, spinTargets, obstacles, bonuses, coins, inputQueue, DOM, curves, getLaneCooldown, setLaneCooldown } from './state.js';
+import { audioManager } from './audio.js';
+import { spawnParticles } from './particles.js';
+import { playerEffects, playerUpgrades } from './store.js';
+import { showBonusText } from './ui.js';
+import { project, projectPlayer, updatePlayerAnimation } from './renderer.js';
+import { endGame } from './game.js';
 
-let laneCooldown = window.laneCooldown || 0;
-let { playerEffects = null, playerUpgrades = null } = window;
-
-function syncStoreGlobals() {
-  ({ playerEffects = null, playerUpgrades = null } = window);
-}
+let laneCooldown = getLaneCooldown();
 
 
 function resetGameSessionState() {
@@ -286,8 +274,8 @@ function spawnCoinCluster() {
 /* ===== UPDATE FUNCTION ===== */
 
 function update(delta) {
-  if (!isFinite(gameState.speed) || gameState.speed < 0) { window.endGame("Speed error"); return; }
-  if (!isFinite(gameState.distance) || gameState.distance < 0) { window.endGame("Distance error"); return; }
+  if (!isFinite(gameState.speed) || gameState.speed < 0) { endGame("Speed error"); return; }
+  if (!isFinite(gameState.distance) || gameState.distance < 0) { endGame("Distance error"); return; }
 
   gameState.deltaTime = delta;
 
@@ -349,7 +337,7 @@ function update(delta) {
   // Emergency check — no objects spawned for 600m
   if (gameState.distance - gameState.lastObstacleSpawnDistance > 600) {
     console.error("❌ No objects spawned for 600m! Forced game end.");
-    window.endGame("spawn_error");
+    endGame("spawn_error");
     return;
   }
 
@@ -452,7 +440,7 @@ function update(delta) {
   }
 
   if (laneCooldown > 0) laneCooldown--;
-  window.laneCooldown = laneCooldown;
+  setLaneCooldown(laneCooldown);
 
   // Lane transition animation
   if (player.isLaneTransition) {
@@ -485,7 +473,7 @@ function update(delta) {
         const comboScore = comboTable[Math.min(gameState.spinComboCount, comboTable.length - 1)];
         if (comboScore > 0) {
           gameState.score += comboScore * gameState.baseMultiplier;
-          window.showBonusText(`🎯 Combo x${gameState.spinComboCount}! +${comboScore}`);
+          showBonusText(`🎯 Combo x${gameState.spinComboCount}! +${comboScore}`);
         }
         gameState.spinComboCount = 0;
       }
@@ -511,7 +499,7 @@ function update(delta) {
   }
 
   // Player position
-  const p = window.projectPlayer(CONFIG.PLAYER_Z);
+  const p = projectPlayer(CONFIG.PLAYER_Z);
   player.x = p.x - CONFIG.FRAME_SIZE / 2;
   player.y = p.y - CONFIG.FRAME_SIZE / 2;
 
@@ -548,7 +536,7 @@ function update(delta) {
         player.shield = player.shieldCount > 0;
         obstacles.splice(i, 1);
       } else {
-        window.endGame(o.subtype);
+        endGame(o.subtype);
         return;
       }
     }
@@ -565,7 +553,7 @@ function update(delta) {
 
   // Collisions: coins
   const magnetActive = player.magnetActive;
-  const playerPos = magnetActive ? window.projectPlayer(CONFIG.PLAYER_Z) : null;
+  const playerPos = magnetActive ? projectPlayer(CONFIG.PLAYER_Z) : null;
   const magnetRangeSq = 150 * 150;
   for (let i = coins.length - 1; i >= 0; i--) {
     const c = coins[i];
@@ -576,7 +564,7 @@ function update(delta) {
 
     // Magnet
      if (magnetActive && playerPos && c.z > 0.05 && c.z < 1.5) {
-      const cp = typeof c.lane === "number" ? window.project(c.lane, c.z) : null;
+      const cp = typeof c.lane === "number" ? project(c.lane, c.z) : null;
      if (cp) {
         const dx = cp.x - playerPos.x;
         const dy = cp.y - playerPos.y;
@@ -622,7 +610,7 @@ function update(delta) {
   }
 
   // Character animation
-  window.updatePlayerAnimation(delta);
+  updatePlayerAnimation(delta);
 
   // Tube curves
   gameState.tubeWaveMod += 0.002;
@@ -649,7 +637,6 @@ function update(delta) {
 /* ===== BONUS & COINS ===== */
 
 function applyBonus(bonus) {
-  syncStoreGlobals();
   const eff = (key, def) => (playerEffects && playerEffects[key] !== undefined) ? playerEffects[key] : def;
 
   const bonusMap = {
@@ -665,27 +652,27 @@ function applyBonus(bonus) {
 
       player.shieldCount = Math.min(player.shieldCount + 1, maxShieldCount);
       player.shield = player.shieldCount > 0;
-      window.showBonusText(`🛡 Shield! (${player.shieldCount})`);
+      showBonusText(`🛡 Shield! (${player.shieldCount})`);
       audioManager.playSFX("good_bonus");
       spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, "rgba(100, 200, 255, 1)", 20, 8);
     },
     [BONUS_TYPES.SPEED_DOWN]: () => {
       const mult = eff('speed_down_multiplier', 1.0);
       gameState.speed = Math.max(gameState.speed - 0.01 * mult, CONFIG.SPEED_MIN);
-      window.showBonusText(`🐌 Slow! (x${mult})`);
+      showBonusText(`🐌 Slow! (x${mult})`);
       audioManager.playSFX("good_bonus");
     },
     [BONUS_TYPES.SPEED_UP]: () => {
       const mult = eff('speed_up_multiplier', 1.0);
       gameState.speed = Math.min(gameState.speed + 0.01 * mult, CONFIG.SPEED_MAX);
-      window.showBonusText(`⚡ Speed! (x${mult})`);
+      showBonusText(`⚡ Speed! (x${mult})`);
       audioManager.playSFX("good_bonus");
     },
     [BONUS_TYPES.MAGNET]: () => {
       player.magnetActive = true;
       const bonus = eff('magnet_duration_bonus', 0);
       player.magnetTimer = 7 + bonus;
-      window.showBonusText(`🧲 Magnet! ${7 + bonus}s`);
+      showBonusText(`🧲 Magnet! ${7 + bonus}s`);
       audioManager.playSFX("good_bonus");
       spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, "rgba(255, 100, 200, 1)", 15, 7);
     },
@@ -693,35 +680,35 @@ function applyBonus(bonus) {
       player.invertActive = true;
       player.invertTimer = 7;
       gameState.invertScoreMultiplier = eff('invert_score_multiplier', 1.0);
-      window.showBonusText(`🔄 Inverted! (x${gameState.invertScoreMultiplier})`);
+      showBonusText(`🔄 Inverted! (x${gameState.invertScoreMultiplier})`);
       audioManager.playSFX("bad_bonus");
     },
     [BONUS_TYPES.X2]: () => {
       gameState.baseMultiplier = 2;
       const bonus = eff('x2_duration_bonus', 0);
       gameState.x2Timer = 7 + bonus;
-      window.showBonusText(`✖2 Score! ${7 + bonus}s`);
+      showBonusText(`✖2 Score! ${7 + bonus}s`);
       audioManager.playSFX("good_bonus");
     },
     [BONUS_TYPES.SCORE_300]: () => {
       const mult = eff('score_plus_300_multiplier', 1.0);
       const points = Math.floor(300 * mult * gameState.baseMultiplier);
       gameState.score += points;
-      window.showBonusText(`+${points}`);
+      showBonusText(`+${points}`);
       audioManager.playSFX("good_bonus");
     },
     [BONUS_TYPES.SCORE_500]: () => {
       const mult = eff('score_plus_500_multiplier', 1.0);
       const points = Math.floor(500 * mult * gameState.baseMultiplier);
       gameState.score += points;
-      window.showBonusText(`+${points}`);
+      showBonusText(`+${points}`);
       audioManager.playSFX("good_bonus");
     },
     [BONUS_TYPES.SCORE_MINUS_300]: () => {
       const mult = eff('score_minus_300_multiplier', 1.0);
       const penalty = Math.floor(300 * mult);
       gameState.score = Math.max(0, gameState.score - penalty);
-      window.showBonusText(`-${penalty} ❌`);
+      showBonusText(`-${penalty} ❌`);
       audioManager.playSFX("bad_bonus");
       spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, "rgba(255, 100, 100, 1)", 12, 6);
     },
@@ -729,13 +716,13 @@ function applyBonus(bonus) {
       const mult = eff('score_minus_500_multiplier', 1.0);
       const penalty = Math.floor(500 * mult);
       gameState.score = Math.max(0, gameState.score - penalty);
-      window.showBonusText(`-${penalty} ❌`);
+      showBonusText(`-${penalty} ❌`);
       audioManager.playSFX("bad_bonus");
       spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, "rgba(255, 100, 100, 1)", 12, 6);
     },
     [BONUS_TYPES.RECHARGE]: () => {
       gameState.spinCooldown = 0;
-      window.showBonusText("🔄 Spin Ready!");
+      showBonusText("🔄 Spin Ready!");
       audioManager.playSFX("good_bonus");
       spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, "rgba(0, 255, 200, 1)", 15, 7);
     },
@@ -753,7 +740,7 @@ function collectCoin(coin) {
   let particleY = DOM.canvas.height / 2;
 
   if (coin.lane !== undefined) {
-    const p = window.project(coin.lane, coin.z);
+    const p = project(coin.lane, coin.z);
     if (p) { particleX = p.x; particleY = p.y; }
   }
 
@@ -769,8 +756,5 @@ function collectCoin(coin) {
     spawnParticles(particleX, particleY, "rgba(255, 215, 0, 1)", 12, 6);
   }
 }
-
-
-Object.assign(window, { resetGameSessionState, update, applyBonus, collectCoin });
 
 export { resetGameSessionState, update, applyBonus, collectCoin };

--- a/js/state.js
+++ b/js/state.js
@@ -215,6 +215,14 @@ let linkedTelegramId = null;
 let linkedTelegramUsername = null;
 let linkedWallet = null;
 
+function getLaneCooldown() {
+  return laneCooldown;
+}
+
+function setLaneCooldown(value) {
+  laneCooldown = Number.isFinite(value) ? value : 0;
+}
+
 
 Object.assign(window, {
   DOM,
@@ -238,7 +246,9 @@ Object.assign(window, {
   telegramUser,
   linkedTelegramId,
   linkedTelegramUsername,
-  linkedWallet
+  linkedWallet,
+  getLaneCooldown,
+  setLaneCooldown
 });
 
 export {
@@ -263,5 +273,7 @@ export {
   telegramUser,
   linkedTelegramId,
   linkedTelegramUsername,
-  linkedWallet
+  linkedWallet,
+  getLaneCooldown,
+  setLaneCooldown
 };


### PR DESCRIPTION
### Motivation
- Move `js/physics.js` off implicit `window` globals and toward explicit ES module imports to continue the Vite/ESM migration and reduce global coupling.

### Description
- Replaced `window.*` reads in `js/physics.js` with direct imports from `./config.js`, `./state.js`, `./audio.js`, `./particles.js`, `./store.js`, `./ui.js`, `./renderer.js`, and `./game.js` so functions like `endGame`, `showBonusText`, `project`, `projectPlayer`, and `updatePlayerAnimation` are imported directly.
- Added `getLaneCooldown` and `setLaneCooldown` helpers to `js/state.js` and used them to synchronize lane cooldown state instead of reading/writing `window.laneCooldown`.
- Updated `js/input.js` to check `getLaneCooldown()` when triggering spin and adjusted imports accordingly.
- Exported `endGame` from `js/game.js` and removed the `Object.assign(window, ...)` bridge from `js/physics.js`, keeping `physics` as a pure ESM module; preserved existing runtime behavior.
- Files changed: `js/physics.js`, `js/state.js`, `js/input.js`, `js/game.js`.

### Testing
- Ran syntax/consistency checks with `npm run check` (uses `scripts/check-syntax.mjs`) which completed successfully.
- Built production bundle with `npm run build` (Vite) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd8edbd9c8332a02950355011c714)