### PR TITLE
Adjust HUD placement, multiplier display, and mobile tunnel scaling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -715,6 +715,7 @@ body.start-launching #walletCorner {
 }
 
 #uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
 #uiTopLeft .score { color: #c084fc; font-size: 15px; }
 #uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
 
@@ -766,6 +767,17 @@ body.start-launching #walletCorner {
 #uiBottomCenter .coin { display: flex; align-items: center; gap: 5px; }
 #uiBottomCenter .coin .count { color: #c084fc; }
 #uiBottomCenter .speed-info { opacity: .7; font-size: 11px; }
+
+#uiBottomLeft {
+  position: absolute;
+  left: 14px;
+  bottom: 14px;
+  z-index: 10;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255,255,255,.8);
+}
 
 #fpsVal { color: #4caf50; font-weight: bold; }
 #fpsVal.slow { color: #ff9800; }
@@ -1656,18 +1668,23 @@ footer a:hover { color: #e0b0ff; }
   .game-audio-nav { right: 10px; bottom: 65px; gap: 6px; }
   .game-audio-btn { width: 34px; height: 34px; font-size: 14px; }
 
-  /* Mobile in-game HUD: left/right/bottom menus reduced by 2.5x */
+  /* Mobile/Telegram in-game HUD: enlarged for readability */
   #gameContainer.active #uiTopLeft,
   #gameContainer.active #uiTopRight {
-    transform: scale(0.4);
+    transform: scale(0.8);
   }
 
   #gameContainer.active #uiTopLeft { transform-origin: top left; }
   #gameContainer.active #uiTopRight { transform-origin: top right; }
 
   #gameContainer.active #uiBottomCenter {
-    transform: translateX(-50%) scale(0.4);
+    transform: translateX(-50%) scale(0.8);
     transform-origin: bottom center;
+  }
+
+  #gameContainer.active #uiBottomLeft {
+    transform: scale(0.8);
+    transform-origin: bottom left;
   }
 
   #gameStart.start-launching #bear3d {
@@ -1684,6 +1701,7 @@ footer a:hover { color: #e0b0ff; }
 }
 
 @media (max-width: 480px) {
+  #pingDisplay { display: none !important; }
   #gameStart .start-audio-nav {
     left: 8px;
     gap: 6px;

--- a/index.html
+++ b/index.html
@@ -53,11 +53,10 @@
     <div id="gameWrapper">
       <div id="gameContent">
       <div id="uiTopLeft">
+        <div class="speed"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -64px"></span> <span id="speedVal">1.0</span>x</div>
         <div class="distance"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:0px 0px"></span> <span id="distanceVal">0</span>m</div>
         <div class="score"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -32px"></span> <span id="scoreVal">0</span></div>
         <div style="margin-top: 8px; font-size: 11px; opacity: 0.7; border-top: 1px solid rgba(255,255,255,.06); padding-top: 6px;">
-          <div>📊 FPS: <span id="fpsVal">60</span></div>
-          <div>🧪 Render: <span id="renderStatsVal">0q · O0 B0 C0 T0</span></div>
           <div id="pingDisplay" style="display: none;">🌐 Ping: <span id="pingVal">0</span>ms</div>
         </div>
       </div>
@@ -83,7 +82,10 @@
             <span class="count" id="silverVal">0</span>
           </div>
         </div>
-        <div class="speed-info"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px -56px"></span> <span id="speedVal">1.0x</span> | 📊 <span id="coinsCountVal">0</span> coins</div>
+      </div>
+
+      <div id="uiBottomLeft">
+        <div>📊 FPS: <span id="fpsVal">60</span></div>
       </div>
 
       <!-- In-game audio toggles -->

--- a/js/config.js
+++ b/js/config.js
@@ -60,8 +60,9 @@ const isMobileUserAgent = hasNavigator ? /Mobi|Android|iPhone/i.test(navigator.u
 const isMobileViewport = hasWindow ? window.innerWidth < 600 : false;
 const isMobile = isMobileUserAgent || isMobileViewport;
 if (isMobile) {
-  CONFIG.TUBE_SEGMENTS = 13;
+  CONFIG.TUBE_SEGMENTS = 20;
   CONFIG.TUBE_DEPTH_STEPS = 48;
+  CONFIG.TUBE_RADIUS = 250;
 }
 
 const BONUS_TYPES = {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,5 +1,5 @@
 import { CONFIG } from './config.js';
-import { DOM, gameState, player, coins } from './state.js';
+import { DOM, gameState, player } from './state.js';
 import { syncAllAudioUI } from './audio.js';
 import { getAuthStateSnapshot, hasWalletAuthSession } from './auth.js';
 import { applyStoreDefaultLockState, loadPlayerUpgrades, updateStoreUI, setActiveStoreTab, closeDonationModal, isStoreAvailable, isUnauthRuntimeMode, getStoreStateSnapshot } from './store.js';
@@ -50,10 +50,18 @@ function updateUI() {
 
   if (gameState.uiUpdateFrame % 5 === 0) {
     DOM.shieldVal.textContent = player.shieldCount > 0 ? String(player.shieldCount) : "✗";
-    DOM.multiplierVal.textContent = gameState.baseMultiplier > 1
-      ? `x${gameState.baseMultiplier} ${gameState.x2Timer.toFixed(1)}s`
-      : "x1";
-    DOM.speedVal.textContent = (gameState.speed / CONFIG.SPEED_START).toFixed(2) + "x";
+    const x2Active = gameState.baseMultiplier > 1 && gameState.x2Timer > 0;
+    const invertActive = player.invertActive && gameState.invertScoreMultiplier > 1;
+    const totalMultiplier = (x2Active ? gameState.baseMultiplier : 1) * (invertActive ? gameState.invertScoreMultiplier : 1);
+    if (x2Active || invertActive) {
+      const markers = [];
+      if (x2Active) markers.push(`X2 ${gameState.x2Timer.toFixed(1)}s`);
+      if (invertActive) markers.push(`INV ${player.invertTimer.toFixed(1)}s`);
+      DOM.multiplierVal.textContent = `x${Number(totalMultiplier.toFixed(2))} (${markers.join(' · ')})`;
+    } else {
+      DOM.multiplierVal.textContent = "x1";
+    }
+    DOM.speedVal.textContent = (gameState.speed / CONFIG.SPEED_START).toFixed(2);
   }
 
   if (gameState.uiUpdateFrame % 10 === 0) {
@@ -62,7 +70,6 @@ function updateUI() {
     DOM.spinVal.textContent = gameState.spinCooldown > 0 ? `⏳ ${(gameState.spinCooldown / 60).toFixed(1)}s` : "✓";
     DOM.goldVal.textContent = gameState.goldCoins;
     DOM.silverVal.textContent = gameState.silverCoins;
-    DOM.coinsCountVal.textContent = coins.length;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve in-game HUD layout and clarity by removing debug rows and repositioning key metrics for both desktop and mobile.
- Ensure the score multiplier (`X`) accurately reflects active boosts (`X2` and `invert`) and shows remaining timers.
- Reduce tube clipping on wide mobile viewports by increasing tube polygon count and slightly zooming out the tunnel.

### Description
- Moved UI elements in `index.html`: added a `speed` row above distance, removed the `Render` debug line, moved FPS to a new `#uiBottomLeft` (text-only) and removed the spawned-coins counter from the bottom-center panel.
- Updated styles in `css/style.css`: added `.speed` and `#uiBottomLeft` rules, hid `#pingDisplay` on small viewports, and changed mobile/Telegram HUD scale from `0.4` to `0.8` to increase menu sizes.
- Adjusted multiplier and HUD logic in `js/ui.js`: compute `totalMultiplier` from active `X2` and `invert` effects, display effective `xN` with active markers/timers, and stopped updating the ephemeral spawned-coin counter.
- Tuned mobile tunnel parameters in `js/config.js`: set `CONFIG.TUBE_SEGMENTS = 20` for mobile and reduced `CONFIG.TUBE_RADIUS` to `250` so the tube fits better on wide mobile test resolutions.

### Testing
- Ran `npm run check:syntax` and all syntax checks passed successfully.
- Ran `npm run build` (Vite) and the production build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc09ff09c4832096dd496310af8629)