### PR TITLE
Fix Telegram closing confirmation compatibility

### DIFF
--- a/js/runtime-lifecycle.js
+++ b/js/runtime-lifecycle.js
@@ -52,7 +52,9 @@ function initializeTelegramViewportLifecycle() {
     tg.setBackgroundColor('#05030b');
   }
   tg.ready();
-  tg.isClosingConfirmationEnabled = true;
+  if (typeof tg.enableClosingConfirmation === 'function') {
+    tg.enableClosingConfirmation();
+  }
 
   if (!telegramViewportHandler) {
     telegramViewportHandler = (event) => {

--- a/scripts/runtime-lifecycle.test.mjs
+++ b/scripts/runtime-lifecycle.test.mjs
@@ -106,23 +106,36 @@ test('initializeTelegramViewportLifecycle skips unsupported color calls for Tele
   const { initializeTelegramViewportLifecycle } = await import('../js/runtime-lifecycle.js');
   let headerColorCalls = 0;
   let backgroundColorCalls = 0;
+  let closingConfirmationSetterCalls = 0;
+  let closingConfirmationMethodCalls = 0;
 
   try {
+    const webApp = {
+      expand() {},
+      ready() {},
+      onEvent() {},
+      isVersionAtLeast: (version) => version !== '6.1',
+      setHeaderColor: () => { headerColorCalls += 1; },
+      setBackgroundColor: () => { backgroundColorCalls += 1; },
+      enableClosingConfirmation: () => { closingConfirmationMethodCalls += 1; }
+    };
+    Object.defineProperty(webApp, 'isClosingConfirmationEnabled', {
+      set() {
+        closingConfirmationSetterCalls += 1;
+      },
+      configurable: true
+    });
+
     env.window.Telegram = {
-      WebApp: {
-        expand() {},
-        ready() {},
-        onEvent() {},
-        isVersionAtLeast: (version) => version !== '6.1',
-        setHeaderColor: () => { headerColorCalls += 1; },
-        setBackgroundColor: () => { backgroundColorCalls += 1; }
-      }
+      WebApp: webApp
     };
 
     initializeTelegramViewportLifecycle();
 
     assert.equal(headerColorCalls, 0);
     assert.equal(backgroundColorCalls, 0);
+    assert.equal(closingConfirmationSetterCalls, 0);
+    assert.equal(closingConfirmationMethodCalls, 1);
   } finally {
     env.restore();
   }


### PR DESCRIPTION
### Motivation
- Avoid writing to `Telegram.WebApp.isClosingConfirmationEnabled` because older Telegram WebApp versions (6.0) do not support that property and produce warnings. 

### Description
- Replace direct assignment `tg.isClosingConfirmationEnabled = true` with a guarded call to `tg.enableClosingConfirmation()` when that function exists in `js/runtime-lifecycle.js`.
- Extend `scripts/runtime-lifecycle.test.mjs` to mock a `WebApp` exposing `enableClosingConfirmation` and a configurable `isClosingConfirmationEnabled` setter, and assert the setter is not invoked while the method is called once.
- Keep the existing color-version check that skips `setHeaderColor`/`setBackgroundColor` for Telegram v6.0.

### Testing
- Ran `node --test scripts/runtime-lifecycle.test.mjs` and all tests passed (3/3).
- Pre-commit checks executed `npm run check:syntax` and `npm run check:static-analysis` and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee011cbccc832089938357ca13c186)