### PR TITLE
Fix donation card width and radar obstacle delay behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2010,7 +2010,9 @@ footer a:hover { color: #e0b0ff; }
 
 .store-donation-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: 1fr;
+  max-width: 440px;
+  margin: 0 auto;
   gap: 14px;
 }
 

--- a/js/physics-spawning.js
+++ b/js/physics-spawning.js
@@ -100,7 +100,7 @@ function createPhysicsSpawning({
     const types = ['pit', 'spikes', 'bottles', 'wall_brick', 'wall_kactus', 'tree', 'rock1', 'rock2', 'fence', 'bull'];
     const subtype = types[Math.floor(Math.random() * types.length)];
     const obstacleRadarEnabled = Boolean(gameState.radarObstaclesActive);
-    const spawnDelaySeconds = obstacleRadarEnabled ? 1.2 : 0;
+    const spawnDelaySeconds = obstacleRadarEnabled ? (2 + Math.random()) : 0;
     // Projection clamps far-depth scale for z >= ~0.95, so spawn radar-preview obstacles
     // just inside that threshold to keep them visibly inside the tube.
     const radarVisibleSpawnZ = 0.9;

--- a/js/physics.js
+++ b/js/physics.js
@@ -149,7 +149,7 @@ function update(delta) {
   const COIN_ANIM_STEP = 1 / 8;
 
   for (const o of obstacles) {
-    if ((Number(o.spawnDelayRemaining) || 0) > 0) {
+    if (gameState.radarObstaclesActive && (Number(o.spawnDelayRemaining) || 0) > 0) {
       o.spawnDelayRemaining = Math.max(0, Number(o.spawnDelayRemaining) - delta);
       continue;
     }
@@ -339,7 +339,7 @@ function update(delta) {
   // Collisions: obstacles
   for (let i = obstacles.length - 1; i >= 0; i--) {
     const o = obstacles[i];
-    if ((Number(o.spawnDelayRemaining) || 0) > 0) continue;
+    if (gameState.radarObstaclesActive && (Number(o.spawnDelayRemaining) || 0) > 0) continue;
     if (o.z >= obstacleCollisionMin && o.z <= obstacleCollisionMax && o.lane === player.lane) {
       gameState.obstacleCollisionCount += 1;
       if (player.shieldCount > 0) {

--- a/js/state.js
+++ b/js/state.js
@@ -408,12 +408,24 @@ function applyGameplayUpgradeState({
   radarObstaclesActive = false,
   spinAlertLevel = 0
 } = {}) {
+  const parseBooleanFlag = (value) => {
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'true') return true;
+      if (normalized === 'false') return false;
+      if (normalized === '1') return true;
+      if (normalized === '0') return false;
+    }
+    if (typeof value === 'number') return value >= 1;
+    return Boolean(value);
+  };
+
   player.shieldCount = Math.max(0, Number(shieldCount) || 0);
   player.shield = player.shieldCount > 0;
   gameState.spinCooldownReduction = Number(spinCooldownReduction) || 0;
   gameState.invertScoreMultiplier = Number(invertScoreMultiplier) || 1;
-  gameState.radarActive = Boolean(radarActive);
-  gameState.radarObstaclesActive = Boolean(radarObstaclesActive);
+  gameState.radarActive = parseBooleanFlag(radarActive);
+  gameState.radarObstaclesActive = parseBooleanFlag(radarObstaclesActive);
   gameState.spinAlertLevel = Math.max(0, Number(spinAlertLevel) || 0);
 }
 


### PR DESCRIPTION
### Motivation

- Donation product cards on the web store looked narrower than upgrade lots and must match the upgrade layout while keeping inner content unchanged.  
- Radar obstacle behavior was incorrect for players without the `radar_obstacles` upgrade because string boolean payloads (e.g. `"false"`) could enable radar behavior.  
- When `radar_obstacles` is enabled, obstacles should appear as a short radar-preview inside the tube for ~2–3s (optionally pulsing) before they start moving toward the player.

### Description

- Constrain the donation grid to a single centered column matching upgrade lot width by changing `.store-donation-grid` to `grid-template-columns: 1fr` with `max-width: 440px` and `margin: 0 auto` in `css/style.css`.  
- Add a robust `parseBooleanFlag` helper in `js/state.js` and use it for `gameState.radarActive` and `gameState.radarObstaclesActive` so string/number flags like `"false"` or `0` are parsed correctly.  
- Apply spawn delay only when radar obstacles are actually enabled by gating spawn-delay decrement and collision checks on `gameState.radarObstaclesActive` in `js/physics.js`.  
- Change radar-preview spawn delay to a randomized 2–3 second window by setting `spawnDelaySeconds` to `(2 + Math.random())` when `radarObstaclesActive` is true in `js/physics-spawning.js`, relying on the renderer’s existing pulsing logic for the visual effect.

### Testing

- Ran `npm run check:syntax` and it completed successfully.  
- Ran the request-suite with `npm run test:request` and all tests passed (`65` tests, `0` failures).  
- Static analysis and pre-commit checks executed during the commit and passed (`check:static-analysis` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39974b19483208ad6caf72d150711)