### PR TITLE
Fix start screen layout shift when leaderboard grows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1416,7 +1416,7 @@ body.start-launching #walletCorner {
 /* ===== FOOTER ===== */
 footer {
   position: relative;
-  margin-top: 20px;
+  margin-top: auto;
   padding-bottom: 25px;
   padding-top: 12px;
   text-align: center;
@@ -1428,6 +1428,10 @@ footer {
 
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
+
+#gameStart footer {
+  margin-top: 20px;
+}
 
 .footer-socials {
   display: flex;

--- a/css/style.css
+++ b/css/style.css
@@ -1416,7 +1416,7 @@ body.start-launching #walletCorner {
 /* ===== FOOTER ===== */
 footer {
   position: relative;
-  margin-top: auto;
+  margin-top: 20px;
   padding-bottom: 25px;
   padding-top: 12px;
   text-align: center;


### PR DESCRIPTION
### Motivation
- On the start screen the leaderboard expansion caused upper content to be pulled up because `footer` used `margin-top: auto`, but the footer should be pushed down instead.

### Description
- Replace `margin-top: auto` with a fixed `margin-top: 20px` on the `footer` selector in `css/style.css` so leaderboard growth moves content below downward rather than shifting content above.

### Testing
- Ran `npm run check:syntax` which passed, and pre-commit static analysis (`npm run check:static-analysis`) also ran and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)