### PR TITLE
Adjust start screen spacing, leaderboard list height, and overflow in CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -356,7 +356,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -475,7 +475,12 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 30px;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: 252px;
+  overflow-y: auto;
 }
 
 .lb-title {
@@ -589,8 +594,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 100px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1428,6 +1434,10 @@ footer {
 
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
+
+#gameStart footer {
+  margin-top: 20px;
+}
 
 .footer-socials {
   display: flex;


### PR DESCRIPTION
### Motivation
- Improve layout and scrolling behavior on the start screen by adjusting title and wrapper spacing and constraining the leaderboard list height for smaller viewports.

### Description
- Update `css/style.css` to set `.new-title` `margin-top` to `0`, reduce `#startLeaderboardWrap` margin-top to `30px`, add `#startLeaderboardWrap .lb-list { max-height: 252px; overflow-y: auto; }`, increase `#gameStart` top padding to `100px` and add `overflow-x: hidden`, and add `#gameStart footer { margin-top: 20px; }` to tidy footer spacing.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)