### PR TITLE
Smooth tunnel streak transitions

### DIFF
--- a/js/phaser/tunnel/tunnel-draw-pass.js
+++ b/js/phaser/tunnel/tunnel-draw-pass.js
@@ -266,10 +266,12 @@ function renderBaseLayer(renderer, deps, renderTube, frame) {
       if (wallCoverage > 0.25) {
         const depthPhase = animatedDepth * 0.33 - scrollOffset * 1.7 + speedPulse;
         const stripePulse = 0.5 + 0.5 * Math.sin(depthPhase);
-        const stripeGate = Math.pow(stripePulse, 7.5);
+        const stripeGateCurve = Math.pow(stripePulse, 5.2);
+        const stripeGate = deps.clamp((stripeGateCurve - 0.06) / 0.66, 0, 1);
         const segmentNoise = deps.hashNoise(i * 13.77 + Math.floor(animatedDepth) * 0.91);
+        const noiseBlend = deps.clamp((segmentNoise - 0.42) / 0.2, 0, 1);
         const depthWithinRange = depthRatio >= deps.SPEED_STREAK_MIN_DEPTH_RATIO && depthRatio <= deps.SPEED_STREAK_MAX_DEPTH_RATIO;
-        if (depthWithinRange && stripeGate > 0.08 && segmentNoise > 0.48) {
+        if (depthWithinRange && stripeGate > 0.015 && noiseBlend > 0.01) {
           speedStreakOverlays.push({
             quad: {
               p1: { x: x1, y: y1 },
@@ -281,7 +283,7 @@ function renderBaseLayer(renderer, deps, renderTube, frame) {
             spawnBlend,
             wallCoverage,
             colorIndex: (i + Math.floor(animatedDepth)) % deps.SPEED_STREAK_COLORS.length,
-            streakAlpha: stripeGate,
+            streakAlpha: stripeGate * noiseBlend,
           });
         }
       }


### PR DESCRIPTION
### Motivation
- Bright periodic segments in the tunnel produce harsh, popping on/off transitions and need a smoother, more continuous visibility ramp.

### Description
- Modified `js/phaser/tunnel/tunnel-draw-pass.js` to replace the hard high-power gate with a remapped curve (`stripeGateCurve = Math.pow(..., 5.2)` and `stripeGate = deps.clamp((stripeGateCurve - 0.06) / 0.66, 0, 1)`), added a continuous `noiseBlend = deps.clamp((segmentNoise - 0.42) / 0.2, 0, 1)`, and computed streak alpha as `streakAlpha = stripeGate * noiseBlend` while relaxing the appearance thresholds.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- The repository's pre-commit static analysis (`npm run check:static-analysis`) also ran and passed during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbba93bcac83208450142497eb1249)