### PR TITLE
Tweak start screen layout: center hero, adjust spacing, z-index and overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -313,6 +313,8 @@ body.ui-stable #gameStart {
   opacity: 0;
   margin-top: -150px;
   margin-bottom: -250px;
+  margin-left: auto;
+  margin-right: auto;
   -webkit-mask-image: linear-gradient(to bottom, white 30%, transparent 80%);
   mask-image: linear-gradient(to bottom, white 30%, transparent 80%);
 }
@@ -356,7 +358,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -378,6 +380,8 @@ body.ui-stable #gameStart {
   max-width: 420px;
   min-height: 172px;
   padding: 0 20px;
+  position: relative;
+  z-index: 12;
 }
 
 .btn-new {
@@ -401,6 +405,7 @@ body.ui-stable #gameStart {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
 }
 
 .btn-new:hover {
@@ -421,13 +426,16 @@ body.ui-stable #gameStart {
 
 #ridesInfo {
   margin-top: 8px;
-  min-height: 40px;
+  min-height: 52px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
   visibility: hidden;
   opacity: 0;
+  position: relative;
+  z-index: 13;
+  padding-bottom: 8px;
 }
 
 #ridesInfo.visible {
@@ -475,7 +483,14 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 56px;
+  position: relative;
+  z-index: 8;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +604,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 220px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -1429,6 +1445,10 @@ footer {
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
 
+#gameStart footer {
+  margin-top: 20px;
+}
+
 .footer-socials {
   display: flex;
   justify-content: center;
@@ -1703,7 +1723,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 0;
     gap: 12px;
     position: absolute;
-    top: calc(50% - 48px);
+    top: calc(50% - 20px);
     left: 0;
     right: 0;
     margin-left: auto;
@@ -1717,7 +1737,8 @@ footer a:hover { color: #e0b0ff; }
     transform: none;
     margin-top: 4px;
     width: 100%;
-    min-height: 0;
+    min-height: 56px;
+    padding-bottom: 8px;
     text-align: center;
   }
 
@@ -1735,7 +1756,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 70px);
+    margin-top: calc(50dvh + 130px);
     position: relative;
     left: auto;
     transform: none;
@@ -1840,12 +1861,12 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 60px);
+    top: calc(50% - 30px);
   } 
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 56px);
+    margin-top: calc(50dvh + 118px);
     width: min(96vw, 420px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
@@ -1894,11 +1915,11 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 68px);
+    top: calc(50% - 36px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 48px);
+    margin-top: calc(50dvh + 108px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
 


### PR DESCRIPTION
### Motivation

- Improve the visual layout and stacking of the start screen hero, title, buttons and leaderboard to avoid clipping, horizontal overflow and overlapping elements across breakpoints. 

### Description

- Center the hero `.bear-wrapper` horizontally and apply mask adjustments by adding `margin-left: auto` and `margin-right: auto`, and set explicit `opacity` on `.btn-new` for consistency. 
- Adjust spacing and stacking: reset `.new-title` top margin, add `position`/`z-index` to `.new-buttons`, `#ridesInfo`, and `#startLeaderboardWrap`, and increase several `min-height`/`padding` values to prevent content overlap. 
- Increase `#gameStart` top padding and set `overflow-x: hidden` to eliminate unwanted horizontal scrolling, and move footer margin for consistent spacing. 
- Make the leaderboard `.lb-list` non-scrollable in the start layout by removing the `max-height` and `overflow-y` in the start wrapper, and update various responsive `top` and `margin-top` calculations for mobile breakpoints to maintain proper vertical spacing. 

### Testing

- Ran `npm run build` to verify the stylesheet compiles and the production bundle builds successfully, and it passed. 
- Ran `npm test` (unit checks) and `stylelint` for CSS linting, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)