### PR TITLE
Add CI/local guard for new Object.assign(window) usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm run check

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "node scripts/check-syntax.mjs"
+    "check": "node scripts/check-syntax.mjs && npm run check:no-window-assign",
+    "check:no-window-assign": "node scripts/check-no-new-window-assign.mjs"
   },
   "devDependencies": {
     "vite": "^7.1.0"

--- a/scripts/check-no-new-window-assign.mjs
+++ b/scripts/check-no-new-window-assign.mjs
@@ -1,0 +1,51 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const BASELINE = new Set([
+  'js/assets.js:101:Object.assign(window, { AssetManager, assetManager });',
+  'js/config.js:76:Object.assign(window, { BACKEND_URL, WC_PROJECT_ID, CONFIG, BONUS_TYPES, isMobile });',
+  'js/game.js:790:Object.assign(window, { endGame });',
+  'js/particles.js:88:Object.assign(window, { particlePool, spawnParticles, updateParticles, drawParticles });',
+  'js/perf.js:81:Object.assign(window, { PerformanceMonitor, perfMonitor });',
+  'js/request.js:110:Object.assign(window, { RequestError, request });',
+  'js/walletconnect.js:173:Object.assign(window, { WC });'
+]);
+
+const regex = /Object\.assign\(\s*window\b/g;
+const jsDir = path.join(rootDir, 'js');
+const files = readdirSync(jsDir)
+  .filter((name) => name.endsWith('.js'))
+  .sort();
+
+const actual = [];
+
+for (const fileName of files) {
+  const filePath = path.join(jsDir, fileName);
+  const src = readFileSync(filePath, 'utf8');
+  const lines = src.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (regex.test(lines[i])) {
+      actual.push(`js/${fileName}:${i + 1}:${lines[i].trim()}`);
+    }
+    regex.lastIndex = 0;
+  }
+}
+
+const newEntries = actual.filter((entry) => !BASELINE.has(entry));
+
+if (newEntries.length > 0) {
+  console.error('❌ Found new Object.assign(window, ...) usage in js/:');
+  for (const entry of newEntries) {
+    console.error(`   ${entry}`);
+  }
+  console.error('Please use ES module exports/imports instead of adding globals on window.');
+  process.exit(1);
+}
+
+console.log('✅ No new Object.assign(window, ...) usages in js/.');


### PR DESCRIPTION
### Motivation
- Prevent accidental regressions back to the legacy global-window pattern (`Object.assign(window, ...)`) while migrating code to ES modules and Vite.
- Allow the repository to keep an explicit baseline of current global assignments so files can be migrated incrementally without breaking CI.

### Description
- Add a new check script `scripts/check-no-new-window-assign.mjs` that scans `js/*.js` for `Object.assign(window, ...)` and fails only when new occurrences appear compared to the stored baseline.
- Wire the check into the local workflow by adding `check:no-window-assign` and updating the `check` script in `package.json` to run `node scripts/check-syntax.mjs && npm run check:no-window-assign`.
- Add a GitHub Actions workflow in `.github/workflows/ci.yml` that runs `npm ci` and `npm run check` on `push` and `pull_request` events.
- The baseline entries are embedded in the new script to allow progressive migration without immediate failures.

### Testing
- Ran `npm run check` locally and the existing syntax checks and the new `check-no-new-window-assign` guard completed successfully (exit code 0).
- The new script prints `✅ No new Object.assign(window, ...) usages in js/.` when no new occurrences are found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbe2567d8c8332acf1e36480df66b5)