### PR TITLE
Fix analytics delivery to use backend host and make config Node-safe

### DIFF
--- a/js/analytics-delivery.js
+++ b/js/analytics-delivery.js
@@ -1,8 +1,9 @@
 import { ANALYTICS_TRACK_EVENT } from './analytics.js';
+import { BACKEND_URL } from './config.js';
 import { logger } from './logger.js';
 import { requestJsonResult, REQUEST_PROFILE_ANALYTICS_WRITE } from './request.js';
 
-const ANALYTICS_ENDPOINT = '/api/analytics/events';
+const ANALYTICS_ENDPOINT = `${BACKEND_URL}/api/analytics/events`;
 const DEFAULT_FLUSH_INTERVAL_MS = 5000;
 const DEFAULT_MAX_BATCH_SIZE = 20;
 const DEFAULT_MAX_QUEUE_SIZE = 200;

--- a/js/config.js
+++ b/js/config.js
@@ -54,7 +54,11 @@ const CONFIG = {
 };
 
 // Mobile detection — reduce tube polygon count for performance
-const isMobile = /Mobi|Android|iPhone/i.test(navigator.userAgent) || (window.innerWidth < 600);
+const hasNavigator = typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string';
+const hasWindow = typeof window !== 'undefined' && Number.isFinite(window.innerWidth);
+const isMobileUserAgent = hasNavigator ? /Mobi|Android|iPhone/i.test(navigator.userAgent) : false;
+const isMobileViewport = hasWindow ? window.innerWidth < 600 : false;
+const isMobile = isMobileUserAgent || isMobileViewport;
 if (isMobile) {
   CONFIG.TUBE_SEGMENTS = 13;
   CONFIG.TUBE_DEPTH_STEPS = 48;


### PR DESCRIPTION
### Motivation
- Analytics POSTs were being sent to a relative `/api/analytics/events` path which caused requests to hit the frontend host (producing 404s) instead of the backend API host.
- Importing `js/config.js` in Node test runtime caused a `ReferenceError` because `window`/`navigator` were accessed unguarded.

### Description
- Updated `js/analytics-delivery.js` to import `BACKEND_URL` from `js/config.js` and construct the endpoint as ```${BACKEND_URL}/api/analytics/events``` instead of a relative path.
- Made mobile detection in `js/config.js` runtime-safe by guarding access to `navigator.userAgent` and `window.innerWidth` so the module can be imported in non-browser (Node) runtimes.
- Files changed: `js/analytics-delivery.js`, `js/config.js`.

### Testing
- Ran `node --test scripts/analytics-delivery.test.mjs` after the fixes and all analytics-delivery unit tests passed (3/3 subtests OK).
- Pre-commit static checks ran successfully: `npm run check:syntax` and `npm run check:static-analysis` both completed without errors.
- Note: before the `config.js` guard was added, `node --test scripts/analytics-delivery.test.mjs` failed with `ReferenceError: window is not defined`, which was resolved by the change above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7937f81e083208b2b3a19ac9d7050)