### PR TITLE
UI: HUD layout tweaks, responsive store/leaderboard adjustments, and compact timer formatting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -712,9 +712,12 @@ body.start-launching #walletCorner {
   border-radius: var(--radius);
   border: 1px solid var(--border);
   font-family: 'Orbitron', sans-serif;
+  width: 186px;
+  box-sizing: border-box;
 }
 
 #uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft > div:last-child { margin-bottom: 0; }
 #uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
 #uiTopLeft .score { color: #c084fc; font-size: 15px; }
 #uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
@@ -730,6 +733,8 @@ body.start-launching #walletCorner {
   border: 1px solid var(--border);
   font-family: 'Orbitron', sans-serif;
   font-size: 11px;
+  width: 138px;
+  box-sizing: border-box;
 }
 
 #uiTopRight > div {
@@ -740,7 +745,14 @@ body.start-launching #walletCorner {
 }
 
 #uiTopRight .label { opacity: 0.6; }
-#uiTopRight .value { font-weight: 700; color: #c084fc; }
+#uiTopRight .value {
+  font-weight: 700;
+  color: #c084fc;
+  min-width: 70px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 
 #uiBottomCenter {
   position: absolute;
@@ -1696,17 +1708,17 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: 0;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: max(10px, env(safe-area-inset-bottom));
+    margin-top: calc(50dvh + 70px);
+    position: relative;
+    left: auto;
+    transform: none;
+    bottom: auto;
     width: min(94vw, 430px);
     z-index: 14;
   }
   #startLeaderboardWrap .lb-list {
-    max-height: 124px;
-    overflow-y: auto;
+    max-height: none;
+    overflow-y: visible;
   }
   .lb-title { font-size: 12px; }
   .lb-row { font-size: 11px; padding: 8px 8px; }
@@ -1720,7 +1732,7 @@ footer a:hover { color: #e0b0ff; }
   .store-tier { font-size: 9px; padding: 6px 4px; }
   #gameStart footer {
     position: relative;
-    margin-top: calc(100dvh + 80px);
+    margin-top: 20px;
     left: 0;
     right: 0;
     opacity: .6;
@@ -1728,6 +1740,13 @@ footer a:hover { color: #e0b0ff; }
   }
   .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
+  #storeScreen .store-fixed-nav {
+    position: fixed;
+    top: max(12px, env(safe-area-inset-top));
+    left: 8px;
+    z-index: 120;
+    transform: translateZ(0);
+  }
   .rules-title { font-size: 22px; }
   .rules-section-title { font-size: 12px; }
   .rules-section-text { font-size: 11px; }
@@ -1744,7 +1763,13 @@ footer a:hover { color: #e0b0ff; }
   }
 
   #gameContainer.active #uiTopLeft { transform-origin: top left; }
-  #gameContainer.active #uiTopRight { transform-origin: top right; }
+  #gameContainer.active #uiTopRight {
+    transform: scale(0.7);
+    transform-origin: top right;
+  }
+  #gameContainer.active #uiTopLeft {
+    padding: 8px 12px 5px;
+  }
 
   #gameContainer.active #uiBottomCenter {
     transform: translateX(-50%) scale(0.8);
@@ -1794,15 +1819,19 @@ footer a:hover { color: #e0b0ff; }
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: 0;
+    margin-top: calc(50dvh + 56px);
     width: min(96vw, 420px);
   }
-  #startLeaderboardWrap .lb-list { max-height: 118px; }
+  #startLeaderboardWrap .lb-list { max-height: none; }
   .go-title { font-size: 24px; }
   .go-btn { padding: 10px 20px; font-size: 11px; }
   .store-title { font-size: 18px; }
   .store-tiers { gap: 5px; }
   .store-fixed-nav { left: 6px; top: 12px; gap: 6px; }
+  #storeScreen .store-fixed-nav {
+    top: max(10px, env(safe-area-inset-top));
+    left: 6px;
+  }
   .store-nav-btn { width: 34px; height: 34px; font-size: 14px; }
   #storeScreen { padding: 15px 10px 15px 48px; }
   .store-back-fixed { left: 8px; width: 34px; height: 34px; font-size: 14px; }
@@ -1810,6 +1839,9 @@ footer a:hover { color: #e0b0ff; }
   .game-audio-btn { width: 30px; height: 30px; font-size: 12px; }
   .rules-title { font-size: 18px; }
   .rules-section-text { font-size: 10px; }
+  #storeScreen {
+    backdrop-filter: none;
+  }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 160px);
@@ -1839,7 +1871,10 @@ footer a:hover { color: #e0b0ff; }
     top: calc(50% - 68px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
-  #startLeaderboardWrap .lb-list { max-height: 112px; }
+  #startLeaderboardWrap {
+    margin-top: calc(50dvh + 48px);
+  }
+  #startLeaderboardWrap .lb-list { max-height: none; }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 150px);

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       </div>
 
       <div id="uiBottomLeft">
-        <div>📊 FPS: <span id="fpsVal">60</span></div>
+        <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
       <!-- In-game audio toggles -->

--- a/js/ui.js
+++ b/js/ui.js
@@ -43,6 +43,8 @@ function hideStore() {
 }
 
 function updateUI() {
+  const formatSecondsCompact = (seconds) => `${Math.max(0, Math.ceil(Number(seconds) || 0))}s`;
+
   gameState.uiUpdateFrame++;
 
   DOM.distanceVal.textContent = Math.floor(gameState.distance);
@@ -55,19 +57,19 @@ function updateUI() {
     const totalMultiplier = (x2Active ? gameState.baseMultiplier : 1) * (invertActive ? gameState.invertScoreMultiplier : 1);
     if (x2Active || invertActive) {
       const markers = [];
-      if (x2Active) markers.push(`X2 ${gameState.x2Timer.toFixed(1)}s`);
-      if (invertActive) markers.push(`INV ${player.invertTimer.toFixed(1)}s`);
+      if (x2Active) markers.push(`X2 ${formatSecondsCompact(gameState.x2Timer)}`);
+      if (invertActive) markers.push(`INV ${formatSecondsCompact(player.invertTimer)}`);
       DOM.multiplierVal.textContent = `x${Number(totalMultiplier.toFixed(2))} (${markers.join(' · ')})`;
     } else {
       DOM.multiplierVal.textContent = "x1";
     }
-    DOM.speedVal.textContent = (gameState.speed / CONFIG.SPEED_START).toFixed(2);
+    DOM.speedVal.textContent = (gameState.speed / CONFIG.SPEED_START).toFixed(1);
   }
 
   if (gameState.uiUpdateFrame % 10 === 0) {
-    DOM.magnetVal.textContent = player.magnetActive ? `✓ ${player.magnetTimer.toFixed(1)}s` : "OFF";
-    DOM.invertVal.textContent = player.invertActive ? `INV ${player.invertTimer.toFixed(1)}s` : "OK";
-    DOM.spinVal.textContent = gameState.spinCooldown > 0 ? `⏳ ${(gameState.spinCooldown / 60).toFixed(1)}s` : "✓";
+    DOM.magnetVal.textContent = player.magnetActive ? `✓ ${formatSecondsCompact(player.magnetTimer)}` : "OFF";
+    DOM.invertVal.textContent = player.invertActive ? `INV ${formatSecondsCompact(player.invertTimer)}` : "OK";
+    DOM.spinVal.textContent = gameState.spinCooldown > 0 ? `⏳ ${formatSecondsCompact(gameState.spinCooldown / 60)}` : "✓";
     DOM.goldVal.textContent = gameState.goldCoins;
     DOM.silverVal.textContent = gameState.silverCoins;
   }


### PR DESCRIPTION
### Motivation

- Improve readability and alignment of in-game HUD values and make mobile/start screens/layouts behave more predictably. 
- Display timers and speed in a more compact, consistent format for clarity.

### Description

- Adjusted HUD CSS: added fixed widths and `box-sizing` for `#uiTopLeft` and `#uiTopRight`, improved `.value` styling with `min-width`, `text-align:right` and `font-variant-numeric: tabular-nums`, and added small padding/tweaks for active state scaling.
- Updated responsive layout rules: changed `#startLeaderboardWrap` positioning to a relative layout with `margin-top: calc(50dvh + ...)`, removed `max-height`/scrolling on leaderboard lists, adjusted `#gameStart` footer margin, and made `#storeScreen .store-fixed-nav` fixed on small screens; disabled `backdrop-filter` for very small store screens.
- Minor UI/UX tweaks: removed the leading emoji from the FPS label in `index.html` and adjusted various component sizes and transforms in mobile media queries.
- Compact timer formatting in `updateUI()` (`js/ui.js`): introduced `formatSecondsCompact` helper, switched display of power-up timers and spin cooldown to compact `Ns` format and rounded up values, and reduced speed precision from two decimals to one.

### Testing

- Ran project build and lint steps with `npm run build` and `npm run lint`, which completed successfully.
- No unit tests were modified; `npm test` returned no failing tests in the existing suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7859e46083209e950ec50fe83d68)