### PR TITLE
Import loadPlayerUpgrades in game bootstrap to fix runtime ReferenceError

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -7,7 +7,7 @@ import { resizeCanvas, drawTube, drawTubeDepth, drawTubeCenter, drawSpeedLines, 
 import { particlePool, spawnParticles, updateParticles, drawParticles } from './particles.js';
 import { assetManager } from './assets.js';
 import { showBonusText, showStore, hideStore, updateUI } from './ui.js';
-import { initStoreBootstrap, loadPlayerRides, playerRides, useRide, updateRidesDisplay, playerEffects, playerUpgrades, showRules, hideRules, buyUpgrade } from './store.js';
+import { initStoreBootstrap, loadPlayerRides, loadPlayerUpgrades, playerRides, useRide, updateRidesDisplay, playerEffects, playerUpgrades, showRules, hideRules, buyUpgrade } from './store.js';
 import { perfMonitor } from './perf.js';
 import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, getAuthState, setAuthCallbacks } from './auth.js';
 import { initInputHandlers } from './input.js';


### PR DESCRIPTION
### Motivation
- The game was throwing `ReferenceError: loadPlayerUpgrades is not defined` when store-related callbacks were referenced, breaking store UI flows.

### Description
- Add `loadPlayerUpgrades` to the `./store.js` import list in `js/game.js` so the symbol is available where it is used.

### Testing
- Ran `npm run check` (includes `node scripts/check-syntax.mjs` and `check-no-new-window-assign`) and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbe32cd8908332bba9b5075778e946)