### PR TITLE
Point frontend to api.ursasstube.fun and document production domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ npm run preview
 
 ## Production domain checklist
 
+Текущая production-схема доменов:
+- `ursasstube.fun` — лендинг/основной сайт,
+- `play.ursasstube.fun` — фронтенд игры,
+- `api.ursasstube.fun` — backend API.
+
 При переключении frontend-домена (например, на `ursasstube.fun`) код приложения почти не требует изменений, но нужна операционная настройка:
 
 1. Настроить DNS-записи и HTTPS-сертификат на хостинге frontend.

--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,6 @@
 import { logger } from './logger.js';
 /* ===== CONFIG ===== */
-const BACKEND_URL = "https://ursassbackend-production.up.railway.app";
+const BACKEND_URL = "https://api.ursasstube.fun";
 logger.info(`🔗 Backend URL: ${BACKEND_URL}`);
 
 // WalletConnect v2 Project ID — get yours at https://cloud.walletconnect.com


### PR DESCRIPTION
### Motivation
- Switch the frontend runtime to the production API host and record the canonical production domain split for deployment and operational configuration.

### Description
- Update `BACKEND_URL` in `js/config.js` to `https://api.ursasstube.fun` and add the production domain list (`ursasstube.fun`, `play.ursasstube.fun`, `api.ursasstube.fun`) to `README.md`.

### Testing
- Ran `npm run check:syntax` which passed, and the pre-commit hook executed `npm run check:static-analysis` which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d265002083209889d29ed243a5a1)