### PR TITLE
Onboarding first-run UI, start button edge pulse, and layout offset adjustments

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -31,6 +31,7 @@
   --sab: env(safe-area-inset-bottom, 0px);
   --sal: env(safe-area-inset-left, 0px);
   --sar: env(safe-area-inset-right, 0px);
+  --start-ui-offset-y: 100px;
 }
 
 * {
@@ -188,6 +189,18 @@ input:checked + .slider:before {
 .wallet-btn-corner.connected:hover {
   border-color: rgba(255, 100, 100, .4);
   box-shadow: 0 0 12px rgba(255, 100, 100, .15);
+}
+
+body.onboarding-first-run .wallet-btn-corner:not(.connected) {
+  opacity: .55;
+  border-color: rgba(140, 80, 255, .2);
+  background: rgba(255, 255, 255, .04);
+  box-shadow: none;
+}
+
+body.onboarding-first-run .wallet-btn-corner:not(.connected):hover {
+  transform: none;
+  box-shadow: 0 0 10px rgba(140, 80, 255, .1);
 }
 
 .wallet-info {
@@ -470,6 +483,27 @@ body.ui-stable #gameStart {
   box-shadow: 0 0 12px rgba(96, 165, 250, .5);
 }
 
+#startBtn {
+  min-height: 73px;
+  padding: 21px 40px;
+  font-size: 18px;
+}
+
+#startBtn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(120deg, rgba(129, 140, 248, .2), rgba(129, 140, 248, .85), rgba(192, 132, 252, .8), rgba(129, 140, 248, .2));
+  background-size: 200% 200%;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: startButtonEdgePulse 2.8s linear infinite;
+  pointer-events: none;
+}
+
 .btn-new.connected {
   border-color: rgba(140, 80, 255, .4);
   box-shadow: 0 0 12px rgba(140, 80, 255, .15);
@@ -572,6 +606,12 @@ body.ui-stable #gameStart {
   font-family: 'Orbitron', sans-serif;
 }
 
+@keyframes startButtonEdgePulse {
+  0% { background-position: 0% 50%; opacity: .45; }
+  50% { background-position: 100% 50%; opacity: .95; }
+  100% { background-position: 0% 50%; opacity: .45; }
+}
+
 /* Skeleton */
 @keyframes shimmer {
   0% { background-position: -200% 0; }
@@ -615,6 +655,10 @@ body.ui-stable #gameStart {
 }
 
 #gameStart.hidden { display: none; }
+
+#gameStart > :not(.bear-wrapper) {
+  transform: translateY(var(--start-ui-offset-y));
+}
 
 .start-audio-nav {
   display: none;
@@ -663,13 +707,13 @@ body.start-launching #walletCorner {
 
 #gameStart.start-launching .new-title {
   margin-top: 8px;
-  transform: translateY(56px);
+  transform: translateY(calc(56px + var(--start-ui-offset-y)));
 }
 
 #gameStart.start-launching .new-buttons,
 #gameStart.start-launching #startLeaderboardWrap,
 #gameStart.start-launching footer {
-  transform: translateY(220px);
+  transform: translateY(calc(220px + var(--start-ui-offset-y)));
   opacity: 0;
   pointer-events: none;
 }
@@ -1491,14 +1535,20 @@ footer a:hover { color: #e0b0ff; }
   font-family: 'Orbitron', sans-serif;
   font-size: 12px;
   font-weight: 600;
-  color: rgba(255, 255, 255, .5);
+  color: rgba(255, 255, 255, .95);
   cursor: pointer;
   margin-bottom: 10px;
-  transition: color .3s, text-shadow .3s;
+  transition: color .2s ease, opacity .2s ease, box-shadow .2s ease, border-color .2s ease;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(192, 132, 252, .45);
+  background: rgba(192, 132, 252, .1);
+  box-shadow: 0 0 14px rgba(192, 132, 252, .2);
 }
 .footer-rules-link:hover {
-  color: #c084fc;
-  text-shadow: 0 0 10px rgba(192, 132, 252, .3);
+  color: #f3e8ff;
+  border-color: rgba(192, 132, 252, .9);
+  box-shadow: 0 0 18px rgba(192, 132, 252, .35);
 }
 
 /* ===== RULES OVERLAY ===== */
@@ -1760,6 +1810,7 @@ footer a:hover { color: #e0b0ff; }
   }
 
   .btn-new { min-height: 50px; padding: 13px 25px; font-size: 13px; }
+  #startBtn { min-height: 65px; padding: 17px 25px; font-size: 16px; }
   .lb {
     max-width: 92%;
     padding: 12px 14px 10px;
@@ -1874,6 +1925,7 @@ footer a:hover { color: #e0b0ff; }
     top: calc(50% - 30px);
   } 
   .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
+  #startBtn { min-height: 60px; padding: 15px 20px; font-size: 15px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
     margin-top: calc(50dvh + 118px);
@@ -1928,6 +1980,7 @@ footer a:hover { color: #e0b0ff; }
     top: calc(50% - 36px);
   }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
+  #startBtn { min-height: 55px; padding: 13px 15px; font-size: 14px; }
   #startLeaderboardWrap {
     margin-top: calc(50dvh + 108px);
   }

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -12,10 +12,20 @@ import { initializeMetaMaskIntegration } from './integrations/metamask.js';
 import { logger } from '../logger.js';
 import { notifyError } from '../notifier.js';
 import { initAiMode } from '../ai-mode.js';
+import { shouldShowFirstRunHint } from './onboarding-hints.js';
 
 let cleanupPingLifecycle = () => {};
 let uiEventHandlersBound = false;
 let visibilityAudioLifecycleBound = false;
+
+
+function syncFirstRunOnboardingUiState() {
+  if (typeof document === 'undefined') return;
+
+  const storage = typeof window !== 'undefined' ? window.localStorage : null;
+  const isFirstRun = shouldShowFirstRunHint(storage);
+  document.body.classList.toggle('onboarding-first-run', isFirstRun);
+}
 
 async function resetAuthenticatedUiState() {
   resetWalletPlayerUI();
@@ -120,6 +130,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
   });
   logger.info('🔐 Authenticating...');
   await initAuth();
+  syncFirstRunOnboardingUiState();
 
   if (!isAuthenticated()) {
     await loadUnauthGameConfig();

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -281,6 +281,9 @@ function createGameSessionController({
           }
         }, timelineTotalMs + 300);
         markFirstRunHintShown(storage);
+        if (typeof document !== 'undefined') {
+          document.body.classList.remove('onboarding-first-run');
+        }
         trackAnalyticsEvent('onboarding_hint_shown', {
           hints: timeline.length,
           input_profile: inputProfile


### PR DESCRIPTION
### Motivation
- Introduce a lightweight first-run onboarding visual state and ensure onboarding hints are reflected in the UI during startup and when the in-game hint timeline runs.
- Improve the visual prominence and polish of the start button with an animated edge/pulse and make start-screen components respect a configurable vertical offset for smoother launch animations.
- Tweak start/rules/footer and wallet corner visuals for a more cohesive initial-screen appearance across responsive sizes.

### Description
- Added a new CSS variable `--start-ui-offset-y` and applied translateY offsets to `#gameStart` children and `start-launching` transforms so launch animations include the configurable offset.
- Introduced `body.onboarding-first-run` styles to visually de-emphasize the wallet corner when onboarding is active and remove the hover transform to reduce distraction.
- Implemented a pulsing edge effect for `#startBtn` via `#startBtn::before` and `@keyframes startButtonEdgePulse`, and added responsive size adjustments for `#startBtn` across breakpoints.
- Updated `.footer-rules-link` styling with higher contrast, padding, border and background to match updated visual language.
- In `js/game/bootstrap.js` imported `shouldShowFirstRunHint` and added `syncFirstRunOnboardingUiState()` to toggle the `onboarding-first-run` body class during bootstrap initialization.
- In `js/game/session.js` removed `onboarding-first-run` from the body when the onboarding hint timeline is shown and marked as displayed to clear the first-run state once hints are presented.

### Testing
- Ran the project build with `npm run build` which completed successfully.
- Ran the linter with `npm run lint` which completed successfully.
- Performed a local UI smoke check to verify that the `onboarding-first-run` class is applied on startup and removed after the in-game hints run and that the `#startBtn` pulse and layout offsets behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc2dbf3808320827e0f5e739e103a)