### PR TITLE
Fix missing coin income entries in Player Menu history

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -463,8 +463,11 @@ async function fetchCoinHistory(limit = 50) {
       ...REQUEST_PROFILE_LEADERBOARD_READ,
       headers: buildAuthHeaders()
     });
-    if (!ok || !Array.isArray(data)) return [];
-    return data;
+    if (!ok) return [];
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data?.history)) return data.history;
+    if (Array.isArray(data?.items)) return data.items;
+    return [];
   } catch (e) {
     logger.warn('⚠️ fetchCoinHistory error:', e);
     return [];

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -13,9 +13,12 @@ let longPressTimer = null;
 let eventsInitialized = false;
 const COIN_HISTORY_TYPE_LABELS = {
   share: 'Share result',
+  share_reward: 'Share result',
   ride: 'Ride',
   buy: 'Purchase reward',
+  purchase_reward: 'Purchase reward',
   referral: 'Referral bonus',
+  referral_bonus: 'Referral bonus',
   refer: 'Friend joined',
   task: 'Task'
 };
@@ -29,6 +32,50 @@ function escapeHtml(value) {
     .replaceAll("'", '&#39;');
 }
 
+
+function toPositiveNumber(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.max(0, Math.abs(Math.trunc(num)));
+}
+
+function pickCoinAmount(entry, keys = []) {
+  for (const key of keys) {
+    if (entry && Object.prototype.hasOwnProperty.call(entry, key)) {
+      return toPositiveNumber(entry[key]);
+    }
+  }
+  return 0;
+}
+
+function resolveEntryCoins(entry) {
+  const gold = pickCoinAmount(entry, [
+    'gold',
+    'goldCoins',
+    'goldDelta',
+    'goldReward',
+    'goldAmount',
+    'coinsGold'
+  ]);
+  const silver = pickCoinAmount(entry, [
+    'silver',
+    'silverCoins',
+    'silverDelta',
+    'silverReward',
+    'silverAmount',
+    'coinsSilver'
+  ]);
+
+  if (gold || silver) return { gold, silver };
+
+  const amount = pickCoinAmount(entry, ['amount', 'value']);
+  const currency = String(entry?.currency || entry?.coin || entry?.coinType || '').toLowerCase();
+  if (currency === 'gold') return { gold: amount, silver: 0 };
+  if (currency === 'silver') return { gold: 0, silver: amount };
+
+  return { gold: 0, silver: 0 };
+}
+
 function renderCoinHistory(history) {
   const tbody = DOM.pmHistoryBody;
   if (!tbody) return;
@@ -40,10 +87,9 @@ function renderCoinHistory(history) {
   }
 
   const html = rows.map((entry) => {
-    const typeKey = String(entry?.type || '').toLowerCase();
+    const typeKey = String(entry?.type || entry?.rewardType || '').toLowerCase();
     const typeLabel = COIN_HISTORY_TYPE_LABELS[typeKey] || typeKey || 'Unknown';
-    const gold = Math.max(0, Number(entry?.gold || 0));
-    const silver = Math.max(0, Number(entry?.silver || 0));
+    const { gold, silver } = resolveEntryCoins(entry);
     return `<tr><td>${escapeHtml(typeLabel)}</td><td>${gold.toLocaleString('en-US')}</td><td>${silver.toLocaleString('en-US')}</td></tr>`;
   }).join('');
   tbody.innerHTML = html;


### PR DESCRIPTION
### Motivation
- Players reported that coin income lines in the Player Menu history sometimes showed "No rewards yet" or zero values because the frontend expected a strict response shape and specific field names. 
- The change makes the Player Menu resilient to different backend payload shapes and field-name variants so coin rewards display reliably.

### Description
- Relaxed `fetchCoinHistory` in `js/api.js` to accept plain arrays or wrapped responses (`{ history: [...] }` and `{ items: [...] }`) and return an empty array otherwise. 
- Hardened history entry parsing in `js/player-menu/controller.js` by adding `toPositiveNumber`, `pickCoinAmount`, and `resolveEntryCoins` helpers that normalize signed/alternative numeric fields and support many common coin field names (`goldCoins`, `goldDelta`, `goldReward`, `amount + currency`, etc.).
- Added fallback `rewardType` lookup and extra type aliases in `COIN_HISTORY_TYPE_LABELS` (e.g. `share_reward`, `purchase_reward`, `referral_bonus`) so entry types map correctly to user-facing labels.
- Updated `renderCoinHistory` to use the new resolvers and render normalized `gold`/`silver` values in the table.

### Testing
- Ran `npm run check:syntax` and static analysis checks, which completed successfully. 
- Ran the request tests via `npm run test:request`, all tests passed (81/81). 
- Pre-commit quality checks and static-analysis guardrails were executed as part of validation and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0eefbd3848320b7bf15d75c33020d)