### PR TITLE
Improve main menu spacing, boost START CTA visuals, and simplify Game Over summary

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -444,7 +444,7 @@ body.ui-stable #gameStart {
 
 #ridesInfo {
   margin-top: 8px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
   min-height: 52px;
   display: flex;
   flex-direction: column;
@@ -488,6 +488,11 @@ body.ui-stable #gameStart {
   min-height: 73px;
   padding: 21px 40px;
   font-size: 18px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, .26) 0%, rgba(255, 255, 255, 0) 48%),
+    linear-gradient(120deg, rgba(99, 102, 241, .58), rgba(192, 132, 252, .58));
+  box-shadow: 0 0 24px rgba(129, 140, 248, .36), 0 0 46px rgba(192, 132, 252, .28);
+  animation: startButtonGlowBoost 1.35s ease-in-out infinite;
 }
 
 #startBtn::before {
@@ -523,7 +528,7 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 56px;
+  margin-top: 20px;
   position: relative;
   z-index: 8;
 }
@@ -611,6 +616,17 @@ body.ui-stable #gameStart {
   0% { background-position: 0% 50%; opacity: .45; }
   50% { background-position: 100% 50%; opacity: .95; }
   100% { background-position: 0% 50%; opacity: .45; }
+}
+
+@keyframes startButtonGlowBoost {
+  0%, 100% {
+    transform: translateY(0);
+    box-shadow: 0 0 24px rgba(129, 140, 248, .32), 0 0 44px rgba(192, 132, 252, .24);
+  }
+  50% {
+    transform: translateY(-2px) scale(1.02);
+    box-shadow: 0 0 34px rgba(129, 140, 248, .52), 0 0 62px rgba(244, 114, 182, .42);
+  }
 }
 
 /* Skeleton */
@@ -1011,8 +1027,16 @@ body.start-launching #walletCorner {
 }
 
 .go-next-target {
-  color: rgba(255, 255, 255, 0.76);
+  color: #ffffff;
   margin-bottom: 20px;
+  border: 1px solid rgba(248, 113, 113, .72);
+  border-radius: 14px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, rgba(239, 68, 68, .18), rgba(192, 132, 252, .22));
+  box-shadow: 0 0 26px rgba(248, 113, 113, .24);
+  font-weight: 700;
+  letter-spacing: .4px;
+  text-shadow: 0 0 12px rgba(255, 255, 255, .28);
 }
 
 .go-stats {
@@ -1043,6 +1067,33 @@ body.start-launching #walletCorner {
 .go-stat-value { font-weight: 700; color: #c084fc; }
 .go-stat-value.coins-gold { color: #fbbf24; }
 .go-stat-value.coins-silver { color: #94a3b8; }
+.go-stat-coins {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.go-coins-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 13px;
+}
+
+.go-coins-pill-gold {
+  color: #fef3c7;
+  border: 1px solid rgba(251, 191, 36, .52);
+  background: rgba(251, 191, 36, .16);
+}
+
+.go-coins-pill-silver {
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, .58);
+  background: rgba(148, 163, 184, .16);
+}
 
 .go-buttons {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -161,10 +161,6 @@
 
   <div class="go-title" id="goTitle">GAME OVER</div>
 
-  <div class="go-reason">
-    <span class="go-reason-text" id="goReason"></span>
-  </div>
-
   <div class="go-score-hero">
     <div class="go-score-label">SCORE</div>
     <div class="go-score-value" id="goHeroScore">0</div>
@@ -175,24 +171,11 @@
 
   <div class="go-stats">
     <div class="go-stat-row">
-      <span class="go-stat-label"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:0px 0px"></span> Distance</span>
-      <span class="go-stat-value" id="goDistance">0 m</span>
-    </div>
-    <div class="go-stat-row">
-      <span class="go-stat-label"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-128px -32px"></span> Score</span>
-      <span class="go-stat-value" id="goScore">0</span>
-    </div>
-    <div class="go-stat-row">
-      <span class="go-stat-label"><img src="img/icon_gold.png" style="width: 18px; height: 18px; vertical-align: middle;"> Gold</span>
-      <span class="go-stat-value coins-gold" id="goGold">0</span>
-    </div>
-    <div class="go-stat-row">
-      <span class="go-stat-label"><img src="img/icon_silver.png" style="width: 18px; height: 18px; vertical-align: middle;"> Silver</span>
-      <span class="go-stat-value coins-silver" id="goSilver">0</span>
-    </div>
-    <div class="go-stat-row">
-      <span class="go-stat-label"><span class="icon-atlas" style="width:32px;height:32px;background-size:160px auto;background-position:-64px -32px"></span> Time</span>
-      <span class="go-stat-value" id="goTime">0s</span>
+      <span class="go-stat-label">Collected coins</span>
+      <span class="go-stat-value go-stat-coins">
+        <span class="go-coins-pill go-coins-pill-gold"><img src="img/icon_gold.png" style="width: 18px; height: 18px; vertical-align: middle;"> <span id="goGold">0</span></span>
+        <span class="go-coins-pill go-coins-pill-silver"><img src="img/icon_silver.png" style="width: 18px; height: 18px; vertical-align: middle;"> <span id="goSilver">0</span></span>
+      </span>
     </div>
   </div>
 

--- a/js/game/game-over-copy.js
+++ b/js/game/game-over-copy.js
@@ -23,23 +23,23 @@ function buildNextTargetCopy({ score, rankPosition, entries }) {
       const targetRank = rankPosition >= 9 ? 7 : Math.max(1, rankPosition - 1);
       const targetScore = getTopScoreByRank(entries, targetRank);
       if (targetScore && targetScore > scoreNow) {
-        return `Next: +${Math.max(1, targetScore - scoreNow)} to TOP ${targetRank}.`;
+        return `🔥 Push now: +${Math.max(1, targetScore - scoreNow)} to take TOP ${targetRank}!`;
       }
-      return 'Top 10 locked in — chase a higher place!';
+      return '🔥 Top 10 is yours — attack the next place!';
     }
-    if (rankPosition <= 100) return 'Next goal: push into TOP 10.';
-    if (rankPosition <= 1000) return 'Next goal: push into TOP 100.';
-    if (rankPosition <= 10000) return 'Next goal: push into TOP 1000.';
-    return 'Next goal: enter TOP 10000.';
+    if (rankPosition <= 100) return '⚡ One more run: break into TOP 10!';
+    if (rankPosition <= 1000) return '⚡ Keep momentum: storm TOP 100!';
+    if (rankPosition <= 10000) return '⚡ Full throttle: enter TOP 1000!';
+    return '⚡ Start your climb: enter TOP 10000!';
   }
 
   const top10Score = getTopScoreByRank(entries, 10);
   if (top10Score && top10Score > scoreNow) {
     const gap = top10Score - scoreNow;
-    if (gap <= 250) return `Next: +${gap} to TOP 10.`;
-    if (gap <= 1000) return `Next: +${Math.min(gap, 350)} for a real jump.`;
+    if (gap <= 250) return `🔥 You’re close: +${gap} to TOP 10!`;
+    if (gap <= 1000) return `🔥 Big leap incoming: +${Math.min(gap, 350)} this run!`;
   }
-  return 'Next: keep building your score pace.';
+  return '🔥 Hit PLAY AGAIN and smash your new record!';
 }
 
 function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition }) {

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -475,7 +475,6 @@ function createGameSessionController({
         darkScreen.style.display = 'none';
       }
 
-      if (DOM.goReason) DOM.goReason.textContent = prettyReason;
       if (DOM.goDistance) DOM.goDistance.textContent = `${Math.floor(gameState.distance)} m`;
       if (DOM.goScore) DOM.goScore.textContent = Math.floor(gameState.score);
       if (DOM.goHeroScore) DOM.goHeroScore.textContent = Math.floor(gameState.score);


### PR DESCRIPTION
### Motivation
- Make the main menu layout feel more intentional by introducing a fixed 20px separation between the rides timer area and the leaderboard. 
- Increase visibility and affordance of the primary action by making the `START GAME` CTA brighter and more animated. 
- Simplify the Game Over post-run panel to focus on immediate reward (collected coins) and make the motivational hook more aggressive and prominent while removing low-value collision reason text.

### Description
- Adjusted menu spacing by removing bottom margin from `#ridesInfo` and setting `#startLeaderboardWrap { margin-top: 20px; }` to create a consistent 20px gap. (`css/style.css`)
- Enhanced the `START GAME` button with a stronger gradient, additional glow shadow and a new pulsing animation `startButtonGlowBoost` to increase visual prominence. (`css/style.css`)
- Simplified the Game Over info card to show only collected coins (gold + silver) and introduced pill-style coin badges for clarity, replacing multiple stat rows. (`index.html`, `css/style.css`)
- Removed display and assignment of the collision/obstacle reason from the Game Over reveal flow so the cause text is no longer shown. (`index.html`, `js/game/session.js`)
- Rewrote and intensified the post-score motivational copy to higher-energy variants and styled the `go-next-target` block with border, stronger background, shadow and bolder text to act as a clear call-to-action. (`js/game/game-over-copy.js`, `css/style.css`)

### Testing
- Ran `npm run check:syntax` and all inspected files passed the syntax checks. (success)
- Pre-commit hooks executed `npm run check:static-analysis` as part of the commit workflow and the static analysis checks passed. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe4d5b8ac8320b6ae36dccf9566ca)