### PR TITLE
Guard Telegram closing confirmation by WebApp version

### DIFF
--- a/js/runtime-lifecycle.js
+++ b/js/runtime-lifecycle.js
@@ -52,7 +52,10 @@ function initializeTelegramViewportLifecycle() {
     tg.setBackgroundColor('#05030b');
   }
   tg.ready();
-  if (typeof tg.enableClosingConfirmation === 'function') {
+  const canEnableClosingConfirmation = typeof tg.isVersionAtLeast === 'function'
+    ? tg.isVersionAtLeast('6.2')
+    : false;
+  if (canEnableClosingConfirmation && typeof tg.enableClosingConfirmation === 'function') {
     tg.enableClosingConfirmation();
   }
 

--- a/scripts/runtime-lifecycle.test.mjs
+++ b/scripts/runtime-lifecycle.test.mjs
@@ -2,6 +2,16 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { APP_VISIBILITY_EVENT } from '../js/runtime-events.js';
 
+function telegramIsVersionAtLeastFactory(currentVersion) {
+  const [major, minor = 0] = String(currentVersion).split('.').map((part) => Number.parseInt(part, 10) || 0);
+  return (requiredVersion) => {
+    const [requiredMajor, requiredMinor = 0] = String(requiredVersion).split('.').map((part) => Number.parseInt(part, 10) || 0);
+    if (major > requiredMajor) return true;
+    if (major < requiredMajor) return false;
+    return minor >= requiredMinor;
+  };
+}
+
 function withLifecycleGlobals({ hidden = false } = {}) {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
@@ -101,7 +111,7 @@ test('initializePingLifecycle schedules measurements and cleanup stops timers', 
   }
 });
 
-test('initializeTelegramViewportLifecycle skips unsupported color calls for Telegram v6.0', async () => {
+test('initializeTelegramViewportLifecycle skips unsupported color and closing confirmation calls for Telegram v6.0', async () => {
   const env = withLifecycleGlobals();
   const { initializeTelegramViewportLifecycle } = await import('../js/runtime-lifecycle.js');
   let headerColorCalls = 0;
@@ -114,7 +124,7 @@ test('initializeTelegramViewportLifecycle skips unsupported color calls for Tele
       expand() {},
       ready() {},
       onEvent() {},
-      isVersionAtLeast: (version) => version !== '6.1',
+      isVersionAtLeast: telegramIsVersionAtLeastFactory('6.0'),
       setHeaderColor: () => { headerColorCalls += 1; },
       setBackgroundColor: () => { backgroundColorCalls += 1; },
       enableClosingConfirmation: () => { closingConfirmationMethodCalls += 1; }
@@ -135,6 +145,34 @@ test('initializeTelegramViewportLifecycle skips unsupported color calls for Tele
     assert.equal(headerColorCalls, 0);
     assert.equal(backgroundColorCalls, 0);
     assert.equal(closingConfirmationSetterCalls, 0);
+    assert.equal(closingConfirmationMethodCalls, 0);
+  } finally {
+    env.restore();
+  }
+});
+
+test('initializeTelegramViewportLifecycle enables closing confirmation for Telegram v6.2+', async () => {
+  const env = withLifecycleGlobals();
+  const { initializeTelegramViewportLifecycle } = await import('../js/runtime-lifecycle.js');
+  let closingConfirmationMethodCalls = 0;
+
+  try {
+    const webApp = {
+      expand() {},
+      ready() {},
+      onEvent() {},
+      isVersionAtLeast: telegramIsVersionAtLeastFactory('6.2'),
+      setHeaderColor() {},
+      setBackgroundColor() {},
+      enableClosingConfirmation: () => { closingConfirmationMethodCalls += 1; }
+    };
+
+    env.window.Telegram = {
+      WebApp: webApp
+    };
+
+    initializeTelegramViewportLifecycle();
+
     assert.equal(closingConfirmationMethodCalls, 1);
   } finally {
     env.restore();


### PR DESCRIPTION
### Motivation
- Prevent calling `Telegram.WebApp.enableClosingConfirmation()` on older Mini App runtimes (which causes console warnings like "Closing confirmation is not supported in version 6.0").
- Preserve the existing color API guard that relies on `isVersionAtLeast('6.1')` while restricting closing confirmation to `6.2+`.
- Make version-dependent behavior explicit and testable in lifecycle tests.

### Description
- Changed `js/runtime-lifecycle.js` to check `tg.isVersionAtLeast('6.2')` before calling `tg.enableClosingConfirmation()` and only call it if the runtime reports `6.2+` and the method exists.
- Extended `scripts/runtime-lifecycle.test.mjs` with a `telegramIsVersionAtLeastFactory` helper to simulate WebApp version comparisons in tests.
- Updated the existing Telegram lifecycle test to assert that v`6.0` skips color APIs and does not call closing confirmation, and added a new test that v`6.2+` triggers `enableClosingConfirmation()`.

### Testing
- Ran `node --test scripts/runtime-lifecycle.test.mjs` and all tests passed successfully.
- Pre-commit automated checks executed during the change included `node scripts/check-syntax.mjs` and `node scripts/check-static-analysis.mjs`, and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee07b570e4832086fb8abaa47b3bd7)