### PR TITLE
Remove remaining window state/callback dependencies in game/auth flow

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -15,6 +15,31 @@ let linkedTelegramId = null;
 let linkedTelegramUsername = null;
 let linkedWallet = null;
 
+const authCallbacks = {
+  onWalletUiUpdate: async () => {},
+  onLoadPlayerUpgrades: async () => {},
+  onLoadLeaderboard: async () => {},
+  onUpdateRidesDisplay: () => {}
+};
+
+function setAuthCallbacks(callbacks = {}) {
+  if (typeof callbacks.onWalletUiUpdate === 'function') authCallbacks.onWalletUiUpdate = callbacks.onWalletUiUpdate;
+  if (typeof callbacks.onLoadPlayerUpgrades === 'function') authCallbacks.onLoadPlayerUpgrades = callbacks.onLoadPlayerUpgrades;
+  if (typeof callbacks.onLoadLeaderboard === 'function') authCallbacks.onLoadLeaderboard = callbacks.onLoadLeaderboard;
+  if (typeof callbacks.onUpdateRidesDisplay === 'function') authCallbacks.onUpdateRidesDisplay = callbacks.onUpdateRidesDisplay;
+}
+
+async function runPostAuthSync({ withLeaderboard = true, withRidesDisplay = true } = {}) {
+  await authCallbacks.onWalletUiUpdate();
+  await authCallbacks.onLoadPlayerUpgrades();
+  if (withLeaderboard) {
+    await authCallbacks.onLoadLeaderboard();
+  }
+  if (withRidesDisplay) {
+    authCallbacks.onUpdateRidesDisplay();
+  }
+}
+
 function getAuthState() {
   return {
     web3,
@@ -93,10 +118,7 @@ async function connectWalletAuth() {
       console.log("✅ Wallet auth OK:", primaryId);
 
       updateAuthUI();
-      await window.updateWalletUI();
-      await window.loadPlayerUpgrades();
-      await window.loadAndDisplayLeaderboard();
-      window.updateRidesDisplay();
+      await runPostAuthSync();
 
       if (DOM.storeBtn) DOM.storeBtn.classList.remove("menu-hidden");
     }
@@ -232,10 +254,7 @@ async function initAuth() {
         userWallet = data.primaryId;
         console.log("✅ Telegram auth OK:", primaryId);
         updateAuthUI();
-        await window.updateWalletUI();
-        await window.loadPlayerUpgrades();
-        await window.loadAndDisplayLeaderboard();
-        window.updateRidesDisplay();
+        await runPostAuthSync();
       }
     } catch (e) {
       console.error("❌ Telegram auth error:", e);
@@ -413,8 +432,7 @@ async function linkWallet() {
       }
 
       updateAuthUI();
-      await window.updateWalletUI();
-      await window.loadPlayerUpgrades();
+      await runPostAuthSync({ withLeaderboard: false, withRidesDisplay: false });
     } else {
       alert(`❌ ${data.error}`);
     }
@@ -425,6 +443,7 @@ async function linkWallet() {
 
 export {
   getAuthState,
+  setAuthCallbacks,
   isTelegramMiniApp,
   getTelegramUserData,
   connectWalletAuth,

--- a/js/game.js
+++ b/js/game.js
@@ -1,7 +1,7 @@
 import { CONFIG } from './config.js';
-import { isAuthenticated, saveResultToLeaderboard, loadAndDisplayLeaderboard } from './api.js';
+import { isAuthenticated, saveResultToLeaderboard, loadAndDisplayLeaderboard, updateWalletUI } from './api.js';
 import { audioManager, toggleSfxMute, toggleMusicMute, syncAllAudioUI, restoreAudioSettings, initAudioToggles } from './audio.js';
-import { DOM, gameState, curves, player, obstacles, bonuses, coins, spinTargets, ctx, inputQueue } from './state.js';
+import { DOM, gameState, curves, player, obstacles, bonuses, coins, spinTargets, ctx, inputQueue, getBestScore, getBestDistance, setBestScore, setBestDistance } from './state.js';
 import { resetGameSessionState, update } from './physics.js';
 import { resizeCanvas, drawTube, drawTubeDepth, drawTubeCenter, drawSpeedLines, drawNeonLines, drawObjects, drawCoins, drawPlayer, drawTubeBezel, drawRadarHints, drawSpinAlert, drawBonusText, canvasW, canvasH } from './renderer.js';
 import { particlePool, spawnParticles, updateParticles, drawParticles } from './particles.js';
@@ -9,12 +9,10 @@ import { assetManager } from './assets.js';
 import { showBonusText, showStore, hideStore, updateUI } from './ui.js';
 import { loadPlayerRides, playerRides, useRide, updateRidesDisplay, playerEffects, playerUpgrades, showRules, hideRules, buyUpgrade } from './store.js';
 import { perfMonitor } from './perf.js';
-import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, getAuthState } from './auth.js';
+import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, getAuthState, setAuthCallbacks } from './auth.js';
 
 /* ===== GAME FUNCTIONS ===== */
 
-let bestScore = parseInt(localStorage.getItem("bestScore") || "0", 10) || 0;
-let bestDistance = parseInt(localStorage.getItem("bestDistance") || "0", 10) || 0;
 // Cached background gradient — recreated only on resize
 let _cachedBgGrad = null;
 
@@ -412,13 +410,11 @@ function endGame(reason = "Unknown") {
   };
   const prettyReason = reasonMap[reason] || reason;
 
-  if (gameState.score > bestScore) {
-    bestScore = gameState.score;
-    localStorage.setItem("bestScore", bestScore);
+  if (gameState.score > getBestScore()) {
+    setBestScore(gameState.score);
   }
-  if (gameState.distance > bestDistance) {
-    bestDistance = gameState.distance;
-    localStorage.setItem("bestDistance", bestDistance);
+  if (gameState.distance > getBestDistance()) {
+    setBestDistance(gameState.distance);
   }
 
   saveResultToLeaderboard();
@@ -682,6 +678,12 @@ async function initGame() {
   initAudioToggles();
 
   // Auth
+  setAuthCallbacks({
+    onWalletUiUpdate: updateWalletUI,
+    onLoadPlayerUpgrades: loadPlayerUpgrades,
+    onLoadLeaderboard: loadAndDisplayLeaderboard,
+    onUpdateRidesDisplay: updateRidesDisplay
+  });
   console.log("🔐 Authenticating...");
   await initAuth();
   syncAuthGlobals();

--- a/js/state.js
+++ b/js/state.js
@@ -202,6 +202,24 @@ let laneCooldown = 0;
 let bestScore = localStorage.getItem('bestScore') ? parseInt(localStorage.getItem('bestScore')) : 0;
 let bestDistance = localStorage.getItem('bestDistance') ? parseInt(localStorage.getItem('bestDistance')) : 0;
 
+function getBestScore() {
+  return bestScore;
+}
+
+function getBestDistance() {
+  return bestDistance;
+}
+
+function setBestScore(value) {
+  bestScore = Number.isFinite(value) ? value : 0;
+  localStorage.setItem('bestScore', String(bestScore));
+}
+
+function setBestDistance(value) {
+  bestDistance = Number.isFinite(value) ? value : 0;
+  localStorage.setItem('bestDistance', String(bestDistance));
+}
+
 let web3 = null;
 let userWallet = null;
 let isWalletConnected = false;
@@ -237,8 +255,6 @@ export {
   spinTargets,
   inputQueue,
   laneCooldown,
-  bestScore,
-  bestDistance,
   web3,
   userWallet,
   isWalletConnected,
@@ -249,5 +265,9 @@ export {
   linkedTelegramUsername,
   linkedWallet,
   getLaneCooldown,
-  setLaneCooldown
+  setLaneCooldown,
+  getBestScore,
+  getBestDistance,
+  setBestScore,
+  setBestDistance
 };


### PR DESCRIPTION
### Motivation
- Eliminate remaining cross-module `window` globals and direct state shadowing so modules use explicit imports and APIs.
- Move best-score/distance ownership into `state.js` so the game no longer reads duplicated globals from the top of `game.js`.
- Stop `auth.js` from calling UI/data functions via `window.*` and provide a safe callback registration API instead.

### Description
- Added `getBestScore`, `getBestDistance`, `setBestScore`, and `setBestDistance` to `js/state.js` and exported them for other modules to use instead of reading/writing `bestScore`/`bestDistance` directly.
- Updated `js/game.js` to import and use the new `state.js` accessors, removing the local `bestScore`/`bestDistance` variables and switching writes to `setBestScore`/`setBestDistance` and reads to `getBestScore`/`getBestDistance`.
- Introduced callback registration in `js/auth.js` via `setAuthCallbacks` and `runPostAuthSync`, and replaced all `window.updateWalletUI`, `window.loadPlayerUpgrades`, `window.loadAndDisplayLeaderboard`, and `window.updateRidesDisplay` usages with calls through the new callback mechanism.
- Wired the callbacks from `js/game.js` using module imports (`updateWalletUI`, `loadPlayerUpgrades`, `loadAndDisplayLeaderboard`, `updateRidesDisplay`) before calling `initAuth()` so auth no longer depends on globals.

### Testing
- Ran `npm run check` (which runs `node scripts/check-syntax.mjs`) and it completed successfully with all checked files reported as valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbde9ee14c8332a0b59261e5ec93af)