### PR TITLE
Constrain start button glare to border and lower leaderboard by 10px

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -504,18 +504,22 @@ body.ui-stable #gameStart {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid transparent;
-  background:
-    linear-gradient(transparent, transparent) padding-box,
-    conic-gradient(
-      from 0deg,
-      rgba(129, 140, 248, .08) 0deg,
-      rgba(129, 140, 248, .1) 168deg,
-      rgba(255, 255, 255, .95) 184deg,
-      rgba(192, 132, 252, .92) 204deg,
-      rgba(129, 140, 248, .08) 226deg,
-      rgba(129, 140, 248, .08) 360deg
-    ) border-box;
+  padding: 1px;
+  background: conic-gradient(
+    from 0deg,
+    rgba(129, 140, 248, .04) 0deg,
+    rgba(129, 140, 248, .08) 156deg,
+    rgba(255, 255, 255, .98) 176deg,
+    rgba(255, 255, 255, .98) 188deg,
+    rgba(192, 132, 252, .95) 205deg,
+    rgba(129, 140, 248, .08) 228deg,
+    rgba(129, 140, 248, .04) 360deg
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
   animation: startButtonPerimeterSweep 2.4s linear infinite;
   pointer-events: none;
 }
@@ -538,7 +542,7 @@ body.ui-stable #gameStart {
 }
 
 #startLeaderboardWrap {
-  margin-top: 44px;
+  margin-top: 54px;
   position: relative;
   z-index: 8;
 }


### PR DESCRIPTION
### Motivation
- Visually anchor the start-button glint to the button edge so the shine travels around the border rather than crossing the center. 
- Move the start-screen leaderboard slightly down to avoid overlap and match the new button visual spacing. 

### Description
- Reworked `#startBtn::before` in `css/style.css` to use `padding: 1px` + a `conic-gradient` and masking (`-webkit-mask` / `mask-composite`) so the animated highlight is rendered only on the button perimeter. 
- Kept the existing `startButtonPerimeterSweep` animation timing while adjusting gradient stops to make the glint brighter and more focused. 
- Increased `#startLeaderboardWrap` `margin-top` from `44px` to `54px` to lower the leaderboard block by 10px. 

### Testing
- Ran `npm run check:syntax` which completed successfully. 
- Pre-commit static analysis (`node scripts/check-static-analysis.mjs`) was executed as part of checks and passed. 
- Visual verification should be performed in a browser to confirm the perimeter glint follows the button edge as intended (no automated screenshot available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfbe7367883209e75fd8daecb4bd7)