### PR TITLE
Backend-driven X share flow for game over result sharing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1190,6 +1190,13 @@ body.start-launching #walletCorner {
   transform: translateY(-2px);
 }
 
+.go-btn-share:disabled {
+  opacity: .7;
+  cursor: progress;
+  transform: none;
+  box-shadow: none;
+}
+
 .go-btn-menu {
   background: rgba(255, 255, 255, .03);
   border: 1px solid rgba(255,255,255,.12);

--- a/js/api.js
+++ b/js/api.js
@@ -394,6 +394,31 @@ async function fetchGameOverPreview({ score, distance, isAuthenticated }) {
   }
 }
 
+/**
+ * @typedef {Object} SharePayload
+ * @property {number} [scoreForShare]
+ * @property {string} shareUrl
+ * @property {string} postText
+ */
+
+/**
+ * @param {string} wallet
+ * @returns {Promise<{ok:boolean,status:number,data:SharePayload}>}
+ */
+async function fetchSharePayload(wallet) {
+  const normalizedWallet = String(wallet || '').trim();
+  if (!normalizedWallet) {
+    return {
+      ok: false,
+      status: 400,
+      data: { shareUrl: '', postText: '' }
+    };
+  }
+
+  const url = `${BACKEND_URL}/api/leaderboard/share/payload/${encodeURIComponent(normalizedWallet)}`;
+  return requestJsonResult(url, REQUEST_PROFILE_LEADERBOARD_READ);
+}
+
 export {
   isAuthenticated,
   getAuthIdentifier,
@@ -403,5 +428,6 @@ export {
   loadAndDisplayLeaderboard,
   resetLeaderboardUI,
   saveResultToLeaderboard,
-  fetchGameOverPreview
+  fetchGameOverPreview,
+  fetchSharePayload
 };

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -1,11 +1,11 @@
-import { isAuthenticated, loadAndDisplayLeaderboard, updateWalletUI, resetWalletPlayerUI, resetLeaderboardUI } from '../api.js';
+import { isAuthenticated, loadAndDisplayLeaderboard, updateWalletUI, resetWalletPlayerUI, resetLeaderboardUI, fetchSharePayload } from '../api.js';
 import { audioManager, restoreAudioSettings, initAudioToggles } from '../audio.js';
 import { DOM, gameState } from '../state.js';
 import { assetManager } from '../assets.js';
 import { updateGameOverLeaderboardNotice } from '../ui.js';
 import { loadPlayerUpgrades, updateRidesDisplay, resetStoreState, loadUnauthGameConfig, isStoreAvailable, isUnauthRuntimeMode } from '../store.js';
 import { perfMonitor } from '../perf.js';
-import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks } from '../auth.js';
+import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks, getSigningWalletAddress } from '../auth.js';
 import { initializePingLifecycle, subscribeAppVisibilityLifecycle } from '../runtime-lifecycle.js';
 import { initializeTelegramIntegration } from './integrations/telegram.js';
 import { initializeMetaMaskIntegration } from './integrations/metamask.js';
@@ -58,29 +58,49 @@ function bindUiEventHandlers({ startGame, restartFromGameOver, goToMainMenu, sho
   if (DOM.restartBtn) DOM.restartBtn.addEventListener('click', restartFromGameOver);
   if (DOM.shareResultBtn) {
     DOM.shareResultBtn.addEventListener('click', async () => {
-      const score = DOM.goScore?.textContent || '0';
-      const compare = DOM.goComparison?.textContent || '';
-      const shareText = `I scored ${score} in Ursasstube. ${compare}`.trim();
-      try {
-        if (navigator.share) {
-          await navigator.share({ text: shareText });
-          return;
-        }
-      } catch (_error) {
-        // Ignore share cancellation and fallback to clipboard.
+      const shareBtn = DOM.shareResultBtn;
+      const shareBtnDefaultText = shareBtn.textContent || 'SHARE RESULT';
+      const wallet = getSigningWalletAddress();
+
+      if (!wallet) {
+        notifyWarn('🔗 Connect wallet first!');
+        return;
       }
 
+      shareBtn.disabled = true;
+      shareBtn.textContent = 'SHARING...';
+
       try {
-        if (navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(shareText);
-          notifyWarn('📋 Result copied to clipboard');
+        const result = await fetchSharePayload(wallet);
+        if (!result.ok) {
+          if (result.status === 400) {
+            notifyError('⚠️ Invalid wallet for sharing');
+            return;
+          }
+          if (result.status === 404) {
+            notifyError('⚠️ Player not found');
+            return;
+          }
+          notifyError('⚠️ Share service is unavailable');
           return;
         }
-      } catch (_error) {
-        // Fallthrough.
-      }
 
-      notifyError('⚠️ Sharing is unavailable');
+        const postText = String(result.data?.postText || '').trim();
+        const shareUrl = String(result.data?.shareUrl || '').trim();
+        if (!postText || !shareUrl) {
+          notifyError('⚠️ Share payload is incomplete');
+          return;
+        }
+
+        const tweetText = `${postText}\n${shareUrl}`;
+        const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`;
+        window.open(intentUrl, '_blank', 'noopener,noreferrer');
+      } catch (_error) {
+        notifyError('⚠️ Share service is unavailable');
+      } finally {
+        shareBtn.disabled = false;
+        shareBtn.textContent = shareBtnDefaultText;
+      }
     });
   }
   if (DOM.menuBtn) DOM.menuBtn.addEventListener('click', goToMainMenu);


### PR DESCRIPTION
### Motivation
- Replace client-side text assembly with backend-provided share payload so the share text, URL and score selection follow server business logic.
- Provide a robust UX for sharing (loader state, error handling) and a reusable API helper for other UI consumers.

### Description
- Added `fetchSharePayload(wallet)` in `js/api.js` which calls `GET /api/leaderboard/share/payload/:wallet` and returns the backend payload (`scoreForShare`, `shareUrl`, `postText`).
- Updated the `SHARE RESULT` click handler in `js/game/bootstrap.js` to use `getSigningWalletAddress()` and `fetchSharePayload()`, disable the share button and show a `SHARING...` label while the request is in-flight, and open `https://twitter.com/intent/tweet?text=...` where `text` is `${postText}\n${shareUrl}` encoded via `encodeURIComponent`.
- Added status-aware error notifications for `400` (invalid wallet), `404` (player not found) and other failures, and guard for incomplete payloads.
- Added CSS rule `.go-btn-share:disabled` in `css/style.css` to show a loading/disabled visual state for the share button.

### Testing
- Ran `node scripts/check-syntax.mjs` which passed successfully.
- Pre-commit static analysis checks (`npm run check:static-analysis`) ran as part of the commit hook and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3c0832248320a8a8cdfaa6a04a53)