### PR TITLE
Make tunnel segments opaque with backdrop fill

### DIFF
--- a/js/phaser/tunnel/tunnel-draw-pass.js
+++ b/js/phaser/tunnel/tunnel-draw-pass.js
@@ -191,6 +191,11 @@ function renderBaseLayer(renderer, deps, renderTube, frame) {
         curveOffsetY2 +
         centerOffsetY * bend2;
 
+      const trackWallBackdropColor = deps.blendColor(wallColor, 0x03060f, 0.58);
+      renderer.baseGraphics.fillStyle(trackWallBackdropColor, 1);
+      deps.drawQuadPath(renderer.baseGraphics, x1, y1, x2, y2, x3, y3, x4, y4);
+      renderer.baseGraphics.fillPath();
+
       const tileFillAlpha = deps.clamp(quality.segmentAlpha * spawnBlend * curveOcclusion, 0.08, 1);
       const trackWallColor = deps.blendColor(wallColor, 0x7aa3cf, 0.32 * trackCoverage);
       renderer.baseGraphics.fillStyle(trackWallColor, tileFillAlpha);


### PR DESCRIPTION
### Motivation
- Prevent visible transparency gaps in the rendered tunnel segments by ensuring each segment quad has an opaque backdrop before applying the stylized, semi-transparent wall fill.

### Description
- Add an opaque backdrop fill pass using `renderer.baseGraphics.fillStyle(..., 1)` for each segment quad before the existing `tileFillAlpha` pass in `js/phaser/tunnel/tunnel-draw-pass.js`, preserving current tinting, glint and darkening overlays.

### Testing
- Ran `npm run check:syntax` and the check completed successfully.
- Ran the static analysis check (`node scripts/check-static-analysis.mjs`, executed via pre-commit) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad9c7b4c483209a0a64e62c58befa)