### PR TITLE
Update Rules: add Scoring & Referral sections and remove nested history scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2817,8 +2817,8 @@ footer a:hover { color: #e0b0ff; }
 }
 
 .pm-history-table-wrap {
-  max-height: 240px;
-  overflow: auto;
+  max-height: none;
+  overflow: visible;
 }
 
 .pm-history-table {

--- a/index.html
+++ b/index.html
@@ -692,9 +692,21 @@
       <div class="rules-section-title">🎮 How to Play</div>
       <div class="rules-section-text">
         Your character automatically runs forward at increasing speed. Navigate between 3 lanes to collect <b>silver</b> and <b>gold coins</b>, pick up bonuses, and dodge obstacles like fences, rocks, and bulls.<br><br>
-        <b>Silver coins</b> = +10 score<br>
-        <b>Gold coins</b> = +100 score<br><br>
         Hit an obstacle and your run ends — unless you have a <b>🛡 Shield</b>!
+      </div>
+    </div>
+
+    <div class="rules-section">
+      <div class="rules-section-title">🏁 Scoring</div>
+      <div class="rules-section-text">
+        When you move forward you get points, the higher the speed, the faster the points are collected, additional points are also awarded for collecting coins, various bonuses also speed up the receipt of points, study the game and you will definitely find other ways to get points.
+      </div>
+    </div>
+
+    <div class="rules-section">
+      <div class="rules-section-title">🤝 Referral System</div>
+      <div class="rules-section-text">
+        Play and invite friends — both you and your friends receive gold rewards through the referral system.
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Clarify scoring mechanics and add referral information in the Rules screen so players understand how points are gained and that inviting friends grants gold rewards.
- Improve player menu UX by removing the nested scroll inside the History block so the whole player menu scrolls as a single page.

### Description
- Removed the fixed coin-score lines from the **How to Play** section in `index.html`.
- Added a new **Scoring** section after How to Play in `index.html` with the provided text about movement-based scoring, speed, coins, and bonuses.
- Added a new **Referral System** section in `index.html` describing gold rewards for inviting friends.
- Updated `css/style.css` to disable the inner-history scroll by changing `.pm-history-table-wrap` from `max-height: 240px; overflow: auto;` to `max-height: none; overflow: visible;` so the player menu page scrolls as a whole.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- Ran `npm run check:static-analysis` and it completed successfully.
- Pre-commit checks executed during local commit passed (static analysis and syntax checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11b55f7488320a15ced930c1a83df)