### PR TITLE
feat: strengthen obstacle shadows in phaser renderer

### DIFF
--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -299,10 +299,11 @@ function renderObjectsPass(renderer, deps) {
         * growth
         * tuning.readabilityBoost
         * (radarPreviewActive ? 1.12 : 1);
+      const obstacleShadowAlpha = (0.24 + projection.scale * 0.28) * curveOcclusion;
       shadow
         .setPosition(projection.x, projection.y + size * 0.24)
-        .setDisplaySize(size * 0.84, size * 0.24)
-        .setAlpha((0.16 + projection.scale * 0.22) * curveOcclusion)
+        .setDisplaySize(size * 0.92, size * 0.28)
+        .setAlpha(obstacleShadowAlpha)
         .setVisible(true);
       renderer.objectLayer.add(shadow);
       sprite.setTexture(textureKey, frameMap[item.subtype] || 0);


### PR DESCRIPTION
### Motivation

- Improve visual readability of obstacles against the tunnel background by making their contact shadows stronger and slightly larger.

### Description

- In `js/phaser/entities/entity-render-passes.js` extracted obstacle shadow alpha into `obstacleShadowAlpha` and increased its baseline and projection multiplier to make shadows more visible.
- Enlarged obstacle shadow display footprint from `0.84 x 0.24` to `0.92 x 0.28` relative to object `size` for a clearer ground contact impression.
- Kept shadow visibility tied to existing `projection.scale` and `curveOcclusion` logic so occlusion and scaling behavior remains consistent.

### Testing

- Ran `node --test scripts/entity-render-passes.test.mjs` and all tests passed.
- Ran static checks executed during commit: `npm run check:syntax` and `npm run check:static-analysis`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfa6386b8832083654d6c9fe72f39)