### PR TITLE
Load Phaser from local dependency; remove importmap/CDN fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,16 +10,6 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">
   <!-- Intentional external runtime dependency for Telegram Mini App APIs -->
   <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
-  <!-- Import map: resolves bare specifier 'phaser' to the CDN ESM build.
-       Must appear before any <script type="module"> that imports phaser.
-       Note: ESM modules do not set window.Phaser — that is expected and correct. -->
-  <script type="importmap">
-  {
-    "imports": {
-      "phaser": "https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js"
-    }
-  }
-  </script>
 </head>
 
 

--- a/js/phaser/runtime.js
+++ b/js/phaser/runtime.js
@@ -1,28 +1,9 @@
 import { MAIN_SCENE_KEY, createMainSceneClass } from './scenes/MainScene.js';
 import { createRuntimeController } from './runtime-controller.js';
 
-// The CDN ESM build of Phaser. Mapped via importmap in index.html so that
-// bare specifier 'phaser' resolves to this URL in the browser.
-// Note: ESM modules do not populate window.Phaser — typeof window.Phaser
-// will be 'undefined' even when Phaser is loaded correctly via ESM.
-const PHASER_CDN_URL = 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
-
-async function importModule(specifier) {
-  return import(/* @vite-ignore */ specifier);
-}
-
 async function loadPhaserModule() {
-  try {
-    // With the importmap in index.html, 'phaser' resolves to PHASER_CDN_URL in the browser.
-    // In a local dev/build environment where phaser is installed as a package, it resolves locally.
-    const localModule = await importModule('phaser');
-    return localModule.default || localModule;
-  } catch (localError) {
-    // Fallback: load CDN URL directly if the 'phaser' specifier still cannot be resolved.
-    console.warn('⚠️ Local Phaser package is unavailable, falling back to CDN runtime.', localError);
-    const cdnModule = await importModule(PHASER_CDN_URL);
-    return cdnModule.default || cdnModule;
-  }
+  const localModule = await import('phaser');
+  return localModule.default || localModule;
 }
 
 async function createPhaserRuntime({ parent, snapshot, width, height, resolution }) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "vite": "^7.1.0"
   },
   "dependencies": {
-    "@walletconnect/ethereum-provider": "file:vendor/walletconnect-ethereum-provider"
+    "@walletconnect/ethereum-provider": "file:vendor/walletconnect-ethereum-provider",
+    "phaser": "^3.90.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
### Motivation

- Ensure Phaser is resolved from a deterministic local package rather than relying on a browser `importmap` or an external CDN at runtime.

### Description

- Removed the `importmap` and related comments from `index.html` so the page no longer depends on a browser import map for Phaser.
- Simplified `js/phaser/runtime.js` by removing the manual import helper and CDN fallback and now loading Phaser with `import('phaser')` directly.
- Added `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee02fff7d88320bb51ca09cf33da9c)