### PR TITLE
Adjust start screen layout, stacking and overflow for leaderboard, buttons, and footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -356,7 +356,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -378,6 +378,8 @@ body.ui-stable #gameStart {
   max-width: 420px;
   min-height: 172px;
   padding: 0 20px;
+  position: relative;
+  z-index: 12;
 }
 
 .btn-new {
@@ -401,6 +403,7 @@ body.ui-stable #gameStart {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
 }
 
 .btn-new:hover {
@@ -428,6 +431,8 @@ body.ui-stable #gameStart {
   gap: 4px;
   visibility: hidden;
   opacity: 0;
+  position: relative;
+  z-index: 13;
 }
 
 #ridesInfo.visible {
@@ -475,7 +480,14 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 120px;
+  position: relative;
+  z-index: 8;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +601,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 140px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1428,6 +1441,10 @@ footer {
 
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
+
+#gameStart footer {
+  margin-top: 20px;
+}
 
 .footer-socials {
   display: flex;


### PR DESCRIPTION
### Motivation
- Improve spacing and visual stacking on the game start screen so title, buttons, leaderboard and footer do not overlap and display correctly over background elements.
- Ensure interactive elements remain visible and animated layering behaves consistently across screen sizes by tweaking z-index and overflow rules.

### Description
- Remove negative top margin on `.new-title` and increase top padding of `#gameStart` to create consistent top spacing.
- Make `.new-buttons`, `#ridesInfo`, and `#startLeaderboardWrap` positioned with explicit `z-index` values to fix stacking order, and set `.btn-new` to full `opacity` to ensure visibility.
- Raise `#startLeaderboardWrap` margin and override `.lb-list` to remove max-height and allow visible overflow for the start leaderboard area.
- Add `overflow-x: hidden` to `#gameStart` and adjust footer spacing with a small `#gameStart footer` margin tweak.

### Testing
- Ran the front-end build with `npm run build` and the build completed successfully.
- Executed the project's automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)