### PR TITLE
Continuous glow for START GAME and PLAY AGAIN buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -516,6 +516,8 @@ body.ui-stable #gameStart {
   filter: blur(5px);
   opacity: .95;
   background: linear-gradient(45deg, #6366f1, #c084fc, #22d3ee, #6366f1);
+  background-size: 300% 300%;
+  animation: buttonAuraPulse 4s ease-in-out infinite;
 }
 
 .btn-new.connected {
@@ -1175,6 +1177,28 @@ body.start-launching #walletCorner {
   filter: blur(5px);
   opacity: .95;
   background: linear-gradient(45deg, #22d3ee, #10b981, #a855f7, #22d3ee);
+  background-size: 300% 300%;
+  animation: buttonAuraPulse 4s ease-in-out infinite;
+}
+
+.go-btn-restart:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 28px rgba(34, 211, 238, .52);
+}
+
+@keyframes buttonAuraPulse {
+  0% {
+    background-position: 0% 50%;
+    opacity: .78;
+  }
+  50% {
+    background-position: 100% 50%;
+    opacity: 1;
+  }
+  100% {
+    background-position: 0% 50%;
+    opacity: .78;
+  }
 }
 
 .go-btn-share {


### PR DESCRIPTION
### Motivation
- Make the START GAME and PLAY AGAIN buttons have a permanent animated aura so they remain visually prominent without requiring hover.
- Preserve clear hover feedback for interactive state while reusing a single animation to keep behavior consistent and maintainable.

### Description
- Added `background-size: 300% 300%` and `animation: buttonAuraPulse 4s ease-in-out infinite` to `#startBtn::before` in `css/style.css` so the START button shows a continuous aura.
- Added the same `background-size` + `animation` to `.go-btn-restart::before` so PLAY AGAIN also has a persistent glow.
- Added `.go-btn-restart:hover` with a slight translate and stronger shadow to preserve hover feedback.
- Introduced `@keyframes buttonAuraPulse` in `css/style.css` and reused it for both buttons.

### Testing
- Ran `npm run check:syntax`, which completed successfully.
- Pre-commit hooks executed `npm run check:syntax` and `npm run check:static-analysis` during the change and both checks passed.
- The only file modified was `css/style.css` and no additional automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed443569f88320868820ff8059ba6a)