### PR TITLE
Adjust start screen layout, z-index and overflow for leaderboard and start UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -356,7 +356,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -378,6 +378,8 @@ body.ui-stable #gameStart {
   max-width: 420px;
   min-height: 172px;
   padding: 0 20px;
+  position: relative;
+  z-index: 12;
 }
 
 .btn-new {
@@ -401,6 +403,7 @@ body.ui-stable #gameStart {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
 }
 
 .btn-new:hover {
@@ -428,6 +431,8 @@ body.ui-stable #gameStart {
   gap: 4px;
   visibility: hidden;
   opacity: 0;
+  position: relative;
+  z-index: 13;
 }
 
 #ridesInfo.visible {
@@ -475,7 +480,14 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 32px;
+  position: relative;
+  z-index: 8;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +601,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 190px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1429,6 +1442,10 @@ footer {
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
 
+#gameStart footer {
+  margin-top: 20px;
+}
+
 .footer-socials {
   display: flex;
   justify-content: center;
@@ -1703,7 +1720,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 0;
     gap: 12px;
     position: absolute;
-    top: calc(50% - 48px);
+    top: calc(50% - 20px);
     left: 0;
     right: 0;
     margin-left: auto;
@@ -1735,7 +1752,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 70px);
+    margin-top: calc(50dvh + 130px);
     position: relative;
     left: auto;
     transform: none;
@@ -1840,12 +1857,12 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 60px);
+    top: calc(50% - 30px);
   } 
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 56px);
+    margin-top: calc(50dvh + 118px);
     width: min(96vw, 420px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
@@ -1894,11 +1911,11 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 68px);
+    top: calc(50% - 36px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 48px);
+    margin-top: calc(50dvh + 108px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
 


### PR DESCRIPTION
### Motivation
- Improve visual stacking and spacing of the start screen so title, buttons, leaderboard and footer render reliably across viewports.
- Prevent leaderboard list clipping and horizontal overflow by ensuring proper overflow, sizing and z-index behavior.
- Tweak mobile breakpoints so the bear/title/buttons/leaderboard positions look correct on small screens.

### Description
- Updated spacing on start UI elements by changing `.new-title` `margin-top` to `0`, increasing `#gameStart` top padding, and adjusting multiple `top`/`margin-top` values in responsive rules. 
- Added `position: relative` and `z-index` adjustments to `.new-buttons`, `#ridesInfo`, and `#startLeaderboardWrap`, and set `.btn-new` `opacity: 1` to ensure correct stacking and visibility. 
- Fixed leaderboard scrolling and clipping by overriding `.lb-list` in the start wrap to `max-height: none` and `overflow-y: visible`, and added `overflow-x: hidden` to `#gameStart` to prevent horizontal scroll. 
- Minor footer spacing and other small layout tweaks across breakpoints for consistent rendering. 

### Testing
- Ran CSS linting via `stylelint` and the dev build via `npm run build`, and both completed successfully. 
- Performed automated responsive build checks (CI) to ensure no stylesheet compilation errors, which passed. 
- No JS unit tests were modified in this change and existing test suites remained green in the CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)