### PR TITLE
Fix CI failure from missing procedural visual asset paths

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -259,9 +259,8 @@ class EntityRenderer {
         frameHeight: FRAME_SIZE,
       });
     });
-    Object.entries(VISUAL_UPGRADE_TEXTURES).forEach(([key, path]) => {
-      scene.load.image(key, assetUrl(path));
-    });
+    // Visual upgrade textures are generated procedurally at runtime in
+    // ensureVisualUpgradeTextures(), so no static asset preload is required.
   }
   constructor(scene) {
     this.scene = scene;

--- a/js/phaser/entities/entity-visual-assets.js
+++ b/js/phaser/entities/entity-visual-assets.js
@@ -1,8 +1,8 @@
 const VISUAL_UPGRADE_TEXTURES = Object.freeze({
-  shadow_contact_ellipse_01: 'img/new/shadow_contact_ellipse_01.png',
-  bonus_aura_soft_01: 'img/new/bonus_aura_soft_01.png',
-  coin_glint_star_01: 'img/new/coin_glint_star_01.png',
-  shock_ring_impact_01: 'img/new/shock_ring_impact_01.png',
+  shadow_contact_ellipse_01: 'shadow_contact_ellipse_01',
+  bonus_aura_soft_01: 'bonus_aura_soft_01',
+  coin_glint_star_01: 'coin_glint_star_01',
+  shock_ring_impact_01: 'shock_ring_impact_01',
 });
 
 function drawRadialTexture(scene, key, size, stops) {


### PR DESCRIPTION
### Motivation
- CI `check:asset-paths` was failing because `entity-visual-assets.js` referenced `img/new/*.png` files that do not exist under `public/` even though those textures are created procedurally at runtime.

### Description
- Stop preloading visual-upgrade textures in `EntityRenderer.preload` because those textures are generated at runtime by `ensureVisualUpgradeTextures()` and do not require static assets.
- Replace `VISUAL_UPGRADE_TEXTURES` path-like values with their internal texture keys (e.g. `'shadow_contact_ellipse_01'`) to avoid false positives from the public asset path guard while preserving texture keys used at runtime.
- No runtime rendering or texture-key behavior was changed; textures continue to be created with the same keys via the canvas-based helpers in `entity-visual-assets.js`.

### Testing
- Ran `npm run check`, which includes syntax, static analysis, `check:asset-paths`, and the test suite, and it completed successfully.
- Ran `npm run build` (`vite build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf81ca6a0832081d2d2de6884954c)