### PR TITLE
Adjust start screen CSS: centering, spacing, z-index, and responsive behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -313,6 +313,8 @@ body.ui-stable #gameStart {
   opacity: 0;
   margin-top: -150px;
   margin-bottom: -250px;
+  margin-left: auto;
+  margin-right: auto;
   -webkit-mask-image: linear-gradient(to bottom, white 30%, transparent 80%);
   mask-image: linear-gradient(to bottom, white 30%, transparent 80%);
 }
@@ -356,7 +358,7 @@ body.ui-stable #gameStart {
   min-height: 64px;
   font-weight: 700;
   letter-spacing: 2px;
-  margin-top: -30px;
+  margin-top: 0;
   position: relative;
   z-index: 10;
   background: var(--grad);
@@ -378,6 +380,8 @@ body.ui-stable #gameStart {
   max-width: 420px;
   min-height: 172px;
   padding: 0 20px;
+  position: relative;
+  z-index: 12;
 }
 
 .btn-new {
@@ -401,6 +405,7 @@ body.ui-stable #gameStart {
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
 }
 
 .btn-new:hover {
@@ -421,13 +426,16 @@ body.ui-stable #gameStart {
 
 #ridesInfo {
   margin-top: 8px;
-  min-height: 40px;
+  min-height: 52px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
   visibility: hidden;
   opacity: 0;
+  position: relative;
+  z-index: 13;
+  padding-bottom: 8px;
 }
 
 #ridesInfo.visible {
@@ -475,7 +483,14 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 56px;
+  position: relative;
+  z-index: 8;
+}
+
+#startLeaderboardWrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .lb-title {
@@ -589,8 +604,9 @@ body.ui-stable #gameStart {
   justify-content: flex-start;
   z-index: 100;
   flex-direction: column;
-  padding: 10px 20px 20px;
+  padding: 220px 20px 20px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #gameStart.hidden { display: none; }
@@ -635,6 +651,8 @@ body.start-launching #walletCorner {
   /* Desktop: keep bear exactly as on the start screen (no resize/shift). */
   margin-top: -150px;
   margin-bottom: -250px;
+  margin-left: auto;
+  margin-right: auto;
   transform: none;
 }
 
@@ -1005,6 +1023,10 @@ body.start-launching #walletCorner {
 }
 
 .go-lb-wrap .lb { margin-top: 0; max-width: 100%; }
+.go-lb-wrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
+}
 
 /* ===== STORE ===== */
 #storeScreen {
@@ -1429,6 +1451,10 @@ footer {
 footer a { color: #c084fc; text-decoration: none; transition: .3s; }
 footer a:hover { color: #e0b0ff; }
 
+#gameStart footer {
+  margin-top: 20px;
+}
+
 .footer-socials {
   display: flex;
   justify-content: center;
@@ -1703,7 +1729,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 0;
     gap: 12px;
     position: absolute;
-    top: calc(50% - 48px);
+    top: calc(50% - 20px);
     left: 0;
     right: 0;
     margin-left: auto;
@@ -1717,7 +1743,8 @@ footer a:hover { color: #e0b0ff; }
     transform: none;
     margin-top: 4px;
     width: 100%;
-    min-height: 0;
+    min-height: 56px;
+    padding-bottom: 8px;
     text-align: center;
   }
 
@@ -1735,7 +1762,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 70px);
+    margin-top: calc(50dvh + 130px);
     position: relative;
     left: auto;
     transform: none;
@@ -1840,12 +1867,12 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 60px);
+    top: calc(50% - 30px);
   } 
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 56px);
+    margin-top: calc(50dvh + 118px);
     width: min(96vw, 420px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
@@ -1894,11 +1921,11 @@ footer a:hover { color: #e0b0ff; }
   }
   .new-buttons {
     margin-top: 0;
-    top: calc(50% - 68px);
+    top: calc(50% - 36px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 48px);
+    margin-top: calc(50dvh + 108px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
 
@@ -2010,7 +2037,7 @@ footer a:hover { color: #e0b0ff; }
 
 .store-donation-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(560px, 100%), 1fr));
   gap: 14px;
 }
 


### PR DESCRIPTION
### Motivation
- Improve layout and visual stability of the start screen and hero area by fixing centering, stacking, and spacing issues across viewports.
- Ensure leaderboard and other lists expand properly without unwanted internal scrollbars and make CTA and info blocks visible and correctly layered.

### Description
- Centered the hero by adding horizontal auto margins to `.bear-wrapper` and to the start-launching state, and removed negative top offsets and adjusted padding for `#gameStart` to position content lower (`padding: 220px 20px 20px`) and prevent horizontal overflow (`overflow-x: hidden`).
- Updated rides/info/button layout by resetting `.new-title` `margin-top`, ensuring `.btn-new` opacity, enlarging `#ridesInfo` `min-height` and adding `position`/`z-index` and `padding-bottom` to improve stacking and visibility.
- Removed constrained heights and internal scrolls on leaderboard and related lists by setting `.lb-list` and other list containers to `max-height: none` and `overflow-y: visible` in relevant contexts, and increased top margins for `#startLeaderboardWrap` across breakpoints to avoid overlap with hero elements.
- Tweaked responsive offsets for `.new-buttons` and `#startLeaderboardWrap` across mobile breakpoints, adjusted footer spacing in `#gameStart`, and changed the donation grid column formula to `grid-template-columns: repeat(auto-fit, minmax(min(560px, 100%), 1fr))` for better wide-card layouts.

### Testing
- Ran `stylelint` against the modified CSS and it passed without errors.
- Built the application with `npm run build` to verify CSS compiles into the production bundle and the build completed successfully.
- Executed the test suite with `npm test` and unit tests passed (no regressions detected related to layout selectors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39a54a5788320973fe03b9b96f4ba)