### PR TITLE
Play shield-hit SFX for obstacle collisions when shield active

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -26,6 +26,7 @@ const audioManager = {
     this.sfx.gamestart = createAudio('assets/sfx/game_start.wav');
     this.sfx.gameover = createAudio('assets/sfx/game-over.mp3');
     this.sfx.spin = createAudio('assets/sfx/crush__lose_gm.wav');
+    this.sfx.energetic_shield = createAudio('assets/sfx/energetiс_shield.ogg');
     this.sfx.gameover_screen = createAudio('assets/sfx/gameover_screen.wav', { loop: true });
 
     this.music.menu = createAudio('assets/sound/BlackUrsa.ogg', { loop: true });

--- a/js/physics.js
+++ b/js/physics.js
@@ -349,6 +349,7 @@ function update(delta) {
           x: shieldHitPoint?.x ?? getViewportCenter().x,
           y: shieldHitPoint?.y ?? getViewportCenter().y
         });
+        audioManager.playSFX("energetic_shield");
         player.shieldCount--;
         player.shield = player.shieldCount > 0;
         obstacles.splice(i, 1);


### PR DESCRIPTION
### Motivation
- Add audible feedback for shield interactions so a distinct SFX plays when an obstacle is absorbed by an active shield.

### Description
- Register a new SFX key `energetic_shield` that loads `assets/sfx/energetiс_shield.ogg` in `js/audio.js` and play it from the obstacle-collision shield branch in `js/physics.js` only when `player.shieldCount > 0`; no other collision behavior was changed.

### Testing
- Ran `npm run check:syntax` and `npm run check:asset-paths`, and the repository's pre-commit static analysis checks also passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcccdf38d083208f5ed41c2cd79630)