### PR TITLE
Game Over: integrate backend prompts, refine motivation copy and around_player leaderboard UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -589,6 +589,11 @@ body.ui-stable #gameStart {
   border: 1px solid rgba(140, 80, 255, .30);
 }
 
+.lb-row.lb-row--dimmed {
+  opacity: .55;
+  filter: saturate(.65);
+}
+
 .lb-rank {
   min-width: 32px;
   text-align: center;
@@ -1150,20 +1155,26 @@ body.start-launching #walletCorner {
 .go-btn:active { transform: scale(0.95); }
 
 .go-btn-restart {
-  background: linear-gradient(90deg, rgba(255, 107, 107, .35), rgba(192, 132, 252, .35));
-  border: 1px solid rgba(255, 107, 107, .55);
-  box-shadow: 0 0 24px rgba(255, 107, 107, .28);
+  background: linear-gradient(90deg, rgba(34, 211, 238, .52), rgba(16, 185, 129, .52), rgba(168, 85, 247, .48));
+  border: 1px solid rgba(34, 211, 238, .85);
+  box-shadow: 0 0 24px rgba(34, 211, 238, .40);
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: 1.2px;
 }
 
 .go-btn-restart:hover {
-  box-shadow: 0 0 24px rgba(255, 107, 107, .32);
+  box-shadow: 0 0 28px rgba(34, 211, 238, .52);
   transform: translateY(-2px);
-  background: linear-gradient(90deg, rgba(255, 107, 107, .42), rgba(192, 132, 252, .45));
+  background: linear-gradient(90deg, rgba(34, 211, 238, .65), rgba(16, 185, 129, .62), rgba(168, 85, 247, .6));
 }
 
 .go-btn-share {
   background: rgba(14, 116, 144, .16);
   border: 1px solid rgba(56, 189, 248, .30);
+  font-size: 13px;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .go-btn-share:hover {
@@ -1172,14 +1183,19 @@ body.start-launching #walletCorner {
 }
 
 .go-btn-menu {
-  background: var(--glass2);
-  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, .03);
+  border: 1px solid rgba(255,255,255,.12);
+  color: rgba(255,255,255,.62);
+  font-size: 12px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .go-btn-menu:hover {
   box-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
   transform: translateY(-2px);
-  border-color: var(--border-accent);
+  border-color: rgba(148, 163, 184, .42);
+  color: rgba(255,255,255,.8);
 }
 
 .go-lb-wrap {

--- a/js/api.js
+++ b/js/api.js
@@ -5,7 +5,7 @@ import { BACKEND_URL } from './config.js';
 import { request, requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ } from './request.js';
 import { DOM, getGameplayProgressSnapshot } from './state.js';
 import { WC } from './walletconnect.js';
-import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGameOverLeaderboardNotice } from './ui.js';
+import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGameOverLeaderboardNotice, setGameOverPrompt } from './ui.js';
 import { validatePlayerInsights, getRankBucket } from './game/leaderboard-insights.js';
 import { isTelegramAuthMode, hasWalletAuthSession, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot } from './auth.js';
 import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './store.js';
@@ -209,10 +209,13 @@ async function loadAndDisplayLeaderboard() {
       }
 
       const rankBucket = getRankBucket(playerInsights?.rank ?? data?.playerPosition);
+      const gameOverPrompt = data?.gameOverPrompt && typeof data.gameOverPrompt === 'object' ? data.gameOverPrompt : null;
+      if (gameOverPrompt) setGameOverPrompt(gameOverPrompt);
       displayLeaderboard(data?.leaderboard, data?.playerPosition, {
         playerInsights,
         insightsReason,
-        rankBucket
+        rankBucket,
+        gameOverPrompt
       });
       return { ok: true, playerInsights, insightsReason, rankBucket };
     }
@@ -340,6 +343,15 @@ async function saveResultToLeaderboard() {
 
     
     if (response.ok) {
+      let responseData = null;
+      try {
+        responseData = await response.json();
+      } catch (_error) {
+        responseData = null;
+      }
+      if (responseData?.gameOverPrompt && typeof responseData.gameOverPrompt === 'object') {
+        setGameOverPrompt(responseData.gameOverPrompt);
+      }
       logger.info("✅ Result saved!");
       showBonusText("✅ In leaderboard!");
       await loadAndDisplayLeaderboard();
@@ -359,6 +371,29 @@ async function saveResultToLeaderboard() {
   }
 }
 
+async function fetchGameOverPreview({ score, distance, isAuthenticated }) {
+  try {
+    const payload = {
+      score: Math.max(0, Math.floor(Number(score) || 0)),
+      distance: Math.max(0, Math.floor(Number(distance) || 0)),
+      isAuthenticated: Boolean(isAuthenticated)
+    };
+    const response = await request(`${BACKEND_URL}/api/leaderboard/game-over-preview`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!response.ok) return null;
+    const data = await response.json().catch(() => null);
+    const prompt = data?.gameOverPrompt && typeof data.gameOverPrompt === 'object' ? data.gameOverPrompt : null;
+    if (prompt) setGameOverPrompt(prompt);
+    return prompt;
+  } catch (error) {
+    logger.warn('⚠️ game-over-preview failed:', error);
+    return null;
+  }
+}
+
 export {
   isAuthenticated,
   getAuthIdentifier,
@@ -367,5 +402,6 @@ export {
   signMessage,
   loadAndDisplayLeaderboard,
   resetLeaderboardUI,
-  saveResultToLeaderboard
+  saveResultToLeaderboard,
+  fetchGameOverPreview
 };

--- a/js/game/game-over-copy.js
+++ b/js/game/game-over-copy.js
@@ -18,6 +18,33 @@ function getTopScoreByRank(entries, rank) {
   return Number.isFinite(value) && value > 0 ? value : null;
 }
 
+function getRankByScore(entries, score) {
+  if (!Array.isArray(entries) || entries.length === 0) return null;
+  const scoreNow = Math.max(0, Number(score) || 0);
+  const betterCount = entries.filter((entry) => Number(entry?.score ?? entry?.bestScore ?? 0) > scoreNow).length;
+  return betterCount + 1;
+}
+
+function getScoreDeltaToRank(entries, targetRank, score) {
+  const scoreNow = Math.max(0, Number(score) || 0);
+  const targetScore = getTopScoreByRank(entries, targetRank);
+  if (!targetScore) return null;
+  return Math.max(0, targetScore - scoreNow + 1);
+}
+
+function normalizePrompt(prompt) {
+  if (!prompt || typeof prompt !== 'object') return null;
+  return {
+    title: String(prompt.title || '').trim(),
+    hook: String(prompt.hook || '').trim(),
+    boost: String(prompt.boost || '').trim(),
+    rank: Number.isFinite(Number(prompt.rank)) ? Number(prompt.rank) : null,
+    leaderboardSlice: prompt.leaderboardSlice && typeof prompt.leaderboardSlice === 'object'
+      ? prompt.leaderboardSlice
+      : null
+  };
+}
+
 function buildLegacyNextTargetCopy({ score, rankPosition, entries }) {
   const scoreNow = Math.max(0, Number(score) || 0);
   if (Number.isFinite(rankPosition) && rankPosition > 0) {
@@ -97,54 +124,215 @@ function buildInsightsTarget(insights, fallbackText) {
   };
 }
 
-function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition, playerInsights }) {
+function buildLocalMotivationCopy({
+  score,
+  rankPosition,
+  isFirstRun,
+  isPersonalBest,
+  bestScoreAfterRun,
+  entries,
+  insights
+}) {
+  const scoreNow = Math.max(0, Number(score) || 0);
+  const rank = Number.isFinite(rankPosition) && rankPosition > 0 ? rankPosition : getRankByScore(entries, scoreNow);
+  const percentile = Math.round(Number(getPercentileByMode(insights?.comparisonMode || 'none', insights) || 0));
+  const scoreToNextRank = Number.isFinite(rank) && rank > 1 ? getScoreDeltaToRank(entries, rank - 1, scoreNow) : null;
+  const scoreToTop1 = getScoreDeltaToRank(entries, 1, scoreNow);
+  const scoreToTop3 = getScoreDeltaToRank(entries, 3, scoreNow);
+
+  if (Number.isFinite(rank) && rank === 1) {
+    return {
+      title: '👑 NEW LEADER!',
+      comparison: 'No one is above you.',
+      nextTarget: '',
+      hasRecommendedTarget: false,
+      target: null
+    };
+  }
+
+  if (Number.isFinite(rank) && rank <= 3) {
+    return {
+      title: '💥 YOU MADE IT TO TOP 3!',
+      comparison: rank === 2 ? 'Only a few are ahead of you.' : 'You’re among the best players.',
+      nextTarget: scoreToTop1 ? `Next +${scoreToTop1} to #1` : '',
+      hasRecommendedTarget: Boolean(scoreToTop1),
+      target: scoreToTop1 ? { type: 'rank', label: '#1', delta: scoreToTop1 } : null
+    };
+  }
+
+  if (Number.isFinite(rank) && rank <= 10) {
+    return {
+      title: 'NEW RECORD!',
+      comparison: rank <= 5 ? 'You’re among the best players.' : 'Only a few are ahead of you.',
+      nextTarget: scoreToTop3 ? `+${scoreToTop3} points to TOP 3` : '',
+      hasRecommendedTarget: Boolean(scoreToTop3),
+      target: scoreToTop3 ? { type: 'rank', label: 'TOP 3', delta: scoreToTop3 } : null
+    };
+  }
+
+  if (scoreToNextRank !== null && scoreToNextRank < 10) {
+    return {
+      title: 'SO CLOSE!',
+      comparison: '',
+      nextTarget: `+${scoreToNextRank} points to pass the next player`,
+      hasRecommendedTarget: true,
+      target: { type: 'rank', label: 'next rank', delta: scoreToNextRank }
+    };
+  }
+
+  if (isFirstRun) {
+    const strongFirstRun = percentile >= 60;
+    const weakFirstRun = scoreNow <= 250;
+    return {
+      title: 'FIRST RUN!',
+      comparison: strongFirstRun ? 'You’re off to a great start.' : 'Nice start.',
+      nextTarget: strongFirstRun
+        ? `Better than ${Math.max(60, percentile)}% of new players`
+        : weakFirstRun
+          ? 'Let’s beat it — you can go further.'
+          : `+${Math.max(1, scoreToNextRank || 120)} to beat your best`,
+      hasRecommendedTarget: !strongFirstRun,
+      target: !strongFirstRun
+        ? { type: 'score', label: 'your best', delta: Math.max(1, scoreToNextRank || 120) }
+        : null
+    };
+  }
+
+  if (isPersonalBest && Number.isFinite(rank)) {
+    if (rank <= 100) {
+      return {
+        title: 'PERSONAL BEST!',
+        comparison: 'You’re in TOP 100!',
+        nextTarget: `+${Math.max(1, scoreToNextRank || 120)} points to break in`,
+        hasRecommendedTarget: true,
+        target: { type: 'rank', label: 'next place', delta: Math.max(1, scoreToNextRank || 120) }
+      };
+    }
+    if (rank <= 1000) {
+      return {
+        title: 'PERSONAL BEST!',
+        comparison: 'You’re in TOP 1000!',
+        nextTarget: `+${Math.max(1, scoreToNextRank || 120)} points to break in`,
+        hasRecommendedTarget: true,
+        target: { type: 'rank', label: 'next place', delta: Math.max(1, scoreToNextRank || 120) }
+      };
+    }
+    if (rank <= 10000) {
+      return {
+        title: 'PERSONAL BEST!',
+        comparison: 'You’re in TOP 10000!',
+        nextTarget: `+${Math.max(1, scoreToNextRank || 120)} points to break in`,
+        hasRecommendedTarget: true,
+        target: { type: 'rank', label: 'next place', delta: Math.max(1, scoreToNextRank || 120) }
+      };
+    }
+  }
+
+  const closeToBest = Number.isFinite(bestScoreAfterRun) && bestScoreAfterRun > 0 && Math.abs(bestScoreAfterRun - scoreNow) <= 100;
+  const weakRun = insights?.comparisonTextFallbackType === 'weak_first_run' || insights?.comparisonTextFallbackType === 'weak_repeat_run' || scoreNow < 300;
+  const midRun = scoreNow < 900;
+  return {
+    title: 'GOOD RUN!',
+    comparison: closeToBest ? 'Almost a new best.' : weakRun ? 'Warm-up run.' : midRun ? 'Keep climbing.' : 'You can beat this.',
+    nextTarget: closeToBest
+      ? `Only +${Math.max(1, Math.abs(bestScoreAfterRun - scoreNow) + 1)} to your record`
+      : `+${Math.max(1, scoreToNextRank || 120)} to the next rank`,
+    hasRecommendedTarget: true,
+    target: { type: 'rank', label: 'next rank', delta: Math.max(1, scoreToNextRank || 120) }
+  };
+}
+
+function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition, playerInsights, gameOverPrompt, isAuthenticated = true }) {
   const isFirstRunLocal = runIndex <= 1;
   const hasPersonalBest = bestScoreAfterRun > Math.max(0, Number(bestScoreBeforeRun) || 0);
-  const nextRankScore = Number.isFinite(playerPosition) && playerPosition > 1
-    ? getTopScoreByRank(entries, playerPosition - 1)
-    : null;
-  const isCloseToPersonalBest = Number.isFinite(bestScoreAfterRun) && bestScoreAfterRun > 0
-    && Math.abs(bestScoreAfterRun - score) <= 100;
 
   const insights = playerInsights || null;
+  const prompt = normalizePrompt(gameOverPrompt);
   const isFirstRun = insights?.isFirstRun ?? isFirstRunLocal;
   const isPersonalBest = insights?.isPersonalBest ?? hasPersonalBest;
-  const fallbackType = insights?.comparisonTextFallbackType || null;
+  const fallbackType = insights?.comparisonTextFallbackType || null; // analytics compatibility
 
-  let title = 'GOOD RUN!';
-  if (isFirstRun) title = 'FIRST RUN!';
-  else if (isPersonalBest) title = 'NEW RECORD!';
-  else if (isCloseToPersonalBest) title = 'PERSONAL BEST!';
-  else if (fallbackType === 'weak_first_run' || fallbackType === 'weak_repeat_run') title = 'JUST A BIT MORE!';
-
-  const legacyComparison = buildPercentileCopy({
-    score,
-    runIndex,
-    hasPersonalBest,
-    rankPosition: playerPosition
-  }) || (isFirstRun ? 'Getting started!' : 'Let’s do better.');
-
-  const comparison = insights
-    ? buildInsightsComparison(insights)
-    : {
-      text: legacyComparison,
-      isPercentileVisible: true,
-      mode: 'legacy'
+  if (!isAuthenticated) {
+    const practiceRank = Number.isFinite(prompt?.rank) ? prompt.rank : getRankByScore(entries, score);
+    const practicePercent = Math.max(0, Math.round(Number(getPercentileByMode(insights?.comparisonMode || 'none', insights) || 0)));
+    const betterThanText = practicePercent >= 60 ? `Better than ${practicePercent}% of new players` : '';
+    const rankAndSaveText = Number.isFinite(practiceRank)
+      ? `Your rank #${practiceRank} • Save your score & climb the leaderboard`
+      : 'Save your score & climb the leaderboard';
+    return {
+      title: prompt?.title || 'GOOD RUN!',
+      comparison: {
+        text: prompt?.hook || 'You’re playing in practice mode',
+        isPercentileVisible: false,
+        mode: 'practice'
+      },
+      nextTarget: {
+        text: prompt?.boost || (betterThanText || rankAndSaveText),
+        hasRecommendedTarget: false,
+        list: []
+      },
+      meta: {
+        fallbackType,
+        comparisonMode: 'practice',
+        hasInsights: Boolean(insights),
+        promptRank: prompt?.rank ?? null
+      }
     };
+  }
+
+  if (prompt?.title || prompt?.hook || prompt?.boost) {
+    return {
+      title: prompt?.title || 'GOOD RUN!',
+      comparison: {
+        text: prompt?.hook || 'Keep climbing.',
+        isPercentileVisible: false,
+        mode: 'backend_prompt'
+      },
+      nextTarget: {
+        text: prompt?.boost || '',
+        hasRecommendedTarget: false,
+        list: []
+      },
+      meta: {
+        fallbackType,
+        comparisonMode: 'backend_prompt',
+        hasInsights: Boolean(insights),
+        promptRank: prompt?.rank ?? null
+      }
+    };
+  }
+
+  const local = buildLocalMotivationCopy({
+    score,
+    rankPosition: playerPosition,
+    isFirstRun,
+    isPersonalBest,
+    bestScoreAfterRun,
+    entries,
+    insights
+  });
+  const comparison = { text: local.comparison, isPercentileVisible: false, mode: 'local_rules' };
 
   const fallbackTargetText = buildLegacyNextTargetCopy({ score, rankPosition: playerPosition, entries });
   const nextTarget = insights
     ? buildInsightsTarget(insights, fallbackTargetText)
     : { text: fallbackTargetText, hasRecommendedTarget: false, list: [] };
+  const localNextTarget = local.nextTarget || nextTarget.text;
 
   return {
-    title,
+    title: local.title,
     comparison,
-    nextTarget,
+    nextTarget: {
+      ...nextTarget,
+      text: localNextTarget,
+      hasRecommendedTarget: local.hasRecommendedTarget ?? nextTarget.hasRecommendedTarget,
+      target: local.target ?? nextTarget.target
+    },
     meta: {
       fallbackType,
       comparisonMode: comparison.mode,
-      hasInsights: Boolean(insights)
+      hasInsights: Boolean(insights),
+      promptRank: prompt?.rank ?? null
     }
   };
 }

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -1,5 +1,5 @@
 import { CONFIG } from '../config.js';
-import { isAuthenticated, saveResultToLeaderboard, loadAndDisplayLeaderboard } from '../api.js';
+import { isAuthenticated, saveResultToLeaderboard, loadAndDisplayLeaderboard, fetchGameOverPreview } from '../api.js';
 import { audioManager, syncAllAudioUI } from '../audio.js';
 import { showBonusText, updateGameOverLeaderboardNotice, getLeaderboardSnapshot, setGameOverInsightsLoading } from '../ui.js';
 import { clearParticles, spawnParticles } from '../particles.js';
@@ -86,8 +86,8 @@ function createGameSessionController({
   }
 
   function updateGameOverDynamicCopy({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun }) {
-    const { entries, playerPosition, playerInsights } = getLeaderboardSnapshot();
-    const summary = buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition, playerInsights });
+    const { entries, playerPosition, playerInsights, gameOverPrompt } = getLeaderboardSnapshot();
+    const summary = buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition, playerInsights, gameOverPrompt, isAuthenticated: isAuthenticated() });
 
     if (DOM.goTitle) DOM.goTitle.textContent = summary.title;
     if (DOM.goHeroScore) DOM.goHeroScore.textContent = Math.floor(score).toLocaleString();
@@ -508,7 +508,7 @@ function createGameSessionController({
       endGameInProgress = false;
 
       setGameOverInsightsLoading(true);
-      loadAndDisplayLeaderboard()
+      Promise.allSettled([loadAndDisplayLeaderboard(), fetchGameOverPreview({ score: gameState.score, distance: gameState.distance, isAuthenticated: isAuthenticated() })])
         .catch((error) => {
           logger.warn('⚠️ Failed to load leaderboard after game over:', error);
         })

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,7 +1,7 @@
 import { CONFIG } from './config.js';
 import { DOM, gameState, player } from './state.js';
 import { syncAllAudioUI } from './audio.js';
-import { getAuthStateSnapshot, hasWalletAuthSession } from './auth.js';
+import { getAuthStateSnapshot, hasWalletAuthSession, hasAuthenticatedSession } from './auth.js';
 import { applyStoreDefaultLockState, loadPlayerUpgrades, updateStoreUI, setActiveStoreTab, closeDonationModal, isStoreAvailable, isUnauthRuntimeMode, getStoreStateSnapshot } from './store.js';
 import { createElement, createIconAtlas, clearNode } from './dom-render.js';
 import { showStoreScreen, hideStoreScreen } from './screens.js';
@@ -25,7 +25,8 @@ const leaderboardSnapshot = {
   playerPosition: null,
   playerInsights: null,
   insightsReason: null,
-  rankBucket: 'unknown'
+  rankBucket: 'unknown',
+  gameOverPrompt: null
 };
 
 function setTextIfChanged(node, cacheKey, value) {
@@ -146,12 +147,71 @@ function updateGameOverLeaderboardNotice(message = '') {
   notice.hidden = text.length === 0;
 }
 
+function formatLeaderboardName(entry = {}) {
+  if (entry.displayName) return String(entry.displayName);
+  if (entry.wallet && entry.wallet.startsWith('0x')) {
+    return `${entry.wallet.slice(0, 6)}...${entry.wallet.slice(-4)}`;
+  }
+  if (entry.wallet) {
+    return entry.wallet.length > 14 ? `${entry.wallet.slice(0, 10)}...` : entry.wallet;
+  }
+  return 'Unknown';
+}
+
+function createLeaderboardRow(entry, idx, { isMe = false, isDimmed = false, rankOverride = null } = {}) {
+  const score = parseInt(entry?.bestScore ?? entry?.score, 10) || 0;
+  const rankPos = Number.isFinite(rankOverride) ? rankOverride : (idx + 1);
+  let rankClass = '';
+  if (rankPos === 1) rankClass = 'gold';
+  else if (rankPos === 2) rankClass = 'silver';
+  else if (rankPos === 3) rankClass = 'bronze';
+
+  const row = document.createElement('div');
+  row.className = `lb-row${isMe ? ' lb-row--me' : ''}${isDimmed ? ' lb-row--dimmed' : ''}`;
+
+  const rank = document.createElement('span');
+  rank.className = `lb-rank ${rankClass}`.trim();
+  rank.textContent = `#${rankPos}`;
+
+  const wallet = document.createElement('span');
+  wallet.className = 'lb-wallet';
+  wallet.textContent = `${formatLeaderboardName(entry)}${isMe ? ' 👤' : ''}`;
+
+  const scoreEl = document.createElement('span');
+  scoreEl.className = 'lb-score';
+  scoreEl.append(
+    createIconAtlas({
+      width: 16,
+      height: 16,
+      backgroundSize: '80px auto',
+      backgroundPosition: '-64px -16px',
+      marginRight: 4
+    }),
+    document.createTextNode(score.toLocaleString())
+  );
+
+  row.append(rank, wallet, scoreEl);
+  return row;
+}
+
+function setGameOverPrompt(prompt) {
+  leaderboardSnapshot.gameOverPrompt = prompt && typeof prompt === 'object' ? { ...prompt } : null;
+}
+
+function renderGameOverLeaderboard(rows) {
+  renderNodeCopies(DOM.gameOverLeaderboardList, rows);
+}
+
 function displayLeaderboard(leaderboard, playerPosition, options = {}) {
   const { userWallet = null, primaryId = null } = getAuthStateSnapshot();
-  const rows = [];
+  const startRows = [];
+  const gameOverRows = [];
   leaderboardSnapshot.playerInsights = options.playerInsights || null;
   leaderboardSnapshot.insightsReason = options.insightsReason || null;
   leaderboardSnapshot.rankBucket = options.rankBucket || 'unknown';
+  leaderboardSnapshot.gameOverPrompt = options.gameOverPrompt && typeof options.gameOverPrompt === 'object'
+    ? { ...options.gameOverPrompt }
+    : leaderboardSnapshot.gameOverPrompt;
 
   if (Array.isArray(leaderboard) && leaderboard.length > 0) {
     const getEntryScore = (entry) => {
@@ -174,58 +234,39 @@ function displayLeaderboard(leaderboard, playerPosition, options = {}) {
       const empty = document.createElement('div');
       empty.className = 'lb-empty';
       empty.textContent = 'No results';
-      rows.push(empty);
+      startRows.push(empty);
+      gameOverRows.push(empty.cloneNode(true));
     } else {
       topTen.forEach((entry, idx) => {
-        const score = getEntryScore(entry);
         const isMe = entry.wallet === userWallet || entry.wallet === primaryId;
-
-        let rankClass = '';
-        if (idx === 0) rankClass = 'gold';
-        else if (idx === 1) rankClass = 'silver';
-        else if (idx === 2) rankClass = 'bronze';
-
-        const rowClass = isMe ? 'lb-row lb-row--me' : 'lb-row';
-
-        // Use displayName from backend, fallback to wallet formatting.
-        let name = '';
-        if (entry.displayName) {
-          name = String(entry.displayName);
-        } else if (entry.wallet && entry.wallet.startsWith('0x')) {
-          name = `${entry.wallet.slice(0, 6)}...${entry.wallet.slice(-4)}`;
-        } else if (entry.wallet) {
-          name = entry.wallet.length > 14 ? `${entry.wallet.slice(0, 10)}...` : entry.wallet;
-        } else {
-          name = 'Unknown';
-        }
-
-        const row = document.createElement('div');
-        row.className = rowClass;
-
-        const rank = document.createElement('span');
-        rank.className = `lb-rank ${rankClass}`.trim();
-        rank.textContent = `#${idx + 1}`;
-
-        const wallet = document.createElement('span');
-        wallet.className = 'lb-wallet';
-        wallet.textContent = `${name}${isMe ? ' 👤' : ''}`;
-
-        const scoreEl = document.createElement('span');
-        scoreEl.className = 'lb-score';
-        scoreEl.append(
-          createIconAtlas({
-            width: 16,
-            height: 16,
-            backgroundSize: '80px auto',
-            backgroundPosition: '-64px -16px',
-            marginRight: 4
-          }),
-          document.createTextNode(score.toLocaleString())
-        );
-
-        row.append(rank, wallet, scoreEl);
-        rows.push(row);
+        startRows.push(createLeaderboardRow(entry, idx, { isMe, rankOverride: idx + 1 }));
       });
+
+      const promptSliceRows = Array.isArray(options.gameOverPrompt?.leaderboardSlice?.rows)
+        ? options.gameOverPrompt.leaderboardSlice.rows
+        : [];
+      const shouldUseAroundSlice = hasAuthenticatedSession()
+        && promptSliceRows.length > 0
+        && String(options.gameOverPrompt?.leaderboardSlice?.mode || '') === 'around_player';
+
+      if (shouldUseAroundSlice) {
+        promptSliceRows.forEach((sliceRow, idx) => {
+          const rowScore = Number(sliceRow.bestScore ?? sliceRow.score ?? 0);
+          gameOverRows.push(createLeaderboardRow({
+            ...sliceRow,
+            score: rowScore
+          }, idx, {
+            isMe: Boolean(sliceRow.isCurrentPlayerRow),
+            isDimmed: Boolean(sliceRow.isDimmed),
+            rankOverride: Number(sliceRow.position) || null
+          }));
+        });
+      } else {
+        topTen.forEach((entry, idx) => {
+          const isMe = entry.wallet === userWallet || entry.wallet === primaryId;
+          gameOverRows.push(createLeaderboardRow(entry, idx, { isMe, rankOverride: idx + 1 }));
+        });
+      }
     }
   } else {
     leaderboardSnapshot.entries = [];
@@ -233,11 +274,12 @@ function displayLeaderboard(leaderboard, playerPosition, options = {}) {
     const empty = document.createElement('div');
     empty.className = 'lb-empty';
     empty.textContent = 'No data';
-    rows.push(empty);
+    startRows.push(empty);
+    gameOverRows.push(empty.cloneNode(true));
   }
 
-  renderNodeCopies(DOM.startLeaderboardList, rows);
-  renderNodeCopies(DOM.gameOverLeaderboardList, rows);
+  renderNodeCopies(DOM.startLeaderboardList, startRows);
+  renderGameOverLeaderboard(gameOverRows);
 }
 
 function getLeaderboardSnapshot() {
@@ -246,7 +288,8 @@ function getLeaderboardSnapshot() {
     playerPosition: leaderboardSnapshot.playerPosition,
     playerInsights: leaderboardSnapshot.playerInsights,
     insightsReason: leaderboardSnapshot.insightsReason,
-    rankBucket: leaderboardSnapshot.rankBucket
+    rankBucket: leaderboardSnapshot.rankBucket,
+    gameOverPrompt: leaderboardSnapshot.gameOverPrompt ? { ...leaderboardSnapshot.gameOverPrompt } : null
   };
 }
 
@@ -259,5 +302,6 @@ export {
   displayLeaderboard,
   updateGameOverLeaderboardNotice,
   getLeaderboardSnapshot,
-  setGameOverInsightsLoading
+  setGameOverInsightsLoading,
+  setGameOverPrompt
 };

--- a/scripts/game-over-copy.test.mjs
+++ b/scripts/game-over-copy.test.mjs
@@ -19,8 +19,8 @@ test('title mapping priority handles first run and personal best', () => {
     runIndex: 3,
     bestScoreBeforeRun: 200,
     bestScoreAfterRun: 250,
-    entries: [],
-    playerPosition: null,
+    entries: Array.from({ length: 10 }, (_, idx) => ({ score: 1000 - idx * 100 })),
+    playerPosition: 8,
     playerInsights: { isFirstRun: false, isPersonalBest: true, comparisonMode: 'overall', percentileOverall: 82 }
   });
   assert.equal(newRecord.title, 'NEW RECORD!');
@@ -59,4 +59,21 @@ test('graceful fallback with missing fields does not throw and returns default t
 
   assert.equal(typeof summary.comparison.text, 'string');
   assert.equal(typeof summary.nextTarget.text, 'string');
+});
+
+test('practice mode uses dedicated unauth copy and save CTA', () => {
+  const summary = buildGameOverSummary({
+    score: 420,
+    runIndex: 2,
+    bestScoreBeforeRun: 420,
+    bestScoreAfterRun: 420,
+    entries: [{ score: 500 }, { score: 450 }, { score: 430 }],
+    playerPosition: null,
+    playerInsights: { comparisonMode: 'none' },
+    isAuthenticated: false
+  });
+
+  assert.equal(summary.title, 'GOOD RUN!');
+  assert.match(summary.comparison.text, /practice mode/i);
+  assert.match(summary.nextTarget.text, /Save your score/i);
 });


### PR DESCRIPTION
### Motivation
- Ввести более точную агитационную логику на экране Game Over и позволить backend подставлять готовые `title/hook/boost` (переиспользуемые подсказки) в frontend для гибкой коммуникации с игроком.
- Показать соседние строки лидерборда вокруг игрока на странице Game Over для авторизованных пользователей и визуально затемнять нерелевантные строки.

### Description
- Подхват `gameOverPrompt` от backend: теперь фронтенд сохраняет `gameOverPrompt` из ответов `GET /api/leaderboard/top`, из ответа на `POST /api/leaderboard/save` и запрашивает отдельный `POST /api/leaderboard/game-over-preview` через новую `fetchGameOverPreview` в `js/api.js` и `setGameOverPrompt` в `js/ui.js`.
- Новая локальная логика мотивации: реализованы правила формирования заголовка/хука/усиления по рангу / персональному рекорду / первому заезду / близости до следующего ранга, с приоритетом backend-подсказки при её наличии (файл `js/game/game-over-copy.js`).
- Лидерборд на экране Game Over: поддержка `leaderboardSlice.mode = 'around_player'` и отображение с затемнёнными соседними строками и пометкой текущего игрока; общий топ по-прежнему рендерится на стартовом экране (файл `js/ui.js` и правки в `css/style.css` для `.lb-row--dimmed`).
- UI/UX правки кнопок на Game Over: `PLAY AGAIN` — неоновый/яркий стиль, `SHARE` — промежуточный размер, `MENU` — уменьшен и сделан визуально блеклым (изменения в `css/style.css`).
- Тесты: добавлен unit тест для практической (unauth) версии Game Over copy и обновлены существующие тесты (`scripts/game-over-copy.test.mjs`).

### Testing
- Запущен `npm run check:syntax` — успешно (статический синтакс-проход для всех модулей). 
- Запущен `node --test scripts/game-over-copy.test.mjs` — все тесты прошли (5/5). 
- Pre-commit checks (`check:syntax` + `check:static-analysis`) были выполнены и прошли успешно при коммите.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd1fde4b08320afe4012ddf9fb847)