### PR TITLE
Improve HUD/store layout and leaderboard responsiveness; remove FPS emoji

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -715,6 +715,7 @@ body.start-launching #walletCorner {
 }
 
 #uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft > div:last-child { margin-bottom: 0; }
 #uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
 #uiTopLeft .score { color: #c084fc; font-size: 15px; }
 #uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
@@ -1696,17 +1697,17 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: 0;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: max(10px, env(safe-area-inset-bottom));
+    margin-top: 16px;
+    position: relative;
+    left: auto;
+    transform: none;
+    bottom: auto;
     width: min(94vw, 430px);
     z-index: 14;
   }
   #startLeaderboardWrap .lb-list {
-    max-height: 124px;
-    overflow-y: auto;
+    max-height: none;
+    overflow-y: visible;
   }
   .lb-title { font-size: 12px; }
   .lb-row { font-size: 11px; padding: 8px 8px; }
@@ -1720,7 +1721,7 @@ footer a:hover { color: #e0b0ff; }
   .store-tier { font-size: 9px; padding: 6px 4px; }
   #gameStart footer {
     position: relative;
-    margin-top: calc(100dvh + 80px);
+    margin-top: 20px;
     left: 0;
     right: 0;
     opacity: .6;
@@ -1728,6 +1729,13 @@ footer a:hover { color: #e0b0ff; }
   }
   .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
+  #storeScreen .store-fixed-nav {
+    position: fixed;
+    top: max(12px, env(safe-area-inset-top));
+    left: 8px;
+    z-index: 120;
+    transform: translateZ(0);
+  }
   .rules-title { font-size: 22px; }
   .rules-section-title { font-size: 12px; }
   .rules-section-text { font-size: 11px; }
@@ -1744,7 +1752,13 @@ footer a:hover { color: #e0b0ff; }
   }
 
   #gameContainer.active #uiTopLeft { transform-origin: top left; }
-  #gameContainer.active #uiTopRight { transform-origin: top right; }
+  #gameContainer.active #uiTopRight {
+    transform: scale(0.7);
+    transform-origin: top right;
+  }
+  #gameContainer.active #uiTopLeft {
+    padding: 8px 12px 5px;
+  }
 
   #gameContainer.active #uiBottomCenter {
     transform: translateX(-50%) scale(0.8);
@@ -1794,15 +1808,19 @@ footer a:hover { color: #e0b0ff; }
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: 0;
+    margin-top: 14px;
     width: min(96vw, 420px);
   }
-  #startLeaderboardWrap .lb-list { max-height: 118px; }
+  #startLeaderboardWrap .lb-list { max-height: none; }
   .go-title { font-size: 24px; }
   .go-btn { padding: 10px 20px; font-size: 11px; }
   .store-title { font-size: 18px; }
   .store-tiers { gap: 5px; }
   .store-fixed-nav { left: 6px; top: 12px; gap: 6px; }
+  #storeScreen .store-fixed-nav {
+    top: max(10px, env(safe-area-inset-top));
+    left: 6px;
+  }
   .store-nav-btn { width: 34px; height: 34px; font-size: 14px; }
   #storeScreen { padding: 15px 10px 15px 48px; }
   .store-back-fixed { left: 8px; width: 34px; height: 34px; font-size: 14px; }
@@ -1810,6 +1828,9 @@ footer a:hover { color: #e0b0ff; }
   .game-audio-btn { width: 30px; height: 30px; font-size: 12px; }
   .rules-title { font-size: 18px; }
   .rules-section-text { font-size: 10px; }
+  #storeScreen {
+    backdrop-filter: none;
+  }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 160px);
@@ -1839,7 +1860,7 @@ footer a:hover { color: #e0b0ff; }
     top: calc(50% - 68px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
-  #startLeaderboardWrap .lb-list { max-height: 112px; }
+  #startLeaderboardWrap .lb-list { max-height: none; }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 150px);

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       </div>
 
       <div id="uiBottomLeft">
-        <div>📊 FPS: <span id="fpsVal">60</span></div>
+        <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
       <!-- In-game audio toggles -->


### PR DESCRIPTION
### Motivation
- Improve mobile and small-screen layout for HUD, leaderboard and store views to avoid fixed bottom overlays, remove constrained leaderboard scrolling, and better respect safe-area insets while simplifying the FPS label.

### Description
- Add small layout fixes including `#uiTopLeft > div:last-child { margin-bottom: 0; }` and reduced padding for `#gameContainer.active #uiTopLeft` to improve HUD spacing.
- Convert `#startLeaderboardWrap` from an absolutely positioned bottom overlay into a relative/flow element and set `.lb-list` to `max-height: none; overflow-y: visible;` to show full leaderboard content.
- Replace the large off-canvas footer margin (`margin-top: calc(100dvh + 80px)`) with a normal flow margin and add a fixed `#storeScreen .store-fixed-nav` with proper top safe-area handling and `z-index` for consistent store navigation placement.
- Adjust in-game HUD scaling for `#gameContainer.active #uiTopRight` to `scale(0.7)` and refine responsive breakpoint tweaks (various `margin-top`, `max-height` removals, and `backdrop-filter` adjustments) for better mobile rendering.
- Remove the decorative emoji before the FPS label in `index.html` so the label reads `FPS: <span id="fpsVal">60</span>`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7859e46083209e950ec50fe83d68)