### PR TITLE
docs: add production domain checklist to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ npm run build
 npm run preview
 ```
 
+## Production domain checklist
+
+При переключении frontend-домена (например, на `ursasstube.fun`) код приложения почти не требует изменений, но нужна операционная настройка:
+
+1. Настроить DNS-записи и HTTPS-сертификат на хостинге frontend.
+2. Добавить новый origin в CORS allowlist backend.
+3. Проверить домены/redirect URI в внешних интеграциях (Telegram Mini App, OAuth-провайдеры, wallet deep links).
+4. Обновить публичные ссылки в документации и мониторинге (если где-то остался старый host).
+5. Прогнать smoke-check после выката (`npm run check`, затем ручной `Menu → Start → Game Over → Store`).
+
+Технически frontend собран с относительным `base` (`vite.config.js`), поэтому assets остаются переносимыми между доменами без ребилда под конкретный host.
+
 ## Quality gates
 
 Основной gate перед merge/release:


### PR DESCRIPTION
### Motivation
- Add a short operational checklist for switching the frontend to a new production domain (e.g. `ursasstube.fun`) so rollouts avoid common infra mistakes. 

### Description
- Add a `Production domain checklist` section to `README.md` that lists required steps (DNS/HTTPS, add origin to backend CORS allowlist, verify external redirect/URI settings, update public links/monitoring, run smoke checks) and notes that Vite is configured with a relative `base` so assets do not require a rebuild per host. 

### Testing
- Ran `npm run check:syntax` and pre-commit hooks which executed `npm run check:static-analysis`, and both checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a424fed8832088fd29e4cccd02fd)