### PR TITLE
Center Type column and increase coin column spacing in player menu history table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2853,12 +2853,26 @@ footer a:hover { color: #e0b0ff; }
   color: rgba(255, 255, 255, .87);
 }
 
+.pm-history-table td:first-child {
+  text-align: center;
+}
+
 .pm-history-table td:nth-child(2),
 .pm-history-table td:nth-child(3),
 .pm-history-table th:nth-child(2),
 .pm-history-table th:nth-child(3) {
   text-align: right;
-  width: 82px;
+  width: 96px;
+}
+
+.pm-history-table th:nth-child(2),
+.pm-history-table td:nth-child(2) {
+  padding-right: 18px;
+}
+
+.pm-history-table th:nth-child(3),
+.pm-history-table td:nth-child(3) {
+  padding-left: 18px;
 }
 
 .pm-history-empty {


### PR DESCRIPTION
### Motivation
- Align the table body so the `Type` column matches the header and give gold/silver columns more horizontal space to avoid cramped coin counts.

### Description
- CSS adjustments in `css/style.css`: added `.pm-history-table td:first-child { text-align: center; }`, increased coin columns width from `82px` to `96px`, and added asymmetric padding for the 2nd and 3rd columns to separate gold and silver values.

### Testing
- Ran `npm run check:syntax` and pre-commit static analysis (via commit hooks), both passed; an automated `npm run build` + preview + `playwright` screenshot attempt failed due to `playwright` installation being blocked by the environment (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f40189e083208bb1340038381f2c)