### PR TITLE
Make right HUD icons as bright as left

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -839,7 +839,7 @@ body.start-launching #walletCorner {
 }
 
 #uiTopRight .label {
-  opacity: 0.6;
+  opacity: 1;
   order: 2;
   display: inline-flex;
   align-items: center;
@@ -848,6 +848,7 @@ body.start-launching #walletCorner {
 #uiTopRight .label .icon-atlas {
   transform: scale(1.1);
   transform-origin: center;
+  filter: brightness(1.35) saturate(1.2);
 }
 #uiTopRight .value {
   order: 1;


### PR DESCRIPTION
### Motivation
- Right-side HUD icons appeared visually dimmer than left-side indicators, so the UI needs matching brightness for consistent visual feedback.

### Description
- Updated `css/style.css` to set `#uiTopRight .label` opacity to `1` and added `filter: brightness(1.35) saturate(1.2)` to `#uiTopRight .label .icon-atlas` so right-side icons match left-side intensity.

### Testing
- Ran `npm run check:syntax` and the repository pre-commit static analysis checks, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee09947dac8320b20372d4bfddd940)