### PR TITLE
Polish Game Over UI, center coins and fix start-screen spacing/glint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -444,7 +444,7 @@ body.ui-stable #gameStart {
 
 #ridesInfo {
   margin-top: 8px;
-  margin-bottom: 0;
+  margin-bottom: 12px;
   min-height: 52px;
   display: flex;
   flex-direction: column;
@@ -488,6 +488,7 @@ body.ui-stable #gameStart {
   min-height: 73px;
   padding: 21px 40px;
   font-size: 18px;
+  margin-top: -20px;
   background:
     radial-gradient(circle at 20% 20%, rgba(255, 255, 255, .26) 0%, rgba(255, 255, 255, 0) 48%),
     linear-gradient(120deg, rgba(99, 102, 241, .58), rgba(192, 132, 252, .58));
@@ -503,13 +504,14 @@ body.ui-stable #gameStart {
   background: conic-gradient(
     from 0deg,
     rgba(129, 140, 248, .08) 0deg,
-    rgba(129, 140, 248, .1) 170deg,
-    rgba(255, 255, 255, .95) 186deg,
-    rgba(192, 132, 252, .9) 204deg,
-    rgba(129, 140, 248, .08) 224deg,
+    rgba(129, 140, 248, .1) 168deg,
+    rgba(255, 255, 255, .95) 184deg,
+    rgba(192, 132, 252, .92) 204deg,
+    rgba(129, 140, 248, .08) 226deg,
     rgba(129, 140, 248, .08) 360deg
   );
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
   animation: startButtonPerimeterSweep 2.4s linear infinite;
@@ -534,7 +536,7 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 20px;
+  margin-top: 34px;
   position: relative;
   z-index: 8;
 }
@@ -1013,40 +1015,44 @@ body.start-launching #walletCorner {
   color: #f8fafc;
 }
 
-.go-comparison,
-.go-next-target {
+.go-hook {
   width: 100%;
   max-width: 440px;
   text-align: center;
-  margin-bottom: 10px;
-  color: rgba(255, 255, 255, 0.9);
-  font-size: 15px;
-  font-family: 'Orbitron', sans-serif;
+  margin-bottom: 18px;
+  border-radius: 14px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, rgba(251, 191, 36, .16), rgba(74, 222, 128, .16));
+  border: 1px solid rgba(251, 191, 36, .45);
+  box-shadow: 0 0 22px rgba(251, 191, 36, .18);
   animation: fadeUp 0.8s ease 0.18s forwards;
   opacity: 0;
 }
 
+.go-comparison,
 .go-next-target {
-  color: #ffffff;
-  margin-bottom: 20px;
-  border: 1px solid rgba(248, 113, 113, .72);
-  border-radius: 14px;
-  padding: 12px 16px;
-  background: linear-gradient(135deg, rgba(239, 68, 68, .18), rgba(192, 132, 252, .22));
-  box-shadow: 0 0 26px rgba(248, 113, 113, .24);
+  width: 100%;
+  text-align: center;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 15px;
+  font-family: 'Orbitron', sans-serif;
+}
+
+.go-next-target {
+  margin-top: 6px;
+  color: #fef3c7;
   font-weight: 700;
-  letter-spacing: .4px;
-  text-shadow: 0 0 12px rgba(255, 255, 255, .28);
+  letter-spacing: .3px;
 }
 
 .go-stats {
   width: 100%;
   max-width: 400px;
-  background: var(--glass);
-  backdrop-filter: blur(15px);
+  background: transparent;
   border-radius: 15px;
-  border: 1px solid var(--border-accent);
-  padding: 20px 25px;
+  border: none;
+  padding: 6px 0 0;
   margin-bottom: 25px;
   animation: fadeUp 0.8s ease 0.2s forwards;
   opacity: 0;
@@ -1054,33 +1060,26 @@ body.start-launching #walletCorner {
 
 .go-stat-row {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  padding: 10px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  gap: 18px;
+  padding: 0;
+  border-bottom: none;
   font-family: 'Orbitron', sans-serif;
-  font-size: 14px;
 }
 
-.go-stat-row:last-child { border-bottom: none; }
-.go-stat-label { opacity: 0.7; }
-.go-stat-value { font-weight: 700; color: #c084fc; }
-.go-stat-value.coins-gold { color: #fbbf24; }
-.go-stat-value.coins-silver { color: #94a3b8; }
-.go-stat-coins {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
+.go-stat-row-coins {
+  justify-content: center;
 }
 
 .go-coins-pill {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 6px 10px;
+  gap: 8px;
+  padding: 8px 16px;
   border-radius: 999px;
   font-weight: 800;
-  font-size: 13px;
+  font-size: 20px;
 }
 
 .go-coins-pill-gold {
@@ -1924,7 +1923,7 @@ footer a:hover { color: #e0b0ff; }
     margin-top: 20px;
   }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 158px);
+    margin-top: calc(50dvh + 190px);
     position: relative;
     left: auto;
     transform: none;
@@ -1940,7 +1939,7 @@ footer a:hover { color: #e0b0ff; }
   .lb-row { font-size: 11px; padding: 8px 8px; }
   .go-title { font-size: 30px; }
   .go-reason { font-size: 13px; }
-  .go-stats { max-width: 90%; padding: 15px 18px; }
+  .go-stats { max-width: 90%; padding: 4px 0 0; }
   .go-stat-row { font-size: 12px; padding: 8px 0; }
   .go-btn { padding: 12px 25px; font-size: 12px; }
   .store-title { font-size: 20px; }
@@ -2035,7 +2034,7 @@ footer a:hover { color: #e0b0ff; }
   #startBtn { min-height: 60px; padding: 15px 20px; font-size: 15px; }
   .lb { max-width: 95%; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 146px);
+    margin-top: calc(50dvh + 176px);
     width: min(96vw, 420px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
@@ -2089,7 +2088,7 @@ footer a:hover { color: #e0b0ff; }
   .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
   #startBtn { min-height: 55px; padding: 13px 15px; font-size: 14px; }
   #startLeaderboardWrap {
-    margin-top: calc(50dvh + 136px);
+    margin-top: calc(50dvh + 164px);
   }
   #startLeaderboardWrap .lb-list { max-height: none; }
 

--- a/index.html
+++ b/index.html
@@ -166,16 +166,15 @@
     <div class="go-score-value" id="goHeroScore">0</div>
   </div>
 
-  <div class="go-comparison" id="goComparison">You’re just getting started.</div>
-  <div class="go-next-target" id="goNextTarget">Next: keep pushing your best run.</div>
+  <div class="go-hook">
+    <div class="go-comparison" id="goComparison">You’re just getting started.</div>
+    <div class="go-next-target" id="goNextTarget">Next: keep pushing your best run.</div>
+  </div>
 
-  <div class="go-stats">
-    <div class="go-stat-row">
-      <span class="go-stat-label">Collected coins</span>
-      <span class="go-stat-value go-stat-coins">
-        <span class="go-coins-pill go-coins-pill-gold"><img src="img/icon_gold.png" style="width: 18px; height: 18px; vertical-align: middle;"> <span id="goGold">0</span></span>
-        <span class="go-coins-pill go-coins-pill-silver"><img src="img/icon_silver.png" style="width: 18px; height: 18px; vertical-align: middle;"> <span id="goSilver">0</span></span>
-      </span>
+  <div class="go-stats" aria-label="Collected coins">
+    <div class="go-stat-row go-stat-row-coins">
+      <span class="go-coins-pill go-coins-pill-gold"><img src="img/icon_gold.png" style="width: 24px; height: 24px; vertical-align: middle;"> <span id="goGold">0</span></span>
+      <span class="go-coins-pill go-coins-pill-silver"><img src="img/icon_silver.png" style="width: 24px; height: 24px; vertical-align: middle;"> <span id="goSilver">0</span></span>
     </div>
   </div>
 


### PR DESCRIPTION
### Motivation
- Improve the Game Over screen visual hierarchy by combining the motivational copy into a single hook and making it friendlier (gold/green) instead of the red accent. 
- Simplify the coin display to be more prominent and readable. 
- Prevent the main menu timer/rides block from overlapping the leaderboard by increasing spacing. 
- Nudge the `START GAME` button up and ensure the moving shine runs along the button perimeter instead of appearing in the center.

### Description
- Reworked Game Over markup in `index.html` by replacing the separate `goComparison`/`goNextTarget` and framed coin row with a new `go-hook` block and a simplified centered coin row (larger icons/values). 
- Added `.go-hook` and adjusted `.go-stats`, `.go-coins-pill`, and related styles in `css/style.css` to remove borders/backgrounds, center the coin pills, increase coin size, and change the hook accent to a gold/green gradient. 
- Increased vertical spacing between `#ridesInfo` and the leaderboard by adjusting `#ridesInfo` `margin-bottom` and `#startLeaderboardWrap` `margin-top` in desktop and mobile media queries to avoid overlap. 
- Moved the `#startBtn` up by ~20px via `margin-top: -20px` and refined the perimeter shine by adding `mask` alongside `-webkit-mask` and tuning the `conic-gradient` stops so the animated highlight follows the button edge.

### Testing
- Ran syntax checks with `npm run check:syntax`, which completed successfully. 
- Ran static analysis with `npm run check:static-analysis`, which passed. 
- Pre-commit hooks ran during the commit and the same checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebeedfdfe48320bd58a2c1ce597856)