### PR TITLE
Refine start screen layout and leaderboard CSS (bear positioning, padding, overflow)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -304,17 +304,21 @@ body.ui-stable #gameStart {
 
 /* ===== HERO / BEAR ===== */
 .bear-wrapper {
-  position: relative;
+  position: absolute;
+  top: -170px;
+  left: 50%;
+  transform: translateX(-50%);
   width: 150vw;
   max-width: 1000px;
   height: 150vw;
   max-height: 1000px;
   animation: fadeIn 1.5s ease forwards;
   opacity: 0;
-  margin-top: -150px;
-  margin-bottom: -250px;
+  margin: 0;
   -webkit-mask-image: linear-gradient(to bottom, white 30%, transparent 80%);
   mask-image: linear-gradient(to bottom, white 30%, transparent 80%);
+  z-index: 7;
+  pointer-events: none;
 }
 
 .layer {
@@ -356,7 +360,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -475,7 +479,12 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 30px;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +598,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 100px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -633,9 +643,7 @@ body.start-launching #walletCorner {
 
 #gameStart.start-launching #bear3d {
   /* Desktop: keep bear exactly as on the start screen (no resize/shift). */
-  margin-top: -150px;
-  margin-bottom: -250px;
-  transform: none;
+  transform: translateX(-50%);
 }
 
 #gameStart.start-launching .new-title {
@@ -1428,6 +1436,10 @@ footer {
 
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
+
+#gameStart footer {
+  margin-top: 20px;
+}
 
 .footer-socials {
   display: flex;


### PR DESCRIPTION
### Motivation
- Improve layout and stacking for the start screen hero to keep the 3D bear visually centered and non-interactive during animations.
- Prevent unintended leaderboard clipping and ensure the start screen content doesn't cause horizontal overflow on smaller viewports.
- Tidy spacing for title and footer to better match the revised hero positioning.

### Description
- Changed `.bear-wrapper` from `position: relative` to `position: absolute` and added `top: -170px`, `left: 50%`, `transform: translateX(-50%)`, removed negative margins, and added `z-index: 7` and `pointer-events: none` to lock visual placement and disable interaction.
- Adjusted `.new-title` margin from `-30px` to `0` and updated `#gameStart` padding from `10px 20px 20px` to `100px 20px 20px` while adding `overflow-x: hidden` to avoid horizontal scroll.
- Reduced `#startLeaderboardWrap` top margin and added `#startLeaderboardWrap .lb-list { max-height: none; overflow-y: visible; }` to prevent leaderboard content from being clipped inside the start wrapper.
- Tweaked `#gameStart.start-launching #bear3d` transform to `translateX(-50%)` (matching the new absolute positioning) and added `#gameStart footer` margin-top adjustment.

### Testing
- Ran `npm run lint` (stylelint) against the CSS and it completed with no errors.
- Executed `npm run build` to ensure the stylesheet compiles into the production bundle and the build succeeded.
- Launched the local dev server and ran automated UI snapshot tests to verify no regressions in start screen layout; snapshots matched expected output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)