### PR TITLE
Adjust radar obstacle spawning/timing and upgrade flag parsing; center donation grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2010,7 +2010,9 @@ footer a:hover { color: #e0b0ff; }
 
 .store-donation-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: 1fr;
+  max-width: 440px;
+  margin: 0 auto;
   gap: 14px;
 }
 

--- a/js/physics-spawning.js
+++ b/js/physics-spawning.js
@@ -100,11 +100,14 @@ function createPhysicsSpawning({
     const types = ['pit', 'spikes', 'bottles', 'wall_brick', 'wall_kactus', 'tree', 'rock1', 'rock2', 'fence', 'bull'];
     const subtype = types[Math.floor(Math.random() * types.length)];
     const obstacleRadarEnabled = Boolean(gameState.radarObstaclesActive);
-    const spawnDelaySeconds = obstacleRadarEnabled ? 1.2 : 0;
+    const spawnDelaySeconds = obstacleRadarEnabled ? (2 + Math.random()) : 0;
     // Projection clamps far-depth scale for z >= ~0.95, so spawn radar-preview obstacles
     // just inside that threshold to keep them visibly inside the tube.
     const radarVisibleSpawnZ = 0.9;
-    const spawnZ = obstacleRadarEnabled ? radarVisibleSpawnZ : 1.65;
+    // Without radar obstacles upgrade, keep spawn close enough so obstacles
+    // immediately enter active motion instead of looking like a deep "preview".
+    const regularSpawnZ = 1.12;
+    const spawnZ = obstacleRadarEnabled ? radarVisibleSpawnZ : regularSpawnZ;
 
     let groupSize = 1;
     if (gameState.distance >= 1000) groupSize = Math.random() < 0.6 ? 2 : 1;
@@ -120,7 +123,7 @@ function createPhysicsSpawning({
         const testLane = availableLanes[idx];
         const obstacleZ = obstacleRadarEnabled
           ? spawnZ - i * 0.08
-          : spawnZ + i * 0.15;
+          : spawnZ + i * 0.06;
         if (!isLaneOccupied(testLane, obstacleZ)) {
           foundLane = testLane;
           availableLanes.splice(idx, 1);
@@ -135,7 +138,7 @@ function createPhysicsSpawning({
       if (foundLane !== null) {
         const obstacleZ = obstacleRadarEnabled
           ? spawnZ - i * 0.08
-          : spawnZ + i * 0.15;
+          : spawnZ + i * 0.06;
         obstacles.push({
           lane: foundLane,
           z: obstacleZ,

--- a/js/physics.js
+++ b/js/physics.js
@@ -149,7 +149,7 @@ function update(delta) {
   const COIN_ANIM_STEP = 1 / 8;
 
   for (const o of obstacles) {
-    if ((Number(o.spawnDelayRemaining) || 0) > 0) {
+    if (gameState.radarObstaclesActive && (Number(o.spawnDelayRemaining) || 0) > 0) {
       o.spawnDelayRemaining = Math.max(0, Number(o.spawnDelayRemaining) - delta);
       continue;
     }
@@ -339,7 +339,7 @@ function update(delta) {
   // Collisions: obstacles
   for (let i = obstacles.length - 1; i >= 0; i--) {
     const o = obstacles[i];
-    if ((Number(o.spawnDelayRemaining) || 0) > 0) continue;
+    if (gameState.radarObstaclesActive && (Number(o.spawnDelayRemaining) || 0) > 0) continue;
     if (o.z >= obstacleCollisionMin && o.z <= obstacleCollisionMax && o.lane === player.lane) {
       gameState.obstacleCollisionCount += 1;
       if (player.shieldCount > 0) {

--- a/js/state.js
+++ b/js/state.js
@@ -408,12 +408,24 @@ function applyGameplayUpgradeState({
   radarObstaclesActive = false,
   spinAlertLevel = 0
 } = {}) {
+  const parseBooleanFlag = (value) => {
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'true') return true;
+      if (normalized === 'false') return false;
+      if (normalized === '1') return true;
+      if (normalized === '0') return false;
+    }
+    if (typeof value === 'number') return value >= 1;
+    return Boolean(value);
+  };
+
   player.shieldCount = Math.max(0, Number(shieldCount) || 0);
   player.shield = player.shieldCount > 0;
   gameState.spinCooldownReduction = Number(spinCooldownReduction) || 0;
   gameState.invertScoreMultiplier = Number(invertScoreMultiplier) || 1;
-  gameState.radarActive = Boolean(radarActive);
-  gameState.radarObstaclesActive = Boolean(radarObstaclesActive);
+  gameState.radarActive = parseBooleanFlag(radarActive);
+  gameState.radarObstaclesActive = parseBooleanFlag(radarObstaclesActive);
   gameState.spinAlertLevel = Math.max(0, Number(spinAlertLevel) || 0);
 }
 


### PR DESCRIPTION
### Motivation
- Make obstacle spawning and preview behavior feel correct when the radar upgrade is active and avoid deep "preview" obstacles when it's not.
- Ensure upgrade flags for radar features are parsed robustly from different input types.
- Improve the donations UI layout to a compact, centered single-column list for better presentation.

### Description
- Change radar obstacle spawn timing to a randomized delay of `2 + Math.random()` seconds when radar preview is enabled and keep zero delay otherwise, and set `spawnZ` to `0.9` for radar previews and `1.12` for regular spawns instead of the previous deep `1.65` value.
- Reduce non-radar grouped obstacle depth offset from `i * 0.15` to `i * 0.06` so group members appear closer together, and only apply `spawnDelayRemaining` logic when `gameState.radarObstaclesActive` is true.
- In `applyGameplayUpgradeState`, add `parseBooleanFlag` to accept string/number/boolean representations and use it for `radarActive` and `radarObstaclesActive` instead of a plain `Boolean()` cast.
- Update CSS for `.store-donation-grid` to a single-column layout (`grid-template-columns: 1fr`), add `max-width: 440px`, and center it with `margin: 0 auto`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39974b19483208ad6caf72d150711)