### PR TITLE
Adjust start screen layout and leaderboard overflow in CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -356,7 +356,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -478,6 +478,11 @@ body.ui-stable #gameStart {
   margin-top: 44px;
 }
 
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
+}
+
 .lb-title {
   text-align: center;
   font-family: 'Orbitron', sans-serif;
@@ -589,8 +594,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 140px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1428,6 +1434,10 @@ footer {
 
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
+
+#gameStart footer {
+  margin-top: 20px;
+}
 
 .footer-socials {
   display: flex;


### PR DESCRIPTION
### Motivation

- Fix visual layout and scrolling issues on the start screen and leaderboard by adjusting spacing and overflow behavior.

### Description

- Set `.new-title` top margin to `0` (was `-30px`) to correct title positioning.
- Allow the leaderboard list to expand inside the start wrapper by adding `#startLeaderboardWrap .lb-list { max-height: none; overflow-y: visible; }`.
- Increase top padding for the start overlay with `#gameStart { padding: 140px 20px 20px; }` and prevent horizontal scrolling by adding `overflow-x: hidden`.
- Add `#gameStart footer { margin-top: 20px; }` to give footer consistent spacing inside the start overlay.

### Testing

- Ran `stylelint` on the CSS and it passed without errors.
- Performed a build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)