### PR TITLE
Center wallet/username column in Game Over leaderboard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -700,6 +700,11 @@ body.ui-stable #gameStart {
   font-size: 11px;
 }
 
+#gameOverLeaderboardList .lb-wallet {
+  margin-left: 0;
+  text-align: center;
+}
+
 .lb-score {
   min-width: 70px;
   text-align: right;


### PR DESCRIPTION
### Motivation
- On the Game Over screen the wallet address / username column should be centered to match the visual layout of the main leaderboard.

### Description
- Added a CSS override in `css/style.css` targeting `#gameOverLeaderboardList .lb-wallet` to remove the left offset (`margin-left: 0`) and set `text-align: center` for the Game Over leaderboard name column.

### Testing
- Ran `npm run check:syntax`, which completed successfully.
- Pre-commit checks executed `check:static-analysis` as part of commit hooks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0eeb5a99883209d4b1492dcbb2b8b)