### PR TITLE
Only call Telegram color APIs on supported WebApp versions and add test

### DIFF
--- a/js/runtime-lifecycle.js
+++ b/js/runtime-lifecycle.js
@@ -44,8 +44,13 @@ function initializeTelegramViewportLifecycle() {
 
   const tg = window.Telegram.WebApp;
   tg.expand();
-  tg.setHeaderColor('#05030b');
-  tg.setBackgroundColor('#05030b');
+  const canSetColors = typeof tg.isVersionAtLeast === 'function'
+    ? tg.isVersionAtLeast('6.1')
+    : false;
+  if (canSetColors) {
+    tg.setHeaderColor('#05030b');
+    tg.setBackgroundColor('#05030b');
+  }
   tg.ready();
   tg.isClosingConfirmationEnabled = true;
 

--- a/scripts/runtime-lifecycle.test.mjs
+++ b/scripts/runtime-lifecycle.test.mjs
@@ -100,3 +100,30 @@ test('initializePingLifecycle schedules measurements and cleanup stops timers', 
     env.restore();
   }
 });
+
+test('initializeTelegramViewportLifecycle skips unsupported color calls for Telegram v6.0', async () => {
+  const env = withLifecycleGlobals();
+  const { initializeTelegramViewportLifecycle } = await import('../js/runtime-lifecycle.js');
+  let headerColorCalls = 0;
+  let backgroundColorCalls = 0;
+
+  try {
+    env.window.Telegram = {
+      WebApp: {
+        expand() {},
+        ready() {},
+        onEvent() {},
+        isVersionAtLeast: (version) => version !== '6.1',
+        setHeaderColor: () => { headerColorCalls += 1; },
+        setBackgroundColor: () => { backgroundColorCalls += 1; }
+      }
+    };
+
+    initializeTelegramViewportLifecycle();
+
+    assert.equal(headerColorCalls, 0);
+    assert.equal(backgroundColorCalls, 0);
+  } finally {
+    env.restore();
+  }
+});


### PR DESCRIPTION
### Motivation
- Prevent calling Telegram WebApp color APIs on older clients where those calls may be unsupported and could cause errors.

### Description
- Add a `canSetColors` guard that uses `tg.isVersionAtLeast('6.1')` (when available) to decide whether to call `tg.setHeaderColor` and `tg.setBackgroundColor` in `initializeTelegramViewportLifecycle`.
- Fall back safely when `isVersionAtLeast` is not a function by treating colors as unsupported.
- Add a unit test `initializeTelegramViewportLifecycle skips unsupported color calls for Telegram v6.0` in `scripts/runtime-lifecycle.test.mjs` that mocks `window.Telegram.WebApp` and asserts color setters are not called for v6.0.

### Testing
- Ran the unit test `initializeTelegramViewportLifecycle skips unsupported color calls for Telegram v6.0`, which passed.
- Ran the lifecycle test suite (including `initializePingLifecycle` and visibility/resize tests) after the change, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfe79290c8320ac344302e10786ba)