### PR TITLE
Handle non-retryable telemetry 4xx without requeue

### DIFF
--- a/js/analytics-delivery.js
+++ b/js/analytics-delivery.js
@@ -7,6 +7,7 @@ const DEFAULT_ANALYTICS_ENDPOINT = `${BACKEND_URL}/api/telemetry/events`;
 const DEFAULT_FLUSH_INTERVAL_MS = 5000;
 const DEFAULT_MAX_BATCH_SIZE = 20;
 const DEFAULT_MAX_QUEUE_SIZE = 200;
+const NON_RETRYABLE_STATUSES = new Set([400, 401, 403, 404, 413, 422]);
 
 function createAnalyticsDelivery({
   endpoint = DEFAULT_ANALYTICS_ENDPOINT,
@@ -51,17 +52,25 @@ function createAnalyticsDelivery({
 
     try {
       stats.flushAttempts += 1;
-      const { ok } = await sendRequest(endpoint, {
+      const { ok, status } = await sendRequest(endpoint, {
         ...REQUEST_PROFILE_ANALYTICS_WRITE,
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ events: batch, sentAt: Date.now() })
       });
 
-      if (!ok) {
+      const isNonRetryable = NON_RETRYABLE_STATUSES.has(status);
+
+      if (!ok && !isNonRetryable) {
         stats.failed += batch.length;
         stats.requeued += batch.length;
         queue.unshift(...batch);
+      }
+      if (!ok && isNonRetryable) {
+        stats.failed += batch.length;
+        stats.dropped += batch.length;
+        stats.lastErrorMessage = `Non-retryable analytics status ${status}`;
+        log.warn(`⚠️ Analytics events dropped due to non-retryable status ${status}.`);
       }
       if (ok) {
         stats.delivered += batch.length;

--- a/scripts/analytics-delivery.test.mjs
+++ b/scripts/analytics-delivery.test.mjs
@@ -90,6 +90,33 @@ test('analytics delivery re-queues batch when request returns non-ok', async () 
   delivery.stop();
 });
 
+test('analytics delivery drops batch when request returns non-retryable status', async () => {
+  const eventTarget = createEventTargetMock();
+  const warns = [];
+  const delivery = createAnalyticsDelivery({
+    eventTarget,
+    maxBatchSize: 5,
+    flushIntervalMs: 10000,
+    requestFn: async () => ({ ok: false, status: 400, data: { error: 'bad_request' } }),
+    loggerInstance: { warn(message) { warns.push(message); } }
+  });
+
+  eventTarget.dispatch(ANALYTICS_TRACK_EVENT, {
+    name: 'game_start',
+    payload: { mode: 'default' },
+    timestamp: 2
+  });
+
+  await delivery.flush();
+  assert.equal(delivery.getQueueSize(), 0);
+  assert.equal(delivery.getStats().failed, 1);
+  assert.equal(delivery.getStats().requeued, 0);
+  assert.equal(delivery.getStats().dropped, 1);
+  assert.match(delivery.getStats().lastErrorMessage, /Non-retryable analytics status 400/);
+  assert.equal(warns.length, 1);
+  delivery.stop();
+});
+
 test('analytics delivery tracks dropped events when queue overflows', async () => {
   const eventTarget = createEventTargetMock();
   const delivery = createAnalyticsDelivery({


### PR DESCRIPTION
### Motivation
- Client-side `4xx` telemetry responses (e.g. `400`) caused the analytics delivery to requeue and repeatedly retry batches, producing console noise and endless retries for client-fixable errors. 
- Non-retryable statuses should be treated as dropped so invalid payloads or blocked endpoints don't create retry loops.

### Description
- Added a `NON_RETRYABLE_STATUSES` set and updated `flush` in `js/analytics-delivery.js` to treat those statuses (`400`, `401`, `403`, `404`, `413`, `422`) as drop conditions instead of re-queuing the batch. 
- When a non-retryable status is returned the code now increments `failed` and `dropped`, sets a descriptive `lastErrorMessage`, and emits a `logger.warn`. 
- Preserved existing behavior for retryable failures and network errors (they still requeue). 
- Added unit test `analytics delivery drops batch when request returns non-retryable status` in `scripts/analytics-delivery.test.mjs` to cover the new branch.

### Testing
- Ran `node --test scripts/analytics-delivery.test.mjs` and all tests passed (4/4). 
- Pre-commit checks including `check:syntax` and static analysis (`check:static-analysis`) were executed and succeeded during validation. 
- Local test iteration fixed an initial reference bug and verified the final behavior with the added unit test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10ac80f108320bda2af6f30c2c3cf)