### PR TITLE
Improve tunnel wall shading with backdrop pass and overlay tinting

### DIFF
--- a/js/phaser/tunnel/tunnel-draw-pass.js
+++ b/js/phaser/tunnel/tunnel-draw-pass.js
@@ -191,9 +191,16 @@ function renderBaseLayer(renderer, deps, renderTube, frame) {
         curveOffsetY2 +
         centerOffsetY * bend2;
 
-      const tileFillAlpha = deps.clamp(quality.segmentAlpha * spawnBlend * curveOcclusion, 0.08, 1);
-      const trackWallColor = deps.blendColor(wallColor, 0x7aa3cf, 0.32 * trackCoverage);
-      renderer.baseGraphics.fillStyle(trackWallColor, tileFillAlpha);
+      const tileVisibility = deps.clamp(quality.segmentAlpha * spawnBlend * curveOcclusion, 0.08, 1);
+      const trackWallBackdropColor = deps.blendColor(wallColor, 0x18304d, 0.46 + trackCoverage * 0.2);
+      renderer.baseGraphics.fillStyle(trackWallBackdropColor, 1);
+      deps.drawQuadPath(renderer.baseGraphics, x1, y1, x2, y2, x3, y3, x4, y4);
+      renderer.baseGraphics.fillPath();
+
+      const trackWallTintedColor = deps.blendColor(wallColor, 0x7aa3cf, 0.32 * trackCoverage);
+      const trackWallColor = deps.blendColor(trackWallTintedColor, 0x060b16, 1 - tileVisibility);
+      const trackWallOverlayAlpha = deps.clamp(0.22 + tileVisibility * 0.5, 0.22, 0.72);
+      renderer.baseGraphics.fillStyle(trackWallColor, trackWallOverlayAlpha);
       deps.drawQuadPath(renderer.baseGraphics, x1, y1, x2, y2, x3, y3, x4, y4);
       renderer.baseGraphics.fillPath();
       deps.drawTunnelDarkeningOverlay(renderer.fogGraphics, {


### PR DESCRIPTION
### Motivation

- Make tunnel wall segments visually richer and more legible by separating a darker backdrop and a tinted overlay instead of a single flat fill.
- Provide a more stable mapping between segment visibility and overlay intensity to reduce washed-out or overly bright tiles.

### Description

- Replace single fill pass with a two-pass rendering for track walls: a solid backdrop drawn with `deps.drawQuadPath`/`fillPath` and a tinted overlay drawn on top with a computed alpha.
- Rename `tileFillAlpha` to `tileVisibility` and compute `trackWallBackdropColor` using `deps.blendColor` with a deeper base (`0x18304d`) influenced by `trackCoverage`.
- Compute `trackWallColor` by tinting with `0x7aa3cf` and then blending toward `0x060b16` based on `1 - tileVisibility`, and clamp overlay alpha via `deps.clamp(0.22 + tileVisibility * 0.5, 0.22, 0.72)`.
- Keep existing fog and glint overlays (`deps.drawTunnelDarkeningOverlay` and `deps.drawSegmentGlintOverlay`) and the grid radial overlay collection logic unchanged.

### Testing

- Ran the automated test suite via `npm test` and unit tests relevant to rendering passed. 
- Performed a headless renderer smoke test to assert no runtime errors during the tunnel draw path, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad9c7b4c483209a0a64e62c58befa)