### PR TITLE
refactor: remove window global syncs in migrated ES modules

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -290,15 +290,6 @@ async function saveResultToLeaderboard() {
   }
 }
 
-Object.assign(window, {
-  isAuthenticated,
-  getAuthIdentifier,
-  updateWalletUI,
-  signMessage,
-  loadAndDisplayLeaderboard,
-  saveResultToLeaderboard
-});
-
 export {
   isAuthenticated,
   getAuthIdentifier,

--- a/js/audio.js
+++ b/js/audio.js
@@ -223,20 +223,6 @@ function restoreAudioSettings() {
   syncAllAudioUI();
 }
 
-
-
-Object.assign(window, {
-  audioManager,
-  audioSettings,
-  setSfxEnabled,
-  setMusicEnabled,
-  toggleSfxMute,
-  toggleMusicMute,
-  syncAllAudioUI,
-  initAudioToggles,
-  restoreAudioSettings
-});
-
 export {
   audioManager,
   audioSettings,

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1234,25 +1234,6 @@ function generateTubeTexture() {
 
 generateTubeTexture();
 
-Object.assign(window, {
-  resizeCanvas,
-  project,
-  projectPlayer,
-  updatePlayerAnimation,
-  drawTube,
-  drawTubeDepth,
-  drawTubeCenter,
-  drawPlayer,
-  drawCoins,
-  drawObjects,
-  drawSpeedLines,
-  drawNeonLines,
-  drawBonusText,
-  drawRadarHints,
-  drawSpinAlert,
-  drawTubeBezel
-});
-
 export {
   resizeCanvas,
   project,

--- a/js/security.js
+++ b/js/security.js
@@ -20,9 +20,4 @@ function sanitizeTelegramHandle(value, fallback = 'Ursasstube_bot') {
   return fallback;
 }
 
-Object.assign(window, {
-  escapeHtml,
-  sanitizeTelegramHandle
-});
-
 export { escapeHtml, sanitizeTelegramHandle };

--- a/js/store.js
+++ b/js/store.js
@@ -3,6 +3,7 @@ import { BACKEND_URL } from './config.js';
 import { request } from './request.js';
 import { isAuthenticated, getAuthIdentifier, signMessage } from './api.js';
 import { getAuthState } from './auth.js';
+import { syncAllAudioUI } from './audio.js';
 
 let {
   authMode = null,
@@ -34,15 +35,6 @@ let playerRides = {
   resetInFormatted: "Ready"
 };
 
-function syncStoreGlobals() {
-  Object.assign(window, {
-    playerRides,
-    playerUpgrades,
-    playerEffects,
-    playerBalance
-  });
-}
-
 async function loadPlayerRides() {
   if (!isAuthenticated()) return;
   const identifier = getAuthIdentifier();
@@ -51,7 +43,6 @@ async function loadPlayerRides() {
     const data = await response.json();
     if (response.ok) {
       playerRides = data;
-      syncStoreGlobals();
       console.log("🎟 Rides:", playerRides);
     }
   } catch (e) {
@@ -73,13 +64,11 @@ async function useRide() {
 
     if (response.ok && data.success) {
       playerRides = data.rides;
-      syncStoreGlobals();
       updateRidesDisplay();
       console.log(`🎟 Ride used. Remaining: ${playerRides.totalRides}`);
       return true;
     } else {
       playerRides = data.rides || playerRides;
-      syncStoreGlobals();
       updateRidesDisplay();
       return false;
     }
@@ -327,7 +316,6 @@ async function loadPlayerUpgrades() {
       playerUpgrades = data.upgrades;
       playerEffects = data.activeEffects;
       playerBalance = data.balance;
-      syncStoreGlobals();
       if (data.rides) playerRides = data.rides;
 
            // Some gold upgrades can be reflected first in active effects and only
@@ -560,7 +548,6 @@ async function buyUpgrade(key, tier) {
 
       playerBalance = data.balance;
       playerEffects = data.activeEffects;
-      syncStoreGlobals();
 
       await loadPlayerUpgrades();
       updateStoreUI();
@@ -591,8 +578,6 @@ async function buyUpgrade(key, tier) {
             playerUpgrades[key].currentLevel = tier + 1;
           }
         }
-        syncStoreGlobals();
-
         updateStoreUI();
       }
 
@@ -629,29 +614,14 @@ function hideRules() {
 }
 
 function updateRulesAudioButtons() {
-  if (typeof window.syncAllAudioUI === 'function') window.syncAllAudioUI();
+  syncAllAudioUI();
 }
-
-syncStoreGlobals();
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', applyStoreDefaultLockState, { once: true });
 } else {
   applyStoreDefaultLockState();
 }
-
-Object.assign(window, {
-  loadPlayerRides,
-  useRide,
-  updateRidesDisplay,
-  applyStoreDefaultLockState,
-  loadPlayerUpgrades,
-  updateStoreUI,
-  buyUpgrade,
-  showRules,
-  hideRules,
-  updateRulesAudioButtons
-});
 
 export {
   playerRides,

--- a/js/ui.js
+++ b/js/ui.js
@@ -141,15 +141,6 @@ function displayLeaderboard(leaderboard, playerPosition) {
   if (goList) goList.innerHTML = html;
 }
 
-Object.assign(window, {
-  showBonusText,
-  showStore,
-  hideStore,
-  updateUI,
-  showLeaderboardSkeletons,
-  displayLeaderboard
-});
-
 export {
   showBonusText,
   showStore,


### PR DESCRIPTION
### Motivation
- Continue ES module + Vite migration by removing mixed global `window` bindings and relying on explicit imports/exports for inter-module communication.
- Eliminate legacy implicit store sync to `window` so reactive state flows through module exports and explicit UI update calls.

### Description
- Removed `Object.assign(window, ...)` bridges from migrated modules (`js/store.js`, `js/ui.js`, `js/security.js`, `js/api.js`, `js/audio.js`, `js/renderer.js`) and left the existing ES `export` API unchanged.
- Deleted `syncStoreGlobals()` and all its calls in `js/store.js`, preserving exported state (`playerRides`, `playerUpgrades`, `playerEffects`, `playerBalance`) and update functions so consumers must import and call the exported functions directly.
- Replaced the ad-hoc `window.syncAllAudioUI` usage with an explicit import `syncAllAudioUI` from `js/audio.js` and call it in `updateRulesAudioButtons()`.
- Kept module exports for the public APIs (functions and state) so callers continue to work via imports rather than relying on globals.

### Testing
- Ran `npm run check` (which executes `node scripts/check-syntax.mjs`) and all files passed syntax checks successfully.
- Ran `npm run build` (Vite production build) and the build completed successfully with modules transformed and chunks generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbe02dc9588332a254c19e04776282)