### PR TITLE
Adjust start screen layout, stacking and leaderboard spacing in CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -356,7 +356,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -378,6 +378,8 @@ body.ui-stable #gameStart {
   max-width: 420px;
   min-height: 172px;
   padding: 0 20px;
+  position: relative;
+  z-index: 12;
 }
 
 .btn-new {
@@ -401,6 +403,7 @@ body.ui-stable #gameStart {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
 }
 
 .btn-new:hover {
@@ -421,13 +424,16 @@ body.ui-stable #gameStart {
 
 #ridesInfo {
   margin-top: 8px;
-  min-height: 40px;
+  min-height: 52px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
   visibility: hidden;
   opacity: 0;
+  position: relative;
+  z-index: 13;
+  padding-bottom: 8px;
 }
 
 #ridesInfo.visible {
@@ -475,7 +481,14 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 56px;
+  position: relative;
+  z-index: 8;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +602,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 220px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1429,6 +1443,10 @@ footer {
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
 
+#gameStart footer {
+  margin-top: 20px;
+}
+
 .footer-socials {
   display: flex;
   justify-content: center;
@@ -1703,7 +1721,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 0;
     gap: 12px;
     position: absolute;
-    top: calc(50% - 48px);
+    top: calc(50% - 20px);
     left: 0;
     right: 0;
     margin-left: auto;
@@ -1717,7 +1735,8 @@ footer a:hover { color: #e0b0ff; }
     transform: none;
     margin-top: 4px;
     width: 100%;
-    min-height: 0;
+    min-height: 56px;
+    padding-bottom: 8px;
     text-align: center;
   }
 
@@ -1735,7 +1754,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 70px);
+    margin-top: calc(50dvh + 130px);
     position: relative;
     left: auto;
     transform: none;
@@ -1840,12 +1859,12 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 60px);
+    top: calc(50% - 30px);
   } 
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 56px);
+    margin-top: calc(50dvh + 118px);
     width: min(96vw, 420px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
@@ -1894,11 +1913,11 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 68px);
+    top: calc(50% - 36px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 48px);
+    margin-top: calc(50dvh + 108px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
 


### PR DESCRIPTION
### Motivation
- Improve spacing and stacking of start-screen elements to prevent overlap and ensure the leaderboard and buttons are visible across viewports.
- Fix overflow and positioning issues that caused UI elements to clip or render behind other layers on mobile and desktop.
- Harmonize z-index and padding so interactive controls remain accessible when the start screen is shown.

### Description
- Updated `.new-title` to remove negative top margin by changing `margin-top: -30px` to `margin-top: 0` to stabilize heading placement.
- Made `.new-buttons` `position: relative` and raised z-index to keep buttons above background layers and set explicit `opacity: 1` for consistency.
- Increased `#ridesInfo` `min-height` and added `position: relative`, `z-index`, and `padding-bottom` to avoid clipping and improve spacing.
- Adjusted `#startLeaderboardWrap` top margins across base and responsive rules, added `position: relative` and `z-index`, and allowed its `.lb-list` to be non-scrolling by setting `max-height: none` and `overflow-y: visible` in relevant contexts.
- Increased top padding of `#gameStart` from `10px` to `220px` and disabled horizontal scrolling with `overflow-x: hidden` to prevent content overflow on small viewports.
- Minor footer and responsive tweaks including footer margin for `#gameStart`, and updated several responsive `top` and `margin-top` offsets for `.new-buttons` and `#startLeaderboardWrap` to align elements across breakpoints.

### Testing
- Ran CSS linting with `stylelint` on modified files, which completed without errors.
- Performed a local build with `npm run build`, and the build succeeded with no style-related failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)