### PR TITLE
Adjust layout/spacing for game start, leaderboard, and footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -356,7 +356,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -475,7 +475,12 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 30px;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +594,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 100px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1428,6 +1434,10 @@ footer {
 
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
+
+#gameStart footer {
+  margin-top: 20px;
+}
 
 .footer-socials {
   display: flex;


### PR DESCRIPTION
### Motivation
- Improve vertical spacing and alignment on the start screen so the title, buttons, leaderboard, and footer display more consistently. 
- Prevent unintended scrolling/overflow in the start UI and leaderboard list. 
- Make small visual/layout fixes to better center and space elements on different viewports.

### Description
- Set `.new-title` top spacing to `margin-top: 0` instead of `-30px` to correct title positioning. 
- Reduce `#startLeaderboardWrap` top margin to `30px` and add a scoped rule `#startLeaderboardWrap .lb-list { max-height: none; overflow-y: visible; }` to disable the nested leaderboard scrolling inside the start wrapper. 
- Increase `#gameStart` top padding to `100px` and add `overflow-x: hidden` to avoid horizontal overflow on the start overlay. 
- Add `#gameStart footer { margin-top: 20px; }` to provide consistent footer spacing within the start UI.

### Testing
- No automated tests were run for these stylesheet changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)