### PR TITLE
Remove leaderboard max-height, fix store nav safe-area positioning, and clean FPS label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1705,8 +1705,8 @@ footer a:hover { color: #e0b0ff; }
     z-index: 14;
   }
   #startLeaderboardWrap .lb-list {
-    max-height: 124px;
-    overflow-y: auto;
+    max-height: none;
+    overflow-y: visible;
   }
   .lb-title { font-size: 12px; }
   .lb-row { font-size: 11px; padding: 8px 8px; }
@@ -1728,6 +1728,13 @@ footer a:hover { color: #e0b0ff; }
   }
   .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
+  #storeScreen .store-fixed-nav {
+    position: fixed;
+    top: max(12px, env(safe-area-inset-top));
+    left: 8px;
+    z-index: 120;
+    transform: translateZ(0);
+  }
   .rules-title { font-size: 22px; }
   .rules-section-title { font-size: 12px; }
   .rules-section-text { font-size: 11px; }
@@ -1797,12 +1804,16 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 0;
     width: min(96vw, 420px);
   }
-  #startLeaderboardWrap .lb-list { max-height: 118px; }
+  #startLeaderboardWrap .lb-list { max-height: none; }
   .go-title { font-size: 24px; }
   .go-btn { padding: 10px 20px; font-size: 11px; }
   .store-title { font-size: 18px; }
   .store-tiers { gap: 5px; }
   .store-fixed-nav { left: 6px; top: 12px; gap: 6px; }
+  #storeScreen .store-fixed-nav {
+    top: max(10px, env(safe-area-inset-top));
+    left: 6px;
+  }
   .store-nav-btn { width: 34px; height: 34px; font-size: 14px; }
   #storeScreen { padding: 15px 10px 15px 48px; }
   .store-back-fixed { left: 8px; width: 34px; height: 34px; font-size: 14px; }
@@ -1839,7 +1850,7 @@ footer a:hover { color: #e0b0ff; }
     top: calc(50% - 68px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
-  #startLeaderboardWrap .lb-list { max-height: 112px; }
+  #startLeaderboardWrap .lb-list { max-height: none; }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 150px);

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       </div>
 
       <div id="uiBottomLeft">
-        <div>📊 FPS: <span id="fpsVal">60</span></div>
+        <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
       <!-- In-game audio toggles -->


### PR DESCRIPTION
### Motivation
- Allow the start leaderboard to fully expand instead of being artificially clipped by fixed pixel heights in various breakpoints.
- Ensure the store's floating navigation respects safe-area insets and remains visible/fixed on the `#storeScreen` overlay.
- Remove a decorative emoji from the FPS readout for a cleaner, more consistent UI.

### Description
- Changed `#startLeaderboardWrap .lb-list` to `max-height: none` and `overflow-y: visible` so the leaderboard is no longer constrained by a fixed pixel height.
- Added positioning rules for `#storeScreen .store-fixed-nav` to make it `position: fixed`, anchored using `env(safe-area-inset-top)`, and given a higher `z-index` and `transform: translateZ(0)` for stable stacking.
- Adjusted mobile breakpoint rules so the store fixed-nav uses the safe-area top inset (`top: max(...)`) and updated left offsets in smaller viewports.
- Removed the emoji from the FPS label in `index.html`, changing `📊 FPS:` to `FPS:` for a simpler display.

### Testing
- No automated tests were added or run for these UI/CSS/HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7859e46083209e950ec50fe83d68)