### PR TITLE
refactor(state): remove global window bridge from state.js

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -13,7 +13,8 @@ import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, getAuth
 
 /* ===== GAME FUNCTIONS ===== */
 
-let { bestScore = 0, bestDistance = 0 } = window;
+let bestScore = parseInt(localStorage.getItem("bestScore") || "0", 10) || 0;
+let bestDistance = parseInt(localStorage.getItem("bestDistance") || "0", 10) || 0;
 // Cached background gradient — recreated only on resize
 let _cachedBgGrad = null;
 

--- a/js/state.js
+++ b/js/state.js
@@ -224,32 +224,6 @@ function setLaneCooldown(value) {
 }
 
 
-Object.assign(window, {
-  DOM,
-  ctx,
-  gameState,
-  player,
-  curves,
-  obstacles,
-  bonuses,
-  coins,
-  spinTargets,
-  inputQueue,
-  laneCooldown,
-  bestScore,
-  bestDistance,
-  web3,
-  userWallet,
-  isWalletConnected,
-  authMode,
-  primaryId,
-  telegramUser,
-  linkedTelegramId,
-  linkedTelegramUsername,
-  linkedWallet,
-  getLaneCooldown,
-  setLaneCooldown
-});
 
 export {
   DOM,


### PR DESCRIPTION
### Motivation
- Reduce global side effects introduced by `Object.assign(window, ...)` in `js/state.js` to finish moving code to ES modules and Vite. 
- Eliminate implicit cross-module coupling so state is accessed via named exports only.

### Description
- Removed the bulk `Object.assign(window, ...)` bridge from `js/state.js` and rely on the module's named exports for consumers. 
- Updated `js/game.js` to initialize `bestScore` and `bestDistance` directly from `localStorage` instead of reading them from `window`. 
- Kept exported symbols (`DOM`, `gameState`, `player`, etc.) intact so existing imports in other modules continue to work without the global bridge. 
- Files changed: `js/state.js`, `js/game.js`.

### Testing
- Ran `npm run check` (project syntax checks) and it completed successfully. 
- Ran `npm run build` (Vite production build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbdd9e4644833293ec639d17b4a03a)