### PR TITLE
Add optional visual upgrade assets and rendering hooks (aura, glint, shock ring) + Russian design doc

### DIFF
--- a/docs/phaser-visual-max-options-2026-04-10-ru.md
+++ b/docs/phaser-visual-max-options-2026-04-10-ru.md
@@ -1,0 +1,285 @@
+# Phaser visual uplift: варианты прокачки визуала для раннера (Web + Telegram Mini App)
+
+Дата: 2026-04-10
+
+## Контекст текущего рендера
+
+В проекте уже есть сильная база:
+- отдельный рендерер туннеля с многопроходной отрисовкой, depth-rays и управлением альфой/контрастом;
+- отдельные passes для сущностей и эффектов подбора;
+- runtime разделён на scene/controller/renderer.
+
+Это значит, что лучший путь — не переписывать игру, а включить «production-level» VFX-слои поверх текущей архитектуры.
+
+---
+
+## Вариант A — **Performance First (Telegram-safe)**
+
+Цель: максимум читаемости и «сочности» при минимальной цене кадра.
+
+### 1) Труба
+- Оставить текущую геометрию и draw-pass, но добавить:
+  - **анимированную нормаль/шум-маску** в виде тайлового texture-overlay по глубине;
+  - **rim-light** по сегментам (узкая полоска света на 20–35° от источника);
+  - **lane pulse**: периодический импульс по дорожкам, завязанный на BPM музыки или скорость.
+- Избегать тяжёлых постпроцессов на весь экран.
+
+### 2) Эффекты
+- Для coin/bonus/shield:
+  - заменить часть circle/tween FX на **GPU-частицы Phaser ParticleEmitter** с pre-baked текстурами;
+  - добавить **additive blending** только на короткой фазе вспышки (80–120ms), затем normal blending.
+- Для столкновений:
+  - 1 кадр chroma-flash (через полупрозрачный fullscreen rectangle),
+  - 200ms radial shock-ring (sprite-based).
+
+### 3) Персонаж
+- Визуально «прибить» к миру:
+  - fake contact shadow (ellipse sprite, alpha по depth);
+  - velocity trail из 2–3 ghost-спрайтов с быстрым fade-out;
+  - bank/lean по горизонтальному вводу (±6–10°).
+
+### 4) Объекты
+- Дать «материал» препятствиям:
+  - ближний LOD: sprite + highlight rim + tiny shadow;
+  - дальний LOD: только sprite и мягкая desaturation.
+- Coins: вращение + короткий specular glint раз в N кадров.
+
+### KPI
+- 55–60 FPS на mid Android в Telegram WebView.
+- +15–25% к субъективной «читаемости» препятствий в слепом тесте.
+
+---
+
+## Вариант B — **Balanced Next-Gen (рекомендуется)**
+
+Цель: заметный «вау»-скачок без риска для WebView.
+
+### 1) Труба (главный визуальный апгрейд)
+- Внедрить **многоуровневую подсветку поверхности**:
+  - базовый цветовой градиент;
+  - procedural grime/noise на дальних сегментах;
+  - движущиеся energy streaks по направлению движения.
+- Добавить **volumetric slices** (псевдо-объём): 3–5 полупрозрачных колец между игроком и дальним краем.
+
+### 2) Эффекты
+- Ввести **VFX event bus** (spawnCoinBurst, spawnShieldHit, spawnNearMiss и т.д.),
+  чтобы каждый эффект имел 2 профиля: quality=high и quality=low.
+- Пост-эффекты с ограничением:
+  - Bloom-lite (только selected glow layers),
+  - vignette + subtle film grain (опционально).
+
+### 3) Персонаж
+- Перейти от «одного спрайта» к **2.5D stack**:
+  - base body,
+  - emissive eyes layer (additive),
+  - optional outline layer.
+- Добавить state-driven micro-anim:
+  - idle breathing,
+  - lane-swap squash&stretch,
+  - hit recoil c easing-кривыми.
+
+### 4) Объекты
+- Ввести категории материалов:
+  - metal / organic / hazard;
+  - для каждой — свой hit FX, tint, reflection response.
+- Бонусам добавить «ауру» (soft billboard glow),
+  чтобы они читались на любом фоне туннеля.
+
+### KPI
+- 50–60 FPS на большинстве девайсов.
+- +20–35% к удержанию первых 3 минут за счёт визуальной динамики.
+
+---
+
+## Вариант C — **Cinematic Max (флагман)**
+
+Цель: выжать максимум Phaser для браузера, с деградацией по качеству.
+
+### 1) Труба
+- Кастомные WebGL pipelines:
+  - distortion pass по краям,
+  - depth fog color grading,
+  - reactive glow от скорости.
+- Screen-space light shafts + pseudo-reflections.
+
+### 2) Эффекты
+- Layered particles: sparks + smoke + shards + trails.
+- Near miss / perfect dodge события с time-sliced flash.
+
+### 3) Персонаж
+- Полноценный sprite-sheet animation set + secondary motion.
+- Impact decals (временные следы/царапины) на окружении.
+
+### 4) Объекты
+- Runtime palette swaps (биомы/темы).
+- Event-driven lighting, когда объекты подсвечивают туннель при пролёте.
+
+### KPI
+- 45–60 FPS на desktop, 40–55 на свежих смартфонах.
+- Требуется quality auto-scaler и пер-девайс fallback.
+
+---
+
+## Что выбрать для вашего проекта сейчас
+
+С учётом Web + Telegram Mini App, оптимален **Вариант B (Balanced Next-Gen)**:
+- даёт большой прирост визуала;
+- не требует полного перехода на тяжёлые fullscreen-пайплайны;
+- легко откатывается на A-профиль по производительности.
+
+---
+
+## Практический roadmap на 3 итерации
+
+### Итерация 1 (1–2 дня): «читаемость + материал»
+1. Усилить rim-light и контраст препятствий по depth.
+2. Вынести quality-профили эффектов (low/high).
+3. Добавить contact shadow + lean для персонажа.
+
+### Итерация 2 (2–4 дня): «вау-слой»
+1. Energy streaks и volumetric slices для туннеля.
+2. Aura/outline для бонусов и опасностей.
+3. Настроить speed-reactive intensity.
+
+### Итерация 3 (2–3 дня): «polish + адаптивность»
+1. Auto quality scaler по FPS budget.
+2. Device tiering для Telegram WebView.
+3. А/Б тест визуальных пресетов.
+
+---
+
+## Технические правила, чтобы Codex не «ломал» визуал при следующих итерациях
+
+1. Любой новый эффект добавлять только через единый слой событий VFX (не хаотично в gameplay-логике).
+2. У каждого эффекта обязателен low-quality путь.
+3. Любой fullscreen постэффект — только с фичефлагом.
+4. Все визуальные константы хранить в централизованном конфиге quality tiers.
+5. Для Telegram держать budget:
+   - draw calls и активные партиклы ограничены;
+   - expensive blending включать кратковременно.
+
+---
+
+## Конкретные точки расширения в текущем коде
+
+- Туннель и depth-эффекты:
+  - `js/phaser/tunnel/TunnelRenderer.js`
+  - `js/phaser/tunnel/tunnel-draw-pass.js`
+  - `js/phaser/tunnel/tunnel-depth-rays.js`
+
+- Эффекты и объекты:
+  - `js/phaser/entities/entity-render-passes.js`
+  - `js/phaser/entities/EntityRenderer.js`
+
+- orchestration сцены:
+  - `js/phaser/scenes/MainScene.js`
+
+Это правильные места, чтобы наращивать качество поэтапно, не трогая ядро игровой логики.
+
+---
+
+## Нужны ли дополнительные ассеты?
+
+Коротко: **да**. Чтобы реально выжать визуал из Phaser, понадобятся дополнительные 2D-ассеты (в основном PNG/WebP + несколько grayscale-масок).
+
+Ниже — минимальный production-ready набор для Варианта B, с промптами для генерации.
+
+### 1) Труба / окружение
+
+1. **`tunnel_noise_tile_01.png`** (512x512, seamless)
+   - Назначение: тонкий grime/noise-слой на дальних сегментах трубы.
+   - Prompt:
+     - `Seamless sci-fi surface noise texture, subtle dirt and brushed metal micro detail, monochrome grayscale, tileable, no symbols, no text, game texture, high contrast but soft transitions`
+
+2. **`tunnel_rim_mask_01.png`** (1024x256, grayscale)
+   - Назначение: маска для rim-light по сегментам.
+   - Prompt:
+     - `Horizontal grayscale mask for rim lighting, bright thin edge band fading to dark center, smooth falloff, clean anti-aliased, no background objects, game VFX mask`
+
+3. **`energy_streak_strip_01.png`** (1024x128, alpha)
+   - Назначение: движущиеся energy streaks вдоль глубины.
+   - Prompt:
+     - `Futuristic neon energy streak strip, cyan and blue glow lines on transparent background, directional motion feel, additive-friendly, clean edges, no text`
+
+4. **`volumetric_ring_soft_01.png`** (512x512, alpha)
+   - Назначение: полупрозрачные volumetric slices/кольца.
+   - Prompt:
+     - `Soft circular volumetric ring sprite, transparent background, inner and outer glow, cyan-white sci-fi style, smooth gradient, no hard artifacts`
+
+### 2) Персонаж (2.5D stack)
+
+5. **`bear_body_base_v2.png`** (1024x1024, alpha)
+   - Назначение: базовый слой персонажа.
+   - Prompt:
+     - `Stylized cyber bear character front-facing for endless runner, clean silhouette, game-ready sprite, medium detail, cool color palette, transparent background, no text`
+
+6. **`bear_eyes_emissive_v2.png`** (1024x1024, alpha)
+   - Назначение: emissive слой глаз (additive blend).
+   - Prompt:
+     - `Glowing cyber eyes layer for bear character, emissive cyan light only, transparent background, isolated details, additive blending friendly`
+
+7. **`bear_outline_soft_v2.png`** (1024x1024, alpha)
+   - Назначение: мягкий контур/ореол для читаемости.
+   - Prompt:
+     - `Soft outline aura around character silhouette, subtle blue glow, transparent background, smooth edge falloff, no internal details`
+
+8. **`shadow_contact_ellipse_01.png`** (256x128, alpha)
+   - Назначение: contact shadow под персонажем.
+   - Prompt:
+     - `Soft elliptical contact shadow sprite, transparent background, dark gray center fading to transparent edges, no noise`
+
+### 3) Объекты и бонусы
+
+9. **`bonus_aura_soft_01.png`** (256x256, alpha)
+   - Назначение: аура бонусов для читаемости.
+   - Prompt:
+     - `Circular soft glow aura sprite for collectible bonus, transparent background, cyan-gold gradient, smooth radial falloff, no symbols`
+
+10. **`coin_glint_star_01.png`** (128x128, alpha)
+    - Назначение: короткий specular glint для монет.
+    - Prompt:
+      - `Small sparkle star glint sprite, transparent background, white-cyan sharp core with soft bloom, clean game VFX element`
+
+11. **`hazard_rim_highlight_01.png`** (512x512, alpha)
+    - Назначение: rim-highlight для опасных объектов.
+    - Prompt:
+      - `Hazard edge highlight overlay, orange-red emissive rim, transparent background, stylized game VFX, no text`
+
+### 4) VFX/экранные эффекты
+
+12. **`shock_ring_impact_01.png`** (512x512, alpha)
+    - Назначение: radial shock-ring при столкновении.
+    - Prompt:
+      - `Radial impact shock ring sprite, transparent background, bright edge with fading inner transparency, sci-fi style, high readability`
+
+13. **`screen_flash_gradient_01.png`** (1920x1080, alpha)
+    - Назначение: мягкий экранный flash без тяжёлого постпроцесса.
+    - Prompt:
+      - `Full-screen soft gradient flash overlay, white to transparent, cinematic bloom feel, no patterns, no text`
+
+14. **`dust_particle_pack_01.png`** (atlas 1024x1024)
+    - Назначение: партиклы пыли/мелкого мусора в движении.
+    - Prompt:
+      - `Set of small dust particles and tiny debris sprites for game atlas, grayscale and light cyan variants, transparent background, clean isolated elements`
+
+---
+
+## Технические требования к ассетам (важно для Web/Telegram)
+
+- Формат:
+  - runtime: `webp` (lossy/lossless по типу ресурса),
+  - маски/служебные текстуры: `png`.
+- Размеры держать степенью двойки, где это возможно (128/256/512/1024).
+- Для glow-ассетов делать запас прозрачного поля (padding 8–16px), чтобы не резало bloom.
+- Не хранить всё в оригинале 4K: сразу готовить mobile-friendly версии (`@1x`, `@0.5x`).
+- Для Telegram Mini App целиться в общий бюджет новых визуальных ассетов ~4–8 MB (после сжатия).
+
+---
+
+## Быстрый порядок внедрения ассетов
+
+1. Сначала добавить: `shadow_contact_ellipse_01`, `bonus_aura_soft_01`, `coin_glint_star_01`, `shock_ring_impact_01`.
+2. Потом подключить трубу: `tunnel_noise_tile_01`, `energy_streak_strip_01`, `volumetric_ring_soft_01`.
+3. В конце — полировка (dust atlas, hazard highlights, screen flash).
+
+Такой порядок даёт самый заметный прирост визуала при минимальном риске просадки FPS.

--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -1,14 +1,13 @@
 import { BONUS_TYPES, CONFIG } from '../../config.js';
 import { gameState } from '../../state.js';
 import { renderCollectAnimationsPass, renderObjectsPass } from './entity-render-passes.js';
-
+import { VISUAL_UPGRADE_TEXTURES } from './entity-visual-assets.js';
 const LANE_ANGLE_STEP = 0.55;
 const BASE_URL = import.meta.env.BASE_URL || './';
 const BONUS_TEXT_DELAY_FRAMES = 60;
 const BONUS_TEXT_FADE_FRAMES = 30;
 const FRAME_MS_60FPS = 1000 / 60;
 const COIN_COLLECT_BURST_ANGLE_STEP = Math.PI / 3;
-
 const PLAYER_TEXTURES = {
   idle_back: 'character_back_idle',
   idle_left: 'character_left_idle',
@@ -17,7 +16,6 @@ const PLAYER_TEXTURES = {
   swipe_right: 'character_right_swipe',
   spin: 'character_spin',
 };
-
 const PLAYER_FRAME_COUNTS = {
   [PLAYER_TEXTURES.idle_back]: 12,
   [PLAYER_TEXTURES.idle_left]: 12,
@@ -26,7 +24,6 @@ const PLAYER_FRAME_COUNTS = {
   [PLAYER_TEXTURES.swipe_right]: 3,
   [PLAYER_TEXTURES.spin]: 14,
 };
-
 const BONUS_TEXTURES = {
   [BONUS_TYPES.SHIELD]: 'bonus_shield',
   [BONUS_TYPES.SPEED_DOWN]: 'bonus_speed',
@@ -40,7 +37,6 @@ const BONUS_TEXTURES = {
   [BONUS_TYPES.SCORE_MINUS_500]: 'bonus_score_minus',
   [BONUS_TYPES.RECHARGE]: 'bonus_recharge',
 };
-
 const OBSTACLE_TEXTURES = {
   fence: 'obstacles_1',
   rock1: 'obstacles_1',
@@ -53,11 +49,9 @@ const OBSTACLE_TEXTURES = {
   spikes: 'obstacles_3',
   bottles: 'obstacles_3',
 };
-
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
 const WIDE_BONUS_TEXTURES = new Set(['bonus_score_plus', 'bonus_score_minus']);
-
 const BONUS_FRAME_DEFS = {
   bonus_score_plus: [
     { name: 'score_300_0', x: 0, y: 0, width: 128, height: 64 },
@@ -78,31 +72,25 @@ function assetUrl(path) {
   const normalizedBase = BASE_URL.endsWith('/') ? BASE_URL : `${BASE_URL}/`;
   return `${normalizedBase}${path}`;
 }
-
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
-
 function parseRgbaColor(rawColor, fallbackHex = 0xffd54a) {
   if (typeof rawColor !== 'string') {
     return { hex: fallbackHex, alpha: 0.9 };
   }
-
   const match = rawColor.match(/rgba?\(([^)]+)\)/i);
   if (!match) {
     return { hex: fallbackHex, alpha: 0.9 };
   }
-
   const parts = match[1].split(',').map((part) => Number(part.trim()));
   const r = clamp(Math.round(Number.isFinite(parts[0]) ? parts[0] : 255), 0, 255);
   const g = clamp(Math.round(Number.isFinite(parts[1]) ? parts[1] : 213), 0, 255);
   const b = clamp(Math.round(Number.isFinite(parts[2]) ? parts[2] : 74), 0, 255);
   const a = Number.isFinite(parts[3]) ? clamp(parts[3], 0.08, 1) : 0.9;
   const hex = (r << 16) | (g << 8) | b;
-
   return { hex, alpha: a };
 }
-
 function getPlayerTextureKey(player, runtime) {
   if (player?.spinActive) {
     return PLAYER_TEXTURES.spin;
@@ -116,7 +104,6 @@ function getPlayerTextureKey(player, runtime) {
   if (player?.lane >= 1) return PLAYER_TEXTURES.idle_right;
   return PLAYER_TEXTURES.idle_back;
 }
-
 function projectLane(lane, z, viewport, tube, includeSpinRotation = false, player = null) {
   const safeZ = clamp(Number.isFinite(z) ? z : CONFIG.PLAYER_Z, 0, 2);
   const safeLane = clamp(Number.isFinite(lane) ? lane : 0, -1, 1);
@@ -124,12 +111,10 @@ function projectLane(lane, z, viewport, tube, includeSpinRotation = false, playe
   const bendInfluence = 1 - scale;
   const radius = CONFIG.TUBE_RADIUS * scale;
   let angle = safeLane * LANE_ANGLE_STEP;
-
   if (includeSpinRotation && player?.spinActive) {
     const spinProgress = (player.spinProgress || 0) / Math.max(CONFIG.SPIN_DURATION, Number.EPSILON);
     angle += spinProgress * Math.PI * 2;
   }
-
   return {
     x:
       viewport.centerX +
@@ -143,11 +128,9 @@ function projectLane(lane, z, viewport, tube, includeSpinRotation = false, playe
     angle,
   };
 }
-
 function getPlayerFrameCount(scene, textureKey) {
   const configuredCount = PLAYER_FRAME_COUNTS[textureKey];
   if (Number.isFinite(configuredCount) && configuredCount > 0) return configuredCount;
-
   const texture = scene?.textures?.get(textureKey);
   if (!texture) return 1;
   const numericFrames = texture.getFrameNames().filter((name) => /^\d+$/.test(name));
@@ -155,13 +138,11 @@ function getPlayerFrameCount(scene, textureKey) {
   const fallback = Number(texture.frameTotal) - 1;
   return Number.isFinite(fallback) && fallback > 0 ? fallback : 1;
 }
-
 function getSpinFrameIndex(spinProgress, totalFrames) {
   const safeTotalFrames = Math.max(1, Number(totalFrames) || 1);
   const progress = clamp(Number(spinProgress) || 0, 0, 1);
   return Math.min(safeTotalFrames - 1, Math.floor(progress * safeTotalFrames));
 }
-
 function projectPolar(angle, z, viewport, tube, radiusFactor = 0.65) {
   const safeZ = clamp(Number.isFinite(z) ? z : 1, 0, 2);
   const scale = Math.max(0.05, 1 - safeZ);
@@ -181,7 +162,6 @@ function projectPolar(angle, z, viewport, tube, radiusFactor = 0.65) {
     angle: orbitAngle,
   };
 }
-
 function getBonusFrame(item) {
   const frame = item.animFrame || 0;
   const toggle = Math.floor(frame / 4) % 2;
@@ -212,7 +192,6 @@ function getBonusFrame(item) {
       return 0;
   }
 }
-
 function registerCustomBonusFrames(scene) {
   Object.entries(BONUS_FRAME_DEFS).forEach(([textureKey, frames]) => {
     const texture = scene.textures.get(textureKey);
@@ -232,7 +211,6 @@ class EntityRenderer {
         frameHeight: PLAYER_FRAME_SIZE,
       });
     });
-
     ['coins_gold', 'coins_silver', ...Object.values(BONUS_TEXTURES), ...Object.values(OBSTACLE_TEXTURES)].forEach((key) => {
       if (WIDE_BONUS_TEXTURES.has(key)) {
         scene.load.image(key, assetUrl(`assets/${key}.png`));
@@ -243,8 +221,10 @@ class EntityRenderer {
         frameHeight: FRAME_SIZE,
       });
     });
+    Object.entries(VISUAL_UPGRADE_TEXTURES).forEach(([key, path]) => {
+      scene.load.image(key, assetUrl(path));
+    });
   }
-
   constructor(scene) {
     this.scene = scene;
     this.snapshot = null;
@@ -254,6 +234,8 @@ class EntityRenderer {
     this.targetLayer = null;
     this.coinSprites = [];
     this.bonusSprites = [];
+    this.bonusAuraSprites = [];
+    this.coinGlintSprites = [];
     this.obstacleSprites = [];
     this.spinTargetGraphics = [];
     this.radarLineGraphics = null;
@@ -266,7 +248,6 @@ class EntityRenderer {
     this.collectEffectSeenIds = new Set();
     this.collectEffectSprites = new Set();
   }
-
   create() {
     registerCustomBonusFrames(this.scene);
     this.root = this.scene.add.container(0, 0).setDepth(12);
@@ -274,11 +255,11 @@ class EntityRenderer {
     this.playerLayer = this.scene.add.container(0, 0).setDepth(13);
     this.targetLayer = this.scene.add.container(0, 0).setDepth(14);
     this.root.add([this.objectLayer, this.playerLayer, this.targetLayer]);
-
-    this.playerShadow = this.scene.add.ellipse(0, 0, 82, 28, 0x000000, 0.26);
+    this.playerShadow = this.scene.textures.exists('shadow_contact_ellipse_01')
+      ? this.scene.add.image(0, 0, 'shadow_contact_ellipse_01').setAlpha(0.26)
+      : this.scene.add.ellipse(0, 0, 82, 28, 0x000000, 0.26);
     this.playerSprite = this.scene.add.sprite(0, 0, PLAYER_TEXTURES.idle_back, 0);
     this.playerLayer.add([this.playerShadow, this.playerSprite]);
-
     this.radarLineGraphics = this.scene.add.graphics().setDepth(18);
     this.spinAlertBackdrop = this.scene.add.rectangle(0, 0, 0, 0, 0x000000, 0.74)
       .setDepth(19)
@@ -293,7 +274,6 @@ class EntityRenderer {
       .setOrigin(0.5, 0.5)
       .setDepth(20)
       .setVisible(false);
-
     this.bonusTextLabel = this.scene.add.text(0, 0, '', {
       fontFamily: 'Orbitron, Arial, sans-serif',
       fontSize: '32px',
@@ -307,12 +287,12 @@ class EntityRenderer {
       .setDepth(21)
       .setVisible(false);
   }
-
   destroyPool(pool) { pool.forEach((entry) => entry.destroy()); pool.length = 0; }
-
   destroy() {
     this.destroyPool(this.coinSprites);
     this.destroyPool(this.bonusSprites);
+    this.destroyPool(this.bonusAuraSprites);
+    this.destroyPool(this.coinGlintSprites);
     this.destroyPool(this.obstacleSprites);
     this.destroyPool(this.spinTargetGraphics);
     this.destroyPool(this.radarHintTexts);
@@ -328,7 +308,6 @@ class EntityRenderer {
     this.root?.destroy();
     this.root = null;
   }
-
   ensurePoolSize(pool, count, factory) {
     while (pool.length < count) {
       pool.push(factory());
@@ -337,7 +316,6 @@ class EntityRenderer {
       pool[index].setVisible(index < count);
     }
   }
-
   applySnapshot(snapshot) {
     this.snapshot = snapshot || null;
     if (!this.root || !snapshot?.viewport || !snapshot?.tube) return;
@@ -349,7 +327,6 @@ class EntityRenderer {
     this.renderBonusText();
     this.renderCollectAnimations();
   }
-
   renderCollectAnimations() {
     renderCollectAnimationsPass(this, {
       BONUS_TEXTURES,
@@ -358,13 +335,11 @@ class EntityRenderer {
       parseRgbaColor,
     });
   }
-
   renderPlayer() {
     const viewport = this.snapshot?.viewport;
     const tube = this.snapshot?.tube;
     const player = this.snapshot?.player;
     if (!viewport || !tube || !player || !this.playerSprite || !this.playerShadow) return;
-
     const laneValue = player.isLaneTransition
       ? (player.lanePrev || 0) + ((player.targetLane || 0) - (player.lanePrev || 0)) * clamp(player.laneAnimFrame / Math.max(1, CONFIG.LANE_TRANSITION_FRAMES), 0, 1)
       : player.lane;
@@ -377,22 +352,20 @@ class EntityRenderer {
         frameCount
       )
       : Math.round(player.frameIndex || 0) % Math.max(1, frameCount);
-
     this.playerSprite.setTexture(textureKey, frameIndex);
     this.playerSprite.setPosition(projection.x, projection.y);
     this.playerSprite.setDisplaySize(154, 154);
     this.playerSprite.setAlpha(1);
-
     this.playerShadow
       .setPosition(projection.x, projection.y + 44)
       .setDisplaySize(100, 30)
       .setAlpha(0.22 + (player.shield ? 0.06 : 0));
   }
-
   renderObjects() {
     renderObjectsPass(this, {
       BONUS_TEXTURES,
       OBSTACLE_TEXTURES,
+      VISUAL_UPGRADE_TEXTURES,
       FRAME_SIZE,
       CONFIG,
       clamp,
@@ -401,14 +374,12 @@ class EntityRenderer {
       getBonusFrame,
     });
   }
-
   renderSpinTargets() {
     const targets = (this.snapshot?.spinTargets || []).filter((item) => !item.collected && item.z > -0.2 && item.z < 1.6);
     const viewport = this.snapshot?.viewport;
     const tube = this.snapshot?.tube;
     if (!viewport || !tube) return;
     this.ensurePoolSize(this.spinTargetGraphics, targets.length, () => this.scene.add.graphics());
-
     targets.forEach((target, index) => {
       const graphics = this.spinTargetGraphics[index];
       const projection = projectPolar(target.angle || 0, target.z, viewport, tube, target.radiusFactor || 0.65);
@@ -426,26 +397,21 @@ class EntityRenderer {
       graphics.setVisible(true);
       this.targetLayer.add(graphics);
     });
-
     for (let index = targets.length; index < this.spinTargetGraphics.length; index += 1) {
       this.spinTargetGraphics[index].clear();
       this.spinTargetGraphics[index].setVisible(false);
     }
   }
-
   renderRadarHints() {
     const viewport = this.snapshot?.viewport;
     const fx = this.snapshot?.fx;
     if (!viewport || !fx) return;
-
     const hints = fx.radarActive && Array.isArray(fx.radarHints)
       ? fx.radarHints.filter((hint) => Number.isFinite(hint?.lane))
       : [];
-
     if (this.radarLineGraphics) {
       this.radarLineGraphics.clear();
     }
-
     const lanePositions = {
       [-1]: viewport.width * 0.25,
       [0]: viewport.width * 0.5,
@@ -459,7 +425,6 @@ class EntityRenderer {
     const topY = viewport.height * 0.22;
     const bottomY = viewport.height - 36;
     const now = this.scene.time?.now || Date.now();
-
     this.ensurePoolSize(this.radarHintTexts, hints.length, () =>
       this.scene.add.text(0, 0, '', {
         fontFamily: 'Orbitron, Arial, sans-serif',
@@ -469,14 +434,12 @@ class EntityRenderer {
         align: 'center'
       }).setOrigin(0.5, 1).setDepth(20)
     );
-
     hints.forEach((hint, index) => {
       const lx = lanePositions[hint.lane] ?? (viewport.width / 2);
       const maxTimer = Math.max(0.1, Number(hint.maxTimer) || 1.8);
       const timer = Math.max(0, Number(hint.timer) || 0);
       const pulse = (Math.sin(now * 0.02) + 1) / 2;
       const alpha = (0.35 + pulse * 0.65) * (timer / maxTimer);
-
       if (this.radarLineGraphics) {
         this.radarLineGraphics.lineStyle(7 + pulse * 3, 0xffcc33, Math.min(1, alpha * 0.45));
         this.radarLineGraphics.beginPath();
@@ -489,7 +452,6 @@ class EntityRenderer {
         this.radarLineGraphics.lineTo(lx, bottomY);
         this.radarLineGraphics.strokePath();
       }
-
       const label = this.radarHintTexts[index];
       label
         .setText(`🟡 NEXT GOLD: ${laneLabels[hint.lane] || 'CENTER'}`)
@@ -498,46 +460,37 @@ class EntityRenderer {
         .setVisible(true);
     });
   }
-
-
   renderBonusText() {
     const viewport = this.snapshot?.viewport;
     const fx = this.snapshot?.fx;
     if (!viewport || !fx || !this.bonusTextLabel) return;
-
     const timer = Number(fx.bonusTextTimer) || 0;
     const text = String(fx.bonusText || '').trim();
     if (timer <= 0 || !text) {
       this.bonusTextLabel.setVisible(false);
       return;
     }
-
     const alpha = timer <= BONUS_TEXT_FADE_FRAMES
       ? Math.min(1, timer / BONUS_TEXT_FADE_FRAMES)
       : 1;
-
     this.bonusTextLabel
       .setPosition(viewport.width * 0.5, viewport.height * 0.28)
       .setText(text)
       .setAlpha(alpha)
       .setVisible(true);
-
     const frameDelta = Math.max(0.25, (Number(this.scene.game?.loop?.delta) || FRAME_MS_60FPS) / FRAME_MS_60FPS);
     gameState.bonusTextTimer = Math.max(0, gameState.bonusTextTimer - frameDelta);
   }
-
   renderSpinAlert() {
     const viewport = this.snapshot?.viewport;
     const fx = this.snapshot?.fx;
     if (!viewport || !fx || !this.spinAlertBackdrop || !this.spinAlertText) return;
-
     const timer = Number(fx.spinAlertTimer) || 0;
     if (timer <= 0) {
       this.spinAlertBackdrop.setVisible(false);
       this.spinAlertText.setVisible(false);
       return;
     }
-
     const now = this.scene.time?.now || Date.now();
     const centerX = viewport.width * 0.5;
     const centerY = viewport.height * 0.18;
@@ -547,7 +500,6 @@ class EntityRenderer {
     let width = 320;
     let height = 56;
     let alpha = Math.min(1, timer);
-
     if ((Number(fx.spinAlertLevel) || 0) >= 2 && (Number(fx.spinAlertCountdown) || 0) > 0) {
       const countNum = Math.ceil(Number(fx.spinAlertCountdown) || 0);
       const pulse = (Math.sin(now * 0.015) + 1) / 2;
@@ -573,19 +525,16 @@ class EntityRenderer {
       height = 56;
       alpha = Math.min(1, timer);
     }
-
     if (!text) {
       this.spinAlertBackdrop.setVisible(false);
       this.spinAlertText.setVisible(false);
       return;
     }
-
     this.spinAlertBackdrop
       .setPosition(centerX, centerY)
       .setSize(width, height)
       .setAlpha(alpha)
       .setVisible(true);
-
     this.spinAlertText
       .setPosition(centerX, centerY)
       .setText(text)
@@ -595,5 +544,4 @@ class EntityRenderer {
       .setVisible(true);
   }
 }
-
 export { EntityRenderer };

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -50,8 +50,16 @@ function renderCollectAnimationsPass(renderer, deps) {
     const bonusType = String(effect.bonusType || '');
     const coinType = String(effect.coinType || '');
     if (kind === 'shield_hit') {
-      const shieldPulse = renderer.scene.add.circle(Number(effect.x) || 0, Number(effect.y) || 0, 62, 0x66e6ff, 0.16);
-      shieldPulse.setStrokeStyle(4, 0x9ff8ff, 0.95);
+      const impactTextureAvailable = renderer.scene.textures.exists('shock_ring_impact_01');
+      const shieldPulse = impactTextureAvailable
+        ? renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, 'shock_ring_impact_01')
+        : renderer.scene.add.circle(Number(effect.x) || 0, Number(effect.y) || 0, 62, 0x66e6ff, 0.16);
+      if (impactTextureAvailable) {
+        shieldPulse.setDisplaySize(128, 128);
+        shieldPulse.setBlendMode('ADD');
+      } else {
+        shieldPulse.setStrokeStyle(4, 0x9ff8ff, 0.95);
+      }
       shieldPulse.setDepth(23);
       renderer.collectEffectSprites.add(shieldPulse);
 
@@ -215,13 +223,19 @@ function renderObjectsPass(renderer, deps) {
   const obstacleCount = objectEntries.filter((entry) => entry.kind === 'obstacle').length;
   const bonusCount = objectEntries.filter((entry) => entry.kind === 'bonus').length;
   const coinCount = objectEntries.filter((entry) => entry.kind === 'coin').length;
+  const hasBonusAura = renderer.scene.textures.exists('bonus_aura_soft_01');
+  const hasCoinGlint = renderer.scene.textures.exists('coin_glint_star_01');
   renderer.ensurePoolSize(renderer.obstacleSprites, obstacleCount, () => renderer.scene.add.sprite(0, 0, 'obstacles_1', 0));
   renderer.ensurePoolSize(renderer.bonusSprites, bonusCount, () => renderer.scene.add.sprite(0, 0, 'bonus_shield', 0));
   renderer.ensurePoolSize(renderer.coinSprites, coinCount, () => renderer.scene.add.sprite(0, 0, 'coins_silver', 0));
+  renderer.ensurePoolSize(renderer.bonusAuraSprites, hasBonusAura ? bonusCount : 0, () => renderer.scene.add.sprite(0, 0, 'bonus_aura_soft_01'));
+  renderer.ensurePoolSize(renderer.coinGlintSprites, hasCoinGlint ? coinCount : 0, () => renderer.scene.add.sprite(0, 0, 'coin_glint_star_01'));
 
   let obstacleIndex = 0;
   let bonusIndex = 0;
   let coinIndex = 0;
+  let bonusAuraIndex = 0;
+  let coinGlintIndex = 0;
 
   for (const entry of objectEntries) {
     const { item } = entry;
@@ -279,6 +293,15 @@ function renderObjectsPass(renderer, deps) {
       sprite.setAlpha(0.95);
       sprite.setVisible(true);
       renderer.objectLayer.add(sprite);
+      if (hasBonusAura) {
+        const aura = renderer.bonusAuraSprites[bonusAuraIndex++];
+        aura.setPosition(projection.x, projection.y);
+        aura.setDisplaySize(size * 1.5, size * 1.5);
+        aura.setAlpha(0.4 + 0.12 * Math.sin(renderer.scene.time.now * 0.01 + item.z * 10));
+        aura.setBlendMode('ADD');
+        aura.setVisible(true);
+        renderer.objectLayer.add(aura);
+      }
     } else {
       const sprite = renderer.coinSprites[coinIndex++];
       const textureKey = item.type === 'gold' || item.type === 'gold_spin' ? 'coins_gold' : 'coins_silver';
@@ -289,6 +312,16 @@ function renderObjectsPass(renderer, deps) {
       sprite.setAlpha(item.spinOnly ? 0.78 : 1);
       sprite.setVisible(true);
       renderer.objectLayer.add(sprite);
+      if (hasCoinGlint) {
+        const glint = renderer.coinGlintSprites[coinGlintIndex++];
+        const pulse = Math.max(0, Math.sin(renderer.scene.time.now * 0.02 + (item.animFrame || 0) * 0.8));
+        glint.setPosition(projection.x + size * 0.14, projection.y - size * 0.14);
+        glint.setDisplaySize(size * 0.42, size * 0.42);
+        glint.setAlpha((item.spinOnly ? 0.15 : 0.25) + pulse * 0.55);
+        glint.setBlendMode('ADD');
+        glint.setVisible(true);
+        renderer.objectLayer.add(glint);
+      }
     }
   }
 
@@ -300,6 +333,12 @@ function renderObjectsPass(renderer, deps) {
   }
   for (let index = coinIndex; index < renderer.coinSprites.length; index += 1) {
     renderer.coinSprites[index].setVisible(false);
+  }
+  for (let index = bonusAuraIndex; index < renderer.bonusAuraSprites.length; index += 1) {
+    renderer.bonusAuraSprites[index].setVisible(false);
+  }
+  for (let index = coinGlintIndex; index < renderer.coinGlintSprites.length; index += 1) {
+    renderer.coinGlintSprites[index].setVisible(false);
   }
 }
 

--- a/js/phaser/entities/entity-visual-assets.js
+++ b/js/phaser/entities/entity-visual-assets.js
@@ -1,0 +1,8 @@
+const VISUAL_UPGRADE_TEXTURES = Object.freeze({
+  shadow_contact_ellipse_01: 'img/new/shadow_contact_ellipse_01.png',
+  bonus_aura_soft_01: 'img/new/bonus_aura_soft_01.png',
+  coin_glint_star_01: 'img/new/coin_glint_star_01.png',
+  shock_ring_impact_01: 'img/new/shock_ring_impact_01.png',
+});
+
+export { VISUAL_UPGRADE_TEXTURES };


### PR DESCRIPTION
### Motivation

- Introduce optional, fallback-friendly visual upgrades (contact shadow, bonus aura, coin glint, shock ring) to enrich VFX without breaking existing flows.
- Provide a design/asset roadmap (Russian) describing visual upgrade options and required assets for phased rollout.

### Description

- Added `js/phaser/entities/entity-visual-assets.js` which exports `VISUAL_UPGRADE_TEXTURES` mapping new asset keys to paths. 
- Loaded the new assets in `EntityRenderer.preload` via `VISUAL_UPGRADE_TEXTURES` and added conditional usage throughout rendering code so features gracefully degrade when textures are absent. 
- Replaced procedural contact shadow with a texture fallback in `EntityRenderer.create` using `shadow_contact_ellipse_01` when available. 
- Extended `EntityRenderer` pools and lifecycle to include `bonusAuraSprites` and `coinGlintSprites`, and ensured proper cleanup in `destroy`. 
- Implemented asset-driven collect effects in `renderCollectAnimationsPass` to prefer `shock_ring_impact_01` sprite for shield hits and fall back to circle primitives when missing. 
- Added bonus aura and coin glint rendering in `renderObjectsPass` with conditional pool sizing and additive blending for visual enhancement. 
- Added a new documentation file `docs/phaser-visual-max-options-2026-04-10-ru.md` containing optioned visual upgrade plans, asset prompts and a 3-iteration roadmap.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d972cf735083208bfc93534c7a54bb)