### PR TITLE
Enhance start/restart button labels and visuals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -492,10 +492,13 @@ body.ui-stable #gameStart {
   min-height: 73px;
   padding: 21px 40px;
   font-size: 18px;
+  font-weight: 800;
   margin-top: -20px;
   position: relative;
   isolation: isolate;
   overflow: hidden;
+  color: #f8fbff;
+  text-shadow: 0 1px 2px rgba(6, 10, 28, .9), 0 0 8px rgba(6, 10, 28, .5);
   background:
     radial-gradient(circle at 20% 20%, rgba(255, 255, 255, .26) 0%, rgba(255, 255, 255, 0) 48%),
     linear-gradient(120deg, rgba(99, 102, 241, .58), rgba(192, 132, 252, .58));
@@ -515,6 +518,12 @@ body.ui-stable #gameStart {
   background: linear-gradient(45deg, #6366f1, #c084fc, #22d3ee, #6366f1);
   background-size: 300% 300%;
   animation: buttonAuraPulse 4s ease-in-out infinite;
+}
+
+#startBtn .btn-label,
+.go-btn-restart .btn-label {
+  position: relative;
+  z-index: 2;
 }
 
 .btn-new.connected {
@@ -1159,6 +1168,8 @@ body.start-launching #walletCorner {
   font-size: 15px;
   font-weight: 800;
   letter-spacing: 1.2px;
+  color: #f8fbff;
+  text-shadow: 0 1px 2px rgba(6, 10, 28, .9), 0 0 8px rgba(6, 10, 28, .45);
   background: linear-gradient(90deg, rgba(34, 211, 238, .65), rgba(16, 185, 129, .62), rgba(168, 85, 247, .6));
 }
 

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 
   <div class="new-buttons">
     <button class="btn-new btn-new-store menu-hidden" id="storeBtn" data-action="show-store">STORE</button>
-    <button class="btn-new btn-new-primary" id="startBtn" data-action="start-game">START GAME</button>
+    <button class="btn-new btn-new-primary" id="startBtn" data-action="start-game"><span class="btn-label">START GAME</span></button>
     <div id="ridesInfo" aria-hidden="true">
       <span id="ridesText" style="font-family: 'Orbitron', sans-serif; font-size: 13px; font-weight: 600; color: rgba(255,255,255,.8);"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> 3 rides</span>
       <span id="ridesTimer" style="font-family: 'Orbitron', sans-serif; font-size: 11px; color: #fbbf24; display: none;"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -28px"></span> Resets in 0h 0m</span>
@@ -180,7 +180,7 @@
   </div>
 
   <div class="go-buttons">
-    <button class="go-btn go-btn-restart" id="restartBtn">PLAY AGAIN</button>
+    <button class="go-btn go-btn-restart" id="restartBtn"><span class="btn-label">PLAY AGAIN</span></button>
     <button class="go-btn go-btn-share" id="shareResultBtn">SHARE RESULT</button>
     <button class="go-btn go-btn-menu" id="menuBtn">MENU</button>
   </div>


### PR DESCRIPTION
### Motivation
- Ensure button text remains readable above animated/gradient button backgrounds and aura effects.
- Improve visual weight and layering of the primary `START GAME` and `PLAY AGAIN` controls so labels render clearly on top of decorative pseudo-elements.

### Description
- Wrap the `START GAME` and `PLAY AGAIN` button text in a `<span class="btn-label">` in `index.html` to create a dedicated label element for layering.
- Add CSS to raise label stacking and ensure proper contrast by introducing `.btn-label` positioning and `z-index` rules and making label text bold via `font-weight: 800`.
- Apply color and `text-shadow` adjustments to `#startBtn` and `.go-btn-restart` and add the corresponding label selector so text remains crisp over the animated gradient aura.

### Testing
- Ran the project's linting for HTML/CSS with `npm run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0fcc3f708320bc280b7c46d6fc6b)