### PR TITLE
Add coin reward history to player menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2792,6 +2792,75 @@ footer a:hover { color: #e0b0ff; }
   letter-spacing: 4px;
 }
 
+.pm-history {
+  margin-top: 20px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: 14px;
+  background: rgba(9, 7, 18, .55);
+  overflow: hidden;
+}
+
+.pm-history-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, .78);
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, .1);
+}
+
+.pm-history-table-wrap {
+  max-height: 240px;
+  overflow: auto;
+}
+
+.pm-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 11px;
+}
+
+.pm-history-table th,
+.pm-history-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+}
+
+.pm-history-table th {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, .55);
+  background: rgba(255, 255, 255, .03);
+}
+
+.pm-history-table th img {
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+}
+
+.pm-history-table td {
+  color: rgba(255, 255, 255, .87);
+}
+
+.pm-history-table td:nth-child(2),
+.pm-history-table td:nth-child(3),
+.pm-history-table th:nth-child(2),
+.pm-history-table th:nth-child(3) {
+  text-align: right;
+  width: 82px;
+}
+
+.pm-history-empty {
+  text-align: center !important;
+  color: rgba(255, 255, 255, .45) !important;
+}
+
 /* Nickname and display mode rows */
 .pm-row {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -260,6 +260,26 @@
         <span class="pm-streak-label">Share streak</span>
         <div class="pm-streak-icons" id="pmStreakIcons"></div>
       </div>
+
+      <section class="pm-history" aria-label="Coin rewards history">
+        <div class="pm-history-title">History</div>
+        <div class="pm-history-table-wrap">
+          <table class="pm-history-table">
+            <thead>
+              <tr>
+                <th scope="col">Type</th>
+                <th scope="col"><img src="img/icon_gold.png" alt="Gold"></th>
+                <th scope="col"><img src="img/icon_silver.png" alt="Silver"></th>
+              </tr>
+            </thead>
+            <tbody id="pmHistoryBody">
+              <tr>
+                <td colspan="3" class="pm-history-empty">No rewards yet</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
     </div>
 
     <!-- Right column: account connections -->

--- a/js/api.js
+++ b/js/api.js
@@ -454,6 +454,23 @@ async function fetchMyProfile() {
   }
 }
 
+async function fetchCoinHistory(limit = 50) {
+  const primaryId = getPrimaryAuthIdentifier();
+  if (!primaryId) return [];
+  try {
+    const url = `${BACKEND_URL}/api/account/me/coin-history?limit=${encodeURIComponent(limit)}`;
+    const { ok, data } = await requestJsonResult(url, {
+      ...REQUEST_PROFILE_LEADERBOARD_READ,
+      headers: buildAuthHeaders()
+    });
+    if (!ok || !Array.isArray(data)) return [];
+    return data;
+  } catch (e) {
+    logger.warn('⚠️ fetchCoinHistory error:', e);
+    return [];
+  }
+}
+
 async function trackReferral(ref) {
   try {
     const { ok, data } = await requestJsonResult(`${BACKEND_URL}/api/referral/track`, {
@@ -554,6 +571,7 @@ export {
   saveResultToLeaderboard,
   fetchGameOverPreview,
   fetchMyProfile,
+  fetchCoinHistory,
   trackReferral,
   startShare,
   confirmShare,

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -1,5 +1,5 @@
 import { DOM } from '../state.js';
-import { fetchMyProfile, disconnectX, setNickname, setLeaderboardDisplay } from '../api.js';
+import { fetchMyProfile, fetchCoinHistory, disconnectX, setNickname, setLeaderboardDisplay } from '../api.js';
 import { hasAuthenticatedSession, linkTelegram, linkWallet } from '../auth.js';
 import { showPlayerMenuScreen, hidePlayerMenuScreen } from '../screens.js';
 import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';
@@ -11,6 +11,43 @@ let menuOpen = false;
 let currentProfile = null;
 let longPressTimer = null;
 let eventsInitialized = false;
+const COIN_HISTORY_TYPE_LABELS = {
+  share: 'Share result',
+  ride: 'Ride',
+  buy: 'Purchase reward',
+  referral: 'Referral bonus',
+  refer: 'Friend joined',
+  task: 'Task'
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderCoinHistory(history) {
+  const tbody = DOM.pmHistoryBody;
+  if (!tbody) return;
+
+  const rows = Array.isArray(history) ? history : [];
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="3" class="pm-history-empty">No rewards yet</td></tr>';
+    return;
+  }
+
+  const html = rows.map((entry) => {
+    const typeKey = String(entry?.type || '').toLowerCase();
+    const typeLabel = COIN_HISTORY_TYPE_LABELS[typeKey] || typeKey || 'Unknown';
+    const gold = Math.max(0, Number(entry?.gold || 0));
+    const silver = Math.max(0, Number(entry?.silver || 0));
+    return `<tr><td>${escapeHtml(typeLabel)}</td><td>${gold.toLocaleString('en-US')}</td><td>${silver.toLocaleString('en-US')}</td></tr>`;
+  }).join('');
+  tbody.innerHTML = html;
+}
 
 function updateShareButtonState(profile) {
   const btn = DOM.pmShareBtn;
@@ -136,10 +173,14 @@ function fillProfileData(profile) {
 }
 
 async function loadProfile() {
-  const profile = await fetchMyProfile();
+  const [profile, coinHistory] = await Promise.all([
+    fetchMyProfile(),
+    fetchCoinHistory(50)
+  ]);
   if (profile) {
     fillProfileData(profile);
   }
+  renderCoinHistory(coinHistory);
   // If profile is null (e.g. 401), keep any fallback values already shown
   return profile;
 }

--- a/js/state.js
+++ b/js/state.js
@@ -159,6 +159,7 @@ const DOM_IDS = {
   pmNicknameInput: 'pmNicknameInput',
   pmNicknameSaveBtn: 'pmNicknameSaveBtn',
   pmDisplaySelect: 'pmDisplaySelect',
+  pmHistoryBody: 'pmHistoryBody',
   startHook: 'startHook'
 };
 


### PR DESCRIPTION
### Motivation
- Provide players with a compact history of recent coin rewards (gold and silver) in the player menu so they can inspect recent credit events.
- Use the existing backend endpoint `GET /api/account/me/coin-history?limit=50` (auth required) to show recent reward types and amounts.

### Description
- Added a new `History` section (table `Type | Gold | Silver`) to the bottom of `#playerMenuOverlay` in `index.html` with default empty state and icon headers using `img/icon_gold.png` and `img/icon_silver.png`.
- Added compact leaderboard-like styles in `css/style.css` for `.pm-history`, `.pm-history-table`, and empty / column alignment rules.
- Implemented `fetchCoinHistory(limit = 50)` in `js/api.js` to call `GET /api/account/me/coin-history` with auth headers and exported it from the API module.
- Wired the new DOM node `pmHistoryBody` into `js/state.js` and updated `js/player-menu/controller.js` to `Promise.all([fetchMyProfile(), fetchCoinHistory(50)])`, render the history table with human-readable type labels and an `escapeHtml()` helper to avoid injection.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- Ran request/unit tests via `npm run test:request` and all tests passed.
- Pre-commit static analysis checks executed during the commit (`check:static-analysis`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b20ed4a88320a176207cfc6d8224)