### PR TITLE
Polish start/restart CTAs: add label wrapper and refine button visuals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -492,10 +492,13 @@ body.ui-stable #gameStart {
   min-height: 73px;
   padding: 21px 40px;
   font-size: 18px;
+  font-weight: 800;
   margin-top: -20px;
   position: relative;
   isolation: isolate;
   overflow: hidden;
+  color: #f8fbff;
+  text-shadow: 0 1px 2px rgba(6, 10, 28, .9), 0 0 8px rgba(6, 10, 28, .5);
   background:
     radial-gradient(circle at 20% 20%, rgba(255, 255, 255, .26) 0%, rgba(255, 255, 255, 0) 48%),
     linear-gradient(120deg, rgba(99, 102, 241, .58), rgba(192, 132, 252, .58));
@@ -513,8 +516,14 @@ body.ui-stable #gameStart {
   filter: none;
   opacity: .38;
   background: linear-gradient(45deg, #6366f1, #c084fc, #22d3ee, #6366f1);
-  background-size: 300% 300%;
-  animation: buttonAuraPulse 4s ease-in-out infinite;
+  background-size: 100% 100%;
+  animation: none;
+}
+
+#startBtn .btn-label,
+.go-btn-restart .btn-label {
+  position: relative;
+  z-index: 2;
 }
 
 .btn-new.connected {
@@ -1159,6 +1168,8 @@ body.start-launching #walletCorner {
   font-size: 15px;
   font-weight: 800;
   letter-spacing: 1.2px;
+  color: #f8fbff;
+  text-shadow: 0 1px 2px rgba(6, 10, 28, .9), 0 0 8px rgba(6, 10, 28, .45);
   background: linear-gradient(90deg, rgba(34, 211, 238, .65), rgba(16, 185, 129, .62), rgba(168, 85, 247, .6));
 }
 
@@ -1172,8 +1183,8 @@ body.start-launching #walletCorner {
   filter: none;
   opacity: .36;
   background: linear-gradient(45deg, #22d3ee, #10b981, #a855f7, #22d3ee);
-  background-size: 300% 300%;
-  animation: buttonAuraPulse 4s ease-in-out infinite;
+  background-size: 100% 100%;
+  animation: none;
 }
 
 .go-btn-restart:hover {

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 
   <div class="new-buttons">
     <button class="btn-new btn-new-store menu-hidden" id="storeBtn" data-action="show-store">STORE</button>
-    <button class="btn-new btn-new-primary" id="startBtn" data-action="start-game">START GAME</button>
+    <button class="btn-new btn-new-primary" id="startBtn" data-action="start-game"><span class="btn-label">START GAME</span></button>
     <div id="ridesInfo" aria-hidden="true">
       <span id="ridesText" style="font-family: 'Orbitron', sans-serif; font-size: 13px; font-weight: 600; color: rgba(255,255,255,.8);"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> 3 rides</span>
       <span id="ridesTimer" style="font-family: 'Orbitron', sans-serif; font-size: 11px; color: #fbbf24; display: none;"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -28px"></span> Resets in 0h 0m</span>
@@ -180,7 +180,7 @@
   </div>
 
   <div class="go-buttons">
-    <button class="go-btn go-btn-restart" id="restartBtn">PLAY AGAIN</button>
+    <button class="go-btn go-btn-restart" id="restartBtn"><span class="btn-label">PLAY AGAIN</span></button>
     <button class="go-btn go-btn-share" id="shareResultBtn">SHARE RESULT</button>
     <button class="go-btn go-btn-menu" id="menuBtn">MENU</button>
   </div>


### PR DESCRIPTION
### Motivation
- Improve the visual prominence and legibility of the primary CTAs on the start and game-over screens. 
- Ensure the button text renders above decorative pseudo-elements so labels remain readable. 
- Remove continuous aura animation for a more static, consistent look and reduced motion impact.

### Description
- Wrapped the start and restart button text with a `<span class="btn-label">` in `index.html` for both `#startBtn` and `#restartBtn` so labels can be layered above decorative backgrounds. 
- Updated `css/style.css` to increase emphasis and contrast for the CTAs by adding `font-weight: 800`, `color: #f8fbff`, and `text-shadow` to `#startBtn` and `.go-btn-restart`. 
- Changed the pseudo-element treatments for `#startBtn::before` and `.go-btn-restart::before` to `background-size: 100% 100%` and disabled the `buttonAuraPulse` animation by setting `animation: none`, and added a `.btn-label` rule to set `z-index: 2` so the label sits above the pseudo-element. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0fcc3f708320bc280b7c46d6fc6b)