### PR TITLE
Show 'Good Spin' on first successful spin

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -426,6 +426,7 @@ function update(delta) {
         t.collected = true;
         gameState.spinComboRingActive = false;
         gameState.spinComboCount++;
+        if (gameState.spinComboCount === 1) showBonusText("Good Spin");
         const comboLevel = Math.max(0, gameState.spinComboCount - 1);
         if (comboLevel > 0) {
           const comboTable = [0, 500, 1500, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000];


### PR DESCRIPTION
### Motivation
- Provide immediate player feedback the first time a spin target is successfully hit in a run by showing a short compliment message.

### Description
- Add a single conditional in `js/physics.js` to call `showBonusText("Good Spin")` when `gameState.spinComboCount === 1`, leaving existing combo messaging unchanged.

### Testing
- Ran `npm run build` which completed successfully and the code passed the repository static checks including `check:syntax` and `check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee044092788320a5b27e50e91bdfe0)