### PR TITLE
Add animated aura and hover effect to start/restart buttons with reduced-motion support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -516,6 +516,8 @@ body.ui-stable #gameStart {
   filter: blur(5px);
   opacity: .95;
   background: linear-gradient(45deg, #6366f1, #c084fc, #22d3ee, #6366f1);
+  background-size: 300% 300%;
+  animation: buttonAuraPulse 4s ease-in-out infinite;
 }
 
 .btn-new.connected {
@@ -1175,6 +1177,37 @@ body.start-launching #walletCorner {
   filter: blur(5px);
   opacity: .95;
   background: linear-gradient(45deg, #22d3ee, #10b981, #a855f7, #22d3ee);
+  background-size: 300% 300%;
+  animation: buttonAuraPulse 4s ease-in-out infinite;
+}
+
+.go-btn-restart:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 28px rgba(34, 211, 238, .52);
+}
+
+@keyframes buttonAuraPulse {
+  0% {
+    background-position: 0% 50%;
+    opacity: .78;
+  }
+  50% {
+    background-position: 100% 50%;
+    opacity: 1;
+  }
+  100% {
+    background-position: 0% 50%;
+    opacity: .78;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #startBtn::before,
+  .go-btn-restart::before {
+    animation: none;
+    background-position: 50% 50%;
+    opacity: .9;
+  }
 }
 
 .go-btn-share {


### PR DESCRIPTION
### Motivation
- Improve visual affordance for primary action buttons by adding a subtle animated aura and a hover lift while respecting users who prefer reduced motion.

### Description
- Add `background-size: 300% 300%` and `animation: buttonAuraPulse 4s ease-in-out infinite` to `#startBtn::before` and `.go-btn-restart::before` and introduce the `@keyframes buttonAuraPulse` animation. 

### Testing
- No automated tests were run for this style-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed443569f88320868820ff8059ba6a)