### PR TITLE
Refactor bootstrap flow for ES module migration

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -7,9 +7,10 @@ import { resizeCanvas, drawTube, drawTubeDepth, drawTubeCenter, drawSpeedLines, 
 import { particlePool, spawnParticles, updateParticles, drawParticles } from './particles.js';
 import { assetManager } from './assets.js';
 import { showBonusText, showStore, hideStore, updateUI } from './ui.js';
-import { loadPlayerRides, playerRides, useRide, updateRidesDisplay, playerEffects, playerUpgrades, showRules, hideRules, buyUpgrade } from './store.js';
+import { initStoreBootstrap, loadPlayerRides, playerRides, useRide, updateRidesDisplay, playerEffects, playerUpgrades, showRules, hideRules, buyUpgrade } from './store.js';
 import { perfMonitor } from './perf.js';
 import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, getAuthState, setAuthCallbacks } from './auth.js';
+import { initInputHandlers } from './input.js';
 
 /* ===== GAME FUNCTIONS ===== */
 
@@ -765,16 +766,27 @@ function onDomReady(callback) {
   }
 }
 
-onDomReady(() => {
-  console.log("📄 DOM loaded");
-  resizeCanvas();
-  initGame();
-});
+let gameBootstrapInitialized = false;
 
-window.addEventListener('resize', () => {
-  resizeCanvas();
-});
+function initGameBootstrap() {
+  if (gameBootstrapInitialized) return;
+
+  initStoreBootstrap();
+  initInputHandlers();
+
+  onDomReady(() => {
+    console.log('📄 DOM loaded');
+    resizeCanvas();
+    initGame();
+  });
+
+  window.addEventListener('resize', () => {
+    resizeCanvas();
+  });
+
+  gameBootstrapInitialized = true;
+}
 
 Object.assign(window, { endGame });
 
-export { endGame };
+export { endGame, initGameBootstrap };

--- a/js/input.js
+++ b/js/input.js
@@ -15,49 +15,56 @@ function isInteractiveElement(el) {
 }
 
 let touchStartX = 0;
-
-document.addEventListener("touchstart", e => {
-  if (isInteractiveElement(e.target)) return;
-  touchStartX = e.touches[0].clientX;
-  if (gameState.running) e.preventDefault();
-}, { passive: false });
-
-document.addEventListener("touchmove", e => {
-  if (!gameState.running) return;
-  if (isInteractiveElement(e.target)) return;
-  e.preventDefault();
-  const diff = e.touches[0].clientX - touchStartX;
-  if (Math.abs(diff) > 50) {
-    let dir = diff < 0 ? -1 : 1;
-    if (player.invertActive) dir = -dir;
-    inputQueue.push(dir);
-    touchStartX = e.touches[0].clientX;
-  }
-}, { passive: false });
-
 let lastTap = 0;
-document.addEventListener("touchend", e => {
-  if (isInteractiveElement(e.target)) return;
-  if (gameState.running) e.preventDefault();
-  const now = Date.now();
-  if (now - lastTap < 300 && !gameState.spinActive && !player.isLaneTransition) {
-    triggerSpin();
-  }
-  lastTap = now;
-}, { passive: false });
+let inputHandlersInitialized = false;
 
-document.addEventListener("keydown", e => {
-  if (!gameState.running) return;
-  if (e.code === "ArrowLeft") {
-    inputQueue.push(player.invertActive ? 1 : -1);
-  } else if (e.code === "ArrowRight") {
-    inputQueue.push(player.invertActive ? -1 : 1);
-  } else if (e.code === "Space") {
-    if (!gameState.spinActive && !player.isLaneTransition && gameState.spinCooldown <= 0) {
+function initInputHandlers() {
+  if (inputHandlersInitialized) return;
+
+  document.addEventListener('touchstart', (e) => {
+    if (isInteractiveElement(e.target)) return;
+    touchStartX = e.touches[0].clientX;
+    if (gameState.running) e.preventDefault();
+  }, { passive: false });
+
+  document.addEventListener('touchmove', (e) => {
+    if (!gameState.running) return;
+    if (isInteractiveElement(e.target)) return;
+    e.preventDefault();
+    const diff = e.touches[0].clientX - touchStartX;
+    if (Math.abs(diff) > 50) {
+      let dir = diff < 0 ? -1 : 1;
+      if (player.invertActive) dir = -dir;
+      inputQueue.push(dir);
+      touchStartX = e.touches[0].clientX;
+    }
+  }, { passive: false });
+
+  document.addEventListener('touchend', (e) => {
+    if (isInteractiveElement(e.target)) return;
+    if (gameState.running) e.preventDefault();
+    const now = Date.now();
+    if (now - lastTap < 300 && !gameState.spinActive && !player.isLaneTransition) {
       triggerSpin();
     }
-  }
-});
+    lastTap = now;
+  }, { passive: false });
+
+  document.addEventListener('keydown', (e) => {
+    if (!gameState.running) return;
+    if (e.code === 'ArrowLeft') {
+      inputQueue.push(player.invertActive ? 1 : -1);
+    } else if (e.code === 'ArrowRight') {
+      inputQueue.push(player.invertActive ? -1 : 1);
+    } else if (e.code === 'Space') {
+      if (!gameState.spinActive && !player.isLaneTransition && gameState.spinCooldown <= 0) {
+        triggerSpin();
+      }
+    }
+  });
+
+  inputHandlersInitialized = true;
+}
 
 function triggerSpin() {
   if (gameState.spinCooldown > 0 || gameState.spinActive || player.isLaneTransition || getLaneCooldown() > 0) return;
@@ -74,7 +81,7 @@ function triggerSpin() {
     }
     gameState.perfectSpinWindow = false;
     gameState.perfectSpinWindowTimer = 0;
-    showBonusText("✨ Perfect Spin!");
+    showBonusText('✨ Perfect Spin!');
   }
 
   gameState.spinActive = true;
@@ -84,10 +91,8 @@ function triggerSpin() {
   gameState.spinCooldown = Math.max(600, CONFIG.SPIN_COOLDOWN_TIME - reductionFrames);
 
   player.isSpin = true;
-  audioManager.playSFX("spin");
-  spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, "rgba(200, 100, 255, 1)", 25, 10);
+  audioManager.playSFX('spin');
+  spawnParticles(DOM.canvas.width / 2, DOM.canvas.height / 2, 'rgba(200, 100, 255, 1)', 25, 10);
 }
 
-Object.assign(window, { isInteractiveElement, triggerSpin });
-
-export { isInteractiveElement, triggerSpin };
+export { isInteractiveElement, initInputHandlers, triggerSpin };

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,72 +1,73 @@
 /* ===== LOGGER ===== */
-(function initLogger() {
-  const LEVELS = {
-    debug: 10,
-    info: 20,
-    warn: 30,
-    error: 40,
-    silent: 50
-  };
+const LEVELS = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 50
+};
 
-  const originalConsole = {
-    debug: console.debug.bind(console),
-    info: console.info.bind(console),
-    log: console.log.bind(console),
-    warn: console.warn.bind(console),
-    error: console.error.bind(console)
-  };
+const originalConsole = {
+  debug: console.debug.bind(console),
+  info: console.info.bind(console),
+  log: console.log.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console)
+};
 
-  const normalizeLevel = (value) => {
-    if (!value) return null;
-    const level = String(value).trim().toLowerCase();
-    return Object.prototype.hasOwnProperty.call(LEVELS, level) ? level : null;
-  };
+const normalizeLevel = (value) => {
+  if (!value) return null;
+  const level = String(value).trim().toLowerCase();
+  return Object.prototype.hasOwnProperty.call(LEVELS, level) ? level : null;
+};
 
-  const defaultLevel = (() => {
-    const host = window.location.hostname;
-    const isLocalHost = host === 'localhost' || host === '127.0.0.1' || host === '::1';
-    return isLocalHost ? 'debug' : 'warn';
-  })();
+let initialized = false;
+let currentLevel = 'warn';
+
+const logger = {
+  getLevel() {
+    return currentLevel;
+  },
+  setLevel(level) {
+    const normalized = normalizeLevel(level);
+    if (!normalized) {
+      originalConsole.warn(`⚠️ Unknown log level: ${level}`);
+      return currentLevel;
+    }
+    currentLevel = normalized;
+    localStorage.setItem('ursass.logLevel', normalized);
+    originalConsole.info(`🔧 Log level set to: ${normalized}`);
+    return currentLevel;
+  },
+  debug(...args) {
+    if (LEVELS.debug >= LEVELS[currentLevel]) originalConsole.debug(...args);
+  },
+  info(...args) {
+    if (LEVELS.info >= LEVELS[currentLevel]) originalConsole.info(...args);
+  },
+  warn(...args) {
+    if (LEVELS.warn >= LEVELS[currentLevel]) originalConsole.warn(...args);
+  },
+  error(...args) {
+    if (LEVELS.error >= LEVELS[currentLevel]) originalConsole.error(...args);
+  }
+};
+
+function initLogger() {
+  if (initialized) return logger;
+
+  const host = window.location.hostname;
+  const isLocalHost = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+  const defaultLevel = isLocalHost ? 'debug' : 'warn';
 
   const params = new URLSearchParams(window.location.search);
   const queryLevel = normalizeLevel(params.get('logLevel'));
   const localStorageLevel = normalizeLevel(localStorage.getItem('ursass.logLevel'));
-  let currentLevel = queryLevel || localStorageLevel || defaultLevel;
+  currentLevel = queryLevel || localStorageLevel || defaultLevel;
 
   if (queryLevel) {
     localStorage.setItem('ursass.logLevel', queryLevel);
   }
-
-  const shouldLog = (level) => LEVELS[level] >= LEVELS[currentLevel];
-
-  const logger = {
-    getLevel() {
-      return currentLevel;
-    },
-    setLevel(level) {
-      const normalized = normalizeLevel(level);
-      if (!normalized) {
-        originalConsole.warn(`⚠️ Unknown log level: ${level}`);
-        return currentLevel;
-      }
-      currentLevel = normalized;
-      localStorage.setItem('ursass.logLevel', normalized);
-      originalConsole.info(`🔧 Log level set to: ${normalized}`);
-      return currentLevel;
-    },
-    debug(...args) {
-      if (shouldLog('debug')) originalConsole.debug(...args);
-    },
-    info(...args) {
-      if (shouldLog('info')) originalConsole.info(...args);
-    },
-    warn(...args) {
-      if (shouldLog('warn')) originalConsole.warn(...args);
-    },
-    error(...args) {
-      if (shouldLog('error')) originalConsole.error(...args);
-    }
-  };
 
   window.LOG_LEVELS = Object.freeze({ ...LEVELS });
   window.logger = logger;
@@ -77,5 +78,9 @@
   console.warn = (...args) => logger.warn(...args);
   console.error = (...args) => logger.error(...args);
 
+  initialized = true;
   logger.info(`🧾 Log level: ${currentLevel}`);
-})();
+  return logger;
+}
+
+export { LEVELS, logger, initLogger };

--- a/js/main.js
+++ b/js/main.js
@@ -1,21 +1,12 @@
-import './logger.js';
-import './config.js';
-import './state.js';
-import './audio.js';
-import './request.js';
-import './walletconnect.js';
-import './assets.js';
-import './particles.js';
-import './perf.js';
-import './security.js';
-import './auth.js';
-import './api.js';
-import './ui.js';
-import './store.js';
-import './physics.js';
-import './renderer.js';
-import './input.js';
+import { initLogger } from './logger.js';
 import { stabilizeMenuLoad } from './stabilize-menu.js';
-import './game.js';
 
-stabilizeMenuLoad();
+async function bootstrap() {
+  initLogger();
+  stabilizeMenuLoad();
+
+  const { initGameBootstrap } = await import('./game.js');
+  initGameBootstrap();
+}
+
+bootstrap();

--- a/js/store.js
+++ b/js/store.js
@@ -617,13 +617,20 @@ function updateRulesAudioButtons() {
   syncAllAudioUI();
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', applyStoreDefaultLockState, { once: true });
-} else {
-  applyStoreDefaultLockState();
+let storeBootstrapInitialized = false;
+
+function initStoreBootstrap() {
+  if (storeBootstrapInitialized) return;
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyStoreDefaultLockState, { once: true });
+  } else {
+    applyStoreDefaultLockState();
+  }
+  storeBootstrapInitialized = true;
 }
 
 export {
+  initStoreBootstrap,
   playerRides,
   playerUpgrades,
   playerEffects,


### PR DESCRIPTION
### Motivation
- Reduce entrypoint side-effect imports and make module initialization order explicit to ease migration to ES modules and Vite.
- Replace modules that relied on global/window side-effects with explicit initialization APIs so the app can bootstrap deterministically from a module entrypoint.

### Description
- Convert `js/main.js` into a minimal bootstrap that calls `initLogger()` and `stabilizeMenuLoad()` and then dynamically imports and calls `initGameBootstrap()` from `js/game.js`.
- Replace the logger IIFE with an explicit `initLogger()` API exported from `js/logger.js` and keep `logger`/`LEVELS` exports for consumers.
- Move input event registration behind an explicit `initInputHandlers()` exported from `js/input.js` to avoid side-effectful listeners at module import time.
- Move store DOM-ready side effects into `initStoreBootstrap()` exported from `js/store.js`, and add `initGameBootstrap()` in `js/game.js` to wire `initStoreBootstrap()` and `initInputHandlers()` and handle DOM-ready and `resize` setup.

### Testing
- Ran `npm run check` (which executes `scripts/check-syntax.mjs`) and it completed successfully with all checked files reported as OK.
- Ran `npm run build` (Vite build) and it completed successfully producing the production bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbe14d6ef88332b6bd2f85eeb88c17)