### PR TITLE
Use color blending (tint) for tunnel track walls and clarify variable names

### DIFF
--- a/js/phaser/tunnel/tunnel-draw-pass.js
+++ b/js/phaser/tunnel/tunnel-draw-pass.js
@@ -191,9 +191,10 @@ function renderBaseLayer(renderer, deps, renderTube, frame) {
         curveOffsetY2 +
         centerOffsetY * bend2;
 
-      const tileFillAlpha = deps.clamp(quality.segmentAlpha * spawnBlend * curveOcclusion, 0.08, 1);
-      const trackWallColor = deps.blendColor(wallColor, 0x7aa3cf, 0.32 * trackCoverage);
-      renderer.baseGraphics.fillStyle(trackWallColor, tileFillAlpha);
+      const tileVisibility = deps.clamp(quality.segmentAlpha * spawnBlend * curveOcclusion, 0.08, 1);
+      const trackWallTintedColor = deps.blendColor(wallColor, 0x7aa3cf, 0.32 * trackCoverage);
+      const trackWallColor = deps.blendColor(trackWallTintedColor, 0x03060f, 1 - tileVisibility);
+      renderer.baseGraphics.fillStyle(trackWallColor, 1);
       deps.drawQuadPath(renderer.baseGraphics, x1, y1, x2, y2, x3, y3, x4, y4);
       renderer.baseGraphics.fillPath();
       deps.drawTunnelDarkeningOverlay(renderer.fogGraphics, {


### PR DESCRIPTION
### Motivation
- Improve how tunnel track wall visibility is rendered by using color blending (tint/darkening) instead of reducing shape alpha, and make variable names clearer for readability.

### Description
- Replace `tileFillAlpha` with `tileVisibility` and compute a tinted base color `trackWallTintedColor` from `wallColor`; then blend that with a dark color based on `1 - tileVisibility` to produce the final `trackWallColor` and call `fillStyle` with full alpha.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad9c7b4c483209a0a64e62c58befa)