### PR TITLE
HUD and mobile UI overhaul: layout, styles, and compact timers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -706,30 +706,46 @@ body.start-launching #walletCorner {
   position: absolute;
   top: 12px; left: 12px;
   z-index: 10;
-  background: var(--glass);
-  backdrop-filter: blur(12px);
+  background: transparent;
+  backdrop-filter: none;
   padding: 10px 14px;
   border-radius: var(--radius);
-  border: 1px solid var(--border);
+  border: none;
   font-family: 'Orbitron', sans-serif;
+  width: 186px;
+  box-sizing: border-box;
 }
 
 #uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft > div:last-child { margin-bottom: 0; }
 #uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
 #uiTopLeft .score { color: #c084fc; font-size: 15px; }
 #uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
+#uiTopLeft .hud-main-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+#uiTopLeft .hud-main-value {
+  min-width: 92px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
 
 #uiTopRight {
   position: absolute;
   top: 12px; right: 12px;
   z-index: 10;
-  background: var(--glass);
-  backdrop-filter: blur(12px);
+  background: transparent;
+  backdrop-filter: none;
   padding: 10px 14px;
   border-radius: var(--radius);
-  border: 1px solid var(--border);
+  border: none;
   font-family: 'Orbitron', sans-serif;
   font-size: 11px;
+  width: 138px;
+  box-sizing: border-box;
 }
 
 #uiTopRight > div {
@@ -740,7 +756,14 @@ body.start-launching #walletCorner {
 }
 
 #uiTopRight .label { opacity: 0.6; }
-#uiTopRight .value { font-weight: 700; color: #c084fc; }
+#uiTopRight .value {
+  font-weight: 700;
+  color: #c084fc;
+  min-width: 70px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 
 #uiBottomCenter {
   position: absolute;
@@ -1696,17 +1719,17 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: 0;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    bottom: max(10px, env(safe-area-inset-bottom));
+    margin-top: calc(50dvh + 70px);
+    position: relative;
+    left: auto;
+    transform: none;
+    bottom: auto;
     width: min(94vw, 430px);
     z-index: 14;
   }
   #startLeaderboardWrap .lb-list {
-    max-height: 124px;
-    overflow-y: auto;
+    max-height: none;
+    overflow-y: visible;
   }
   .lb-title { font-size: 12px; }
   .lb-row { font-size: 11px; padding: 8px 8px; }
@@ -1720,7 +1743,7 @@ footer a:hover { color: #e0b0ff; }
   .store-tier { font-size: 9px; padding: 6px 4px; }
   #gameStart footer {
     position: relative;
-    margin-top: calc(100dvh + 80px);
+    margin-top: 20px;
     left: 0;
     right: 0;
     opacity: .6;
@@ -1728,6 +1751,13 @@ footer a:hover { color: #e0b0ff; }
   }
   .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
+  #storeScreen .store-fixed-nav {
+    position: fixed;
+    top: max(12px, env(safe-area-inset-top));
+    left: 8px;
+    z-index: 120;
+    transform: translateZ(0);
+  }
   .rules-title { font-size: 22px; }
   .rules-section-title { font-size: 12px; }
   .rules-section-text { font-size: 11px; }
@@ -1744,7 +1774,13 @@ footer a:hover { color: #e0b0ff; }
   }
 
   #gameContainer.active #uiTopLeft { transform-origin: top left; }
-  #gameContainer.active #uiTopRight { transform-origin: top right; }
+  #gameContainer.active #uiTopRight {
+    transform: scale(0.7);
+    transform-origin: top right;
+  }
+  #gameContainer.active #uiTopLeft {
+    padding: 8px 12px 5px;
+  }
 
   #gameContainer.active #uiBottomCenter {
     transform: translateX(-50%) scale(0.8);
@@ -1794,15 +1830,19 @@ footer a:hover { color: #e0b0ff; }
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: 0;
+    margin-top: calc(50dvh + 56px);
     width: min(96vw, 420px);
   }
-  #startLeaderboardWrap .lb-list { max-height: 118px; }
+  #startLeaderboardWrap .lb-list { max-height: none; }
   .go-title { font-size: 24px; }
   .go-btn { padding: 10px 20px; font-size: 11px; }
   .store-title { font-size: 18px; }
   .store-tiers { gap: 5px; }
   .store-fixed-nav { left: 6px; top: 12px; gap: 6px; }
+  #storeScreen .store-fixed-nav {
+    top: max(10px, env(safe-area-inset-top));
+    left: 6px;
+  }
   .store-nav-btn { width: 34px; height: 34px; font-size: 14px; }
   #storeScreen { padding: 15px 10px 15px 48px; }
   .store-back-fixed { left: 8px; width: 34px; height: 34px; font-size: 14px; }
@@ -1810,6 +1850,9 @@ footer a:hover { color: #e0b0ff; }
   .game-audio-btn { width: 30px; height: 30px; font-size: 12px; }
   .rules-title { font-size: 18px; }
   .rules-section-text { font-size: 10px; }
+  #storeScreen {
+    backdrop-filter: none;
+  }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 160px);
@@ -1839,7 +1882,10 @@ footer a:hover { color: #e0b0ff; }
     top: calc(50% - 68px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
-  #startLeaderboardWrap .lb-list { max-height: 112px; }
+  #startLeaderboardWrap {
+    margin-top: calc(50dvh + 48px);
+  }
+  #startLeaderboardWrap .lb-list { max-height: none; }
 
   #gameStart.start-launching #bear3d {
     top: calc(50% - 150px);

--- a/index.html
+++ b/index.html
@@ -53,9 +53,9 @@
     <div id="gameWrapper">
       <div id="gameContent">
       <div id="uiTopLeft">
-        <div class="speed"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -64px"></span> <span id="speedVal">1.0</span>x</div>
-        <div class="distance"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:0px 0px"></span> <span id="distanceVal">0</span>m</div>
-        <div class="score"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -32px"></span> <span id="scoreVal">0</span></div>
+        <div class="speed hud-main-row"><span class="hud-main-value"><span id="speedVal">1.0</span>x</span><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -64px"></span></div>
+        <div class="distance hud-main-row"><span class="hud-main-value"><span id="distanceVal">0</span>m</span><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:0px 0px"></span></div>
+        <div class="score hud-main-row"><span class="hud-main-value"><span id="scoreVal">0</span></span><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -32px"></span></div>
         <div style="margin-top: 8px; font-size: 11px; opacity: 0.7; border-top: 1px solid rgba(255,255,255,.06); padding-top: 6px;">
           <div id="pingDisplay" style="display: none;">🌐 Ping: <span id="pingVal">0</span>ms</div>
         </div>
@@ -85,7 +85,7 @@
       </div>
 
       <div id="uiBottomLeft">
-        <div>📊 FPS: <span id="fpsVal">60</span></div>
+        <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
       <!-- In-game audio toggles -->

--- a/js/ui.js
+++ b/js/ui.js
@@ -43,6 +43,8 @@ function hideStore() {
 }
 
 function updateUI() {
+  const formatSecondsCompact = (seconds) => `${Math.max(0, Math.ceil(Number(seconds) || 0))}s`;
+
   gameState.uiUpdateFrame++;
 
   DOM.distanceVal.textContent = Math.floor(gameState.distance);
@@ -55,19 +57,19 @@ function updateUI() {
     const totalMultiplier = (x2Active ? gameState.baseMultiplier : 1) * (invertActive ? gameState.invertScoreMultiplier : 1);
     if (x2Active || invertActive) {
       const markers = [];
-      if (x2Active) markers.push(`X2 ${gameState.x2Timer.toFixed(1)}s`);
-      if (invertActive) markers.push(`INV ${player.invertTimer.toFixed(1)}s`);
+      if (x2Active) markers.push(`X2 ${formatSecondsCompact(gameState.x2Timer)}`);
+      if (invertActive) markers.push(`INV ${formatSecondsCompact(player.invertTimer)}`);
       DOM.multiplierVal.textContent = `x${Number(totalMultiplier.toFixed(2))} (${markers.join(' · ')})`;
     } else {
       DOM.multiplierVal.textContent = "x1";
     }
-    DOM.speedVal.textContent = (gameState.speed / CONFIG.SPEED_START).toFixed(2);
+    DOM.speedVal.textContent = (gameState.speed / CONFIG.SPEED_START).toFixed(1);
   }
 
   if (gameState.uiUpdateFrame % 10 === 0) {
-    DOM.magnetVal.textContent = player.magnetActive ? `✓ ${player.magnetTimer.toFixed(1)}s` : "OFF";
-    DOM.invertVal.textContent = player.invertActive ? `INV ${player.invertTimer.toFixed(1)}s` : "OK";
-    DOM.spinVal.textContent = gameState.spinCooldown > 0 ? `⏳ ${(gameState.spinCooldown / 60).toFixed(1)}s` : "✓";
+    DOM.magnetVal.textContent = player.magnetActive ? `✓ ${formatSecondsCompact(player.magnetTimer)}` : "OFF";
+    DOM.invertVal.textContent = player.invertActive ? `INV ${formatSecondsCompact(player.invertTimer)}` : "OK";
+    DOM.spinVal.textContent = gameState.spinCooldown > 0 ? `⏳ ${formatSecondsCompact(gameState.spinCooldown / 60)}` : "✓";
     DOM.goldVal.textContent = gameState.goldCoins;
     DOM.silverVal.textContent = gameState.silverCoins;
   }


### PR DESCRIPTION
### Motivation
- Improve HUD readability and alignment by separating numeric values from icons and enforcing tabular numeric layout.
- Reduce heavy visual effects and simplify overlays for performance and consistent rendering on mobile/Telegram clients.
- Fix layout/positioning of start leaderboard and store navigation for various viewport heights and safe-area insets.

### Description
- Updated HUD markup in `index.html` to wrap speed/distance/score into `.hud-main-row` and `.hud-main-value` elements and removed an emoji from the FPS display for a cleaner label. 
- Adjusted CSS (`css/style.css`) to remove glass/backdrop styles and borders from top HUD panels, add explicit widths/box-sizing, introduce flex layout and right-aligned tabular numeric styling, and tweak numerous mobile media-query positioning values (start leaderboard margins, store nav positioning, transforms and paddings). 
- Modified timing/formatting in `js/ui.js` by adding `formatSecondsCompact` and switching several timers to compact second formatting, reducing speed display precision to one decimal place, and applying the new formatted values to multiplier/magnet/invert/spin displays.

### Testing
- Ran linting via `npm run lint`, which completed successfully. 
- Built the frontend via `npm run build`, which completed successfully and produced no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7859e46083209e950ec50fe83d68)