### PR TITLE
Show achieved rank boost on Game Over and improve leaderboard around-player display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1040,6 +1040,7 @@ body.start-launching #walletCorner {
   opacity: 0;
 }
 
+.go-boost,
 .go-comparison,
 .go-next-target {
   width: 100%;
@@ -1048,6 +1049,16 @@ body.start-launching #walletCorner {
   color: rgba(255, 255, 255, 0.95);
   font-size: 15px;
   font-family: 'Orbitron', sans-serif;
+}
+
+.go-boost {
+  color: #fde68a;
+  font-size: 26px;
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: .6px;
+  margin-bottom: 4px;
+  text-shadow: 0 0 16px rgba(251, 191, 36, .45);
 }
 
 .go-next-target {
@@ -1062,6 +1073,7 @@ body.start-launching #walletCorner {
   cursor: pointer;
 }
 
+.go-hook-loading .go-boost,
 .go-hook-loading .go-comparison,
 .go-hook-loading .go-next-target {
   color: transparent;

--- a/index.html
+++ b/index.html
@@ -167,6 +167,7 @@
   </div>
 
   <div class="go-hook">
+    <div class="go-boost" id="goBoost" hidden></div>
     <div class="go-comparison" id="goComparison">You’re just getting started.</div>
     <div class="go-next-target" id="goNextTarget">Next: keep pushing your best run.</div>
   </div>

--- a/js/game/game-over-copy.js
+++ b/js/game/game-over-copy.js
@@ -45,6 +45,13 @@ function normalizePrompt(prompt) {
   };
 }
 
+function getAchievedRank({ playerPosition, insights, prompt }) {
+  if (Number.isFinite(Number(playerPosition)) && Number(playerPosition) > 0) return Number(playerPosition);
+  if (Number.isFinite(Number(insights?.rank)) && Number(insights.rank) > 0) return Number(insights.rank);
+  if (Number.isFinite(Number(prompt?.rank)) && Number(prompt.rank) > 0) return Number(prompt.rank);
+  return null;
+}
+
 function buildLegacyNextTargetCopy({ score, rankPosition, entries }) {
   const scoreNow = Math.max(0, Number(score) || 0);
   if (Number.isFinite(rankPosition) && rankPosition > 0) {
@@ -251,6 +258,8 @@ function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAf
   const isFirstRun = insights?.isFirstRun ?? isFirstRunLocal;
   const isPersonalBest = insights?.isPersonalBest ?? hasPersonalBest;
   const fallbackType = insights?.comparisonTextFallbackType || null; // analytics compatibility
+  const achievedRank = getAchievedRank({ playerPosition, insights, prompt });
+  const boostText = isAuthenticated && isPersonalBest && Number.isFinite(achievedRank) ? `You’re #${achievedRank}` : '';
 
   if (!isAuthenticated) {
     const practiceRank = Number.isFinite(prompt?.rank) ? prompt.rank : getRankByScore(entries, score);
@@ -261,6 +270,7 @@ function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAf
       : 'Save your score & climb the leaderboard';
     return {
       title: prompt?.title || 'GOOD RUN!',
+      boostText,
       comparison: {
         text: prompt?.hook || 'You’re playing in practice mode',
         isPercentileVisible: false,
@@ -283,6 +293,7 @@ function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAf
   if (prompt?.title || prompt?.hook || prompt?.boost) {
     return {
       title: prompt?.title || 'GOOD RUN!',
+      boostText,
       comparison: {
         text: prompt?.hook || 'Keep climbing.',
         isPercentileVisible: false,
@@ -321,6 +332,7 @@ function buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAf
 
   return {
     title: local.title,
+    boostText,
     comparison,
     nextTarget: {
       ...nextTarget,

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -88,9 +88,9 @@ function createGameSessionController({
   function updateGameOverDynamicCopy({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun }) {
     const { entries, playerPosition, playerInsights, gameOverPrompt } = getLeaderboardSnapshot();
     const summary = buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition, playerInsights, gameOverPrompt, isAuthenticated: isAuthenticated() });
-
     if (DOM.goTitle) DOM.goTitle.textContent = summary.title;
     if (DOM.goHeroScore) DOM.goHeroScore.textContent = Math.floor(score).toLocaleString();
+    if (DOM.goBoost) { const boostText = String(summary.boostText || '').trim(); DOM.goBoost.textContent = boostText; DOM.goBoost.hidden = boostText.length === 0; }
     if (DOM.goComparison) DOM.goComparison.textContent = summary.comparison.text;
     if (DOM.goNextTarget) {
       const listTail = Array.isArray(summary.nextTarget.list) && summary.nextTarget.list.length ? `\n${summary.nextTarget.list.map((item) => `• +${Math.max(0, Number(item?.delta) || 0)} to ${item?.label || 'target'}`).join('\n')}` : '';

--- a/js/state.js
+++ b/js/state.js
@@ -130,6 +130,7 @@ const DOM_IDS = {
   goReason: 'goReason',
   goTitle: 'goTitle',
   goHeroScore: 'goHeroScore',
+  goBoost: 'goBoost',
   goComparison: 'goComparison',
   goNextTarget: 'goNextTarget',
   goDistance: 'goDistance',

--- a/js/ui.js
+++ b/js/ui.js
@@ -194,6 +194,56 @@ function createLeaderboardRow(entry, idx, { isMe = false, isDimmed = false, rank
   return row;
 }
 
+function createLeaderboardGapRow() {
+  const row = document.createElement('div');
+  row.className = 'lb-row lb-row--dimmed';
+
+  const rank = document.createElement('span');
+  rank.className = 'lb-rank';
+  rank.textContent = '…';
+
+  const wallet = document.createElement('span');
+  wallet.className = 'lb-wallet';
+  wallet.textContent = '…';
+
+  const score = document.createElement('span');
+  score.className = 'lb-score';
+  score.textContent = '…';
+
+  row.append(rank, wallet, score);
+  return row;
+}
+
+function buildAroundPlayerRowsFromTopEntries(entries, playerPosition) {
+  const rank = Number(playerPosition);
+  if (!Number.isFinite(rank) || rank <= 1 || !Array.isArray(entries) || entries.length === 0) return [];
+
+  const aroundRows = [];
+  const above = entries[rank - 2];
+  const me = entries[rank - 1];
+  const below = entries[rank];
+
+  if (above) {
+    aroundRows.push(createLeaderboardRow(above, 0, {
+      isMe: false,
+      rankOverride: rank - 1
+    }));
+  }
+  if (me) {
+    aroundRows.push(createLeaderboardRow(me, 0, {
+      isMe: true,
+      rankOverride: rank
+    }));
+  }
+  if (below) {
+    aroundRows.push(createLeaderboardRow(below, 0, {
+      isMe: false,
+      rankOverride: rank + 1
+    }));
+  }
+  return aroundRows;
+}
+
 function setGameOverPrompt(prompt) {
   leaderboardSnapshot.gameOverPrompt = prompt && typeof prompt === 'object' ? { ...prompt } : null;
 }
@@ -249,6 +299,19 @@ function displayLeaderboard(leaderboard, playerPosition, options = {}) {
         && promptSliceRows.length > 0
         && String(options.gameOverPrompt?.leaderboardSlice?.mode || '') === 'around_player';
 
+      const shouldAppendAroundPlayer = hasAuthenticatedSession()
+        && Number.isFinite(Number(playerPosition))
+        && Number(playerPosition) > topTen.length;
+
+      topTen.forEach((entry, idx) => {
+        const isMe = entry.wallet === userWallet || entry.wallet === primaryId;
+        gameOverRows.push(createLeaderboardRow(entry, idx, { isMe, rankOverride: idx + 1 }));
+      });
+
+      if (shouldAppendAroundPlayer) {
+        gameOverRows.push(createLeaderboardGapRow());
+      }
+
       if (shouldUseAroundSlice) {
         promptSliceRows.forEach((sliceRow, idx) => {
           const rowScore = Number(sliceRow.bestScore ?? sliceRow.score ?? 0);
@@ -261,11 +324,13 @@ function displayLeaderboard(leaderboard, playerPosition, options = {}) {
             rankOverride: Number(sliceRow.position) || null
           }));
         });
-      } else {
-        topTen.forEach((entry, idx) => {
-          const isMe = entry.wallet === userWallet || entry.wallet === primaryId;
-          gameOverRows.push(createLeaderboardRow(entry, idx, { isMe, rankOverride: idx + 1 }));
-        });
+      } else if (shouldAppendAroundPlayer) {
+        const aroundRows = buildAroundPlayerRowsFromTopEntries(sorted, Number(playerPosition));
+        aroundRows.forEach((row) => gameOverRows.push(row));
+      }
+
+      if (shouldAppendAroundPlayer) {
+        gameOverRows.push(createLeaderboardGapRow());
       }
     }
   } else {

--- a/scripts/game-over-copy.test.mjs
+++ b/scripts/game-over-copy.test.mjs
@@ -76,4 +76,31 @@ test('practice mode uses dedicated unauth copy and save CTA', () => {
   assert.equal(summary.title, 'GOOD RUN!');
   assert.match(summary.comparison.text, /practice mode/i);
   assert.match(summary.nextTarget.text, /Save your score/i);
+  assert.equal(summary.boostText, '');
+});
+
+test('boost line shows achieved rank only for a new personal best', () => {
+  const newBest = buildGameOverSummary({
+    score: 505,
+    runIndex: 6,
+    bestScoreBeforeRun: 480,
+    bestScoreAfterRun: 505,
+    entries: [],
+    playerPosition: 101,
+    playerInsights: { isFirstRun: false, isPersonalBest: true, rank: 101, comparisonMode: 'overall' },
+    isAuthenticated: true
+  });
+  assert.equal(newBest.boostText, 'You’re #101');
+
+  const weakerRun = buildGameOverSummary({
+    score: 450,
+    runIndex: 7,
+    bestScoreBeforeRun: 505,
+    bestScoreAfterRun: 505,
+    entries: [],
+    playerPosition: 120,
+    playerInsights: { isFirstRun: false, isPersonalBest: false, rank: 120, comparisonMode: 'overall' },
+    isAuthenticated: true
+  });
+  assert.equal(weakerRun.boostText, '');
 });


### PR DESCRIPTION
### Motivation
- Surface a short "boost" line on the Game Over screen when an authenticated player achieves a new personal best and show their achieved rank. 
- Improve Game Over leaderboard UX by adding visual gaps and optionally including rows around the player when they are outside the top list. 

### Description
- Add a new `goBoost` element in `index.html` and corresponding DOM id in `js/state.js` as `goBoost`. 
- Style the boost line with new CSS rules (`.go-boost` and related loading styles) in `css/style.css`. 
- Populate the boost text in `js/game/session.js` by reading `summary.boostText`, setting `DOM.goBoost.textContent` and toggling `hidden`. 
- In `js/game/game-over-copy.js` add `getAchievedRank` and include `boostText` in the returned summary across practice, backend-prompt, and local/insights flows when appropriate. 
- Enhance leaderboard rendering in `js/ui.js` by adding `createLeaderboardGapRow`, `buildAroundPlayerRowsFromTopEntries`, and logic to append gap/around-player rows when the authenticated player is outside the top entries while preserving prompt-slice behavior. 
- Add unit tests in `scripts/game-over-copy.test.mjs` to assert the `boostText` behavior for new best and non-best runs. 

### Testing
- Ran the game-over copy unit tests in `scripts/game-over-copy.test.mjs`, which include the new `boostText` assertions and they passed. 
- Ran the existing automated summary tests for graceful fallbacks and practice-mode copy, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed131d92d08320ba648d1b086724d2)