### PR TITLE
Unify Telegram header/menu controls and restore start-screen layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2004,6 +2004,10 @@ footer a:hover { color: #e0b0ff; }
     gap: 8px;
   }
 
+  body.telegram-mini-app #gameStart .start-audio-nav {
+    top: max(0px, env(safe-area-inset-top));
+  }
+
   #gameStart {
     justify-content: flex-start;
     padding-top: max(72px, calc(env(safe-area-inset-top) + 56px));
@@ -2015,6 +2019,14 @@ footer a:hover { color: #e0b0ff; }
   #walletCorner {
     top: max(8px, env(safe-area-inset-top));
     right: 14px;
+  }
+
+  body.telegram-mini-app #walletCorner .wallet-btn-corner {
+    display: none;
+  }
+
+  body.telegram-mini-app #walletCorner .wallet-info .wallet-info-row-compact {
+    display: none;
   }
 
   .bear-wrapper {
@@ -2042,6 +2054,10 @@ footer a:hover { color: #e0b0ff; }
     text-shadow: 1px 0 0 rgba(255, 255, 255, .10), -1px 0 0 rgba(255, 255, 255, .10);
     -webkit-font-smoothing: antialiased;
     text-rendering: geometricPrecision;
+  }
+
+  body.telegram-mini-app .new-title {
+    top: calc(50% - 68px);
   }
   .new-buttons {
     max-width: min(90vw, 420px);
@@ -2175,6 +2191,10 @@ footer a:hover { color: #e0b0ff; }
     gap: 6px;
   }
 
+  body.telegram-mini-app #gameStart .start-audio-nav {
+    top: max(0px, env(safe-area-inset-top));
+  }
+
   .bear-wrapper {
     width: min(250vw, 660px);
     height: min(250vw, 660px);
@@ -2185,6 +2205,9 @@ footer a:hover { color: #e0b0ff; }
     min-height: 34px;
     top: calc(50% - 154px);
     text-shadow: 0.8px 0 0 rgba(255, 255, 255, .12), -0.8px 0 0 rgba(255, 255, 255, .12);
+  }
+  body.telegram-mini-app .new-title {
+    top: calc(50% - 54px);
   }
   .new-buttons {
     margin-top: 0;
@@ -2230,6 +2253,10 @@ footer a:hover { color: #e0b0ff; }
     gap: 5px;
   }
 
+  body.telegram-mini-app #gameStart .start-audio-nav {
+    top: max(0px, env(safe-area-inset-top));
+  }
+
   .bear-wrapper {
     width: min(270vw, 590px);
     height: min(270vw, 590px);
@@ -2240,6 +2267,9 @@ footer a:hover { color: #e0b0ff; }
     min-height: 30px;
      top: calc(50% - 142px);
     text-shadow: 0.5px 0 0 rgba(255, 255, 255, .14), -0.5px 0 0 rgba(255, 255, 255, .14);
+  }
+  body.telegram-mini-app .new-title {
+    top: calc(50% - 42px);
   }
   .new-buttons {
     margin-top: 0;
@@ -2590,6 +2620,23 @@ footer a:hover { color: #e0b0ff; }
   gap: 8px;
 }
 
+.tg-account-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  max-width: min(42vw, 220px);
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.42);
+  background: rgba(15, 23, 42, 0.78);
+  color: rgba(224, 242, 254, 0.95);
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ===== PLAYER AVATAR BTN ===== */
 .player-avatar-btn {
   width: 40px;
@@ -2666,6 +2713,24 @@ footer a:hover { color: #e0b0ff; }
   border-color: rgba(255, 255, 255, .25);
 }
 
+.player-menu-overlay .pm-back-btn {
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border-accent);
+  background: var(--glass);
+  backdrop-filter: blur(14px);
+  border-radius: 50%;
+  font-family: 'Orbitron', sans-serif;
+}
+
+.player-menu-overlay .pm-back-btn:hover {
+  box-shadow: 0 0 18px rgba(140, 80, 255, .3);
+  transform: scale(1.08);
+  border-color: rgba(140, 80, 255, .7);
+}
+
+.player-menu-overlay .pm-back-btn:active { transform: scale(0.92); }
+
 .pm-content {
   display: flex;
   flex-direction: row;
@@ -2702,6 +2767,11 @@ footer a:hover { color: #e0b0ff; }
   font-size: 16px;
   color: rgba(255, 255, 255, .7);
   font-family: 'Orbitron', sans-serif;
+}
+
+.pm-connect-wallet-top {
+  align-self: flex-start;
+  margin-top: -6px;
 }
 
 .pm-share-row {

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 <div id="walletCorner">
   <div class="wallet-corner-row">
     <button class="wallet-btn-corner" id="walletBtn">Connect Wallet</button>
+    <span class="tg-account-badge" id="tgAccountBadge" hidden></span>
     <button class="player-avatar-btn" id="playerAvatarBtn" hidden aria-label="Open player menu">
       <img src="img/ursas_bear_head_white.svg" class="player-avatar-icon" alt="" aria-hidden="true">
     </button>
@@ -227,6 +228,7 @@
     <div class="pm-center">
       <div class="pm-rank">You're <span id="pmRankNumber">#—</span></div>
       <div class="pm-best">Best score: <span id="pmBestScore">0</span></div>
+      <button class="pm-side-btn pm-connect-wallet-top" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
 
       <div class="pm-row pm-nickname-row">
         <label for="pmNicknameInput" class="pm-label">Nickname</label>
@@ -289,7 +291,6 @@
         <button class="pm-side-btn" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
         <button class="pm-x-disconnect" id="pmXDisconnectBtn" hidden>Disconnect X</button>
       </div>
-      <button class="pm-side-btn" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
     </aside>
   </div>
 </div>

--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -14,6 +14,7 @@ async function initAuthFlow({
 }) {
   const isTelegramReady = isTelegramMiniApp() || await waitForTelegramMiniApp();
   if (isTelegramReady) {
+    document.body.classList.add('telegram-mini-app');
     authState.telegramUser = getTelegramUserData();
     const telegramInitData = getTelegramInitData();
     const telegramIdentifier = String(
@@ -53,6 +54,7 @@ async function initAuthFlow({
     return;
   }
 
+  document.body.classList.remove('telegram-mini-app');
   clearAuthSessionState();
   logger.info('🌐 Browser mode — wallet auth');
   updateAuthUI();

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -4,6 +4,13 @@ function normalizeTelegramUsername(value) {
   return String(value || '').trim().replace(/^@+/, '');
 }
 
+function formatTelegramAccountLabel(telegramUser = null) {
+  const username = normalizeTelegramUsername(telegramUser?.username);
+  if (username) return `@${username}`;
+  const id = String(telegramUser?.id || '').trim();
+  return id ? `TG ${id}` : 'TG';
+}
+
 function bindWalletInfoActions(infoRoot, { onLinkWallet, onLinkTelegram } = {}) {
   if (!infoRoot) return;
 
@@ -97,24 +104,23 @@ function renderAuthUiState({
 }) {
   const btn = dom.walletBtn;
   const info = dom.walletInfo;
+  const tgAccountBadge = dom.tgAccountBadge;
 
   if (session.isTelegramAuthMode) {
-    const telegramUsername = normalizeTelegramUsername(session.telegramUser?.username);
-    if (session.linkedWallet) {
-      const walletShort = `${session.linkedWallet.slice(0, 6)}...${session.linkedWallet.slice(-4)}`;
-      btn.textContent = walletShort;
-    } else {
-      btn.textContent = telegramUsername ? `@${telegramUsername}` : 'Player';
-    }
+    const telegramAccount = formatTelegramAccountLabel(session.telegramUser);
+    btn.textContent = telegramAccount;
     btn.classList.add('connected');
     btn.classList.add('wallet-btn-readonly');
     btn.onclick = null;
     info.classList.add('visible');
+    if (tgAccountBadge) {
+      tgAccountBadge.textContent = telegramAccount;
+      tgAccountBadge.hidden = false;
+    }
 
     info.textContent = '';
     if (session.linkedWallet) {
-      const walletShort = `${session.linkedWallet.slice(0, 6)}...${session.linkedWallet.slice(-4)}`;
-      renderWalletInfoHeader(info, { compactLabel: walletShort });
+      renderWalletInfoHeader(info, {});
     } else {
       renderWalletInfoHeader(info, { actionLabel: 'Link Wallet', actionName: 'link-wallet' });
     }
@@ -131,6 +137,10 @@ function renderAuthUiState({
     btn.classList.remove('wallet-btn-readonly');
     btn.onclick = onDisconnectAuth;
     info.classList.add('visible');
+    if (tgAccountBadge) {
+      tgAccountBadge.textContent = '';
+      tgAccountBadge.hidden = true;
+    }
 
     info.textContent = '';
     renderWalletStats(info);
@@ -145,6 +155,10 @@ function renderAuthUiState({
   btn.onclick = onConnectWallet;
   info.classList.remove('visible');
   info.textContent = '';
+  if (tgAccountBadge) {
+    tgAccountBadge.textContent = '';
+    tgAccountBadge.hidden = true;
+  }
   if (dom.storeBtn) dom.storeBtn.classList.add('menu-hidden');
 }
 

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -1,6 +1,7 @@
 import { DOM } from '../state.js';
 import { fetchMyProfile, fetchCoinHistory, disconnectX, setNickname, setLeaderboardDisplay } from '../api.js';
 import { hasAuthenticatedSession, linkTelegram, linkWallet } from '../auth.js';
+import { isTelegramAuthMode } from '../auth-state.js';
 import { showPlayerMenuScreen, hidePlayerMenuScreen } from '../screens.js';
 import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
@@ -155,6 +156,13 @@ function updateTelegramBlock(profile) {
   const btn = DOM.pmConnectTelegramBtn;
   if (!btn) return;
 
+  if (isTelegramAuthMode()) {
+    btn.hidden = true;
+    return;
+  }
+
+  btn.hidden = false;
+
   if (profile?.telegram?.connected) {
     const tgUsername = profile.telegram.username;
     const tgId = profile.telegram.id;
@@ -174,8 +182,16 @@ function updateWalletBlock(profile) {
   const btn = DOM.pmConnectWalletBtn;
   if (!btn) return;
 
-  const showWallet = profile?.telegram?.connected && !profile?.wallet?.connected;
+  const showWallet = isTelegramAuthMode() || (profile?.telegram?.connected && !profile?.wallet?.connected);
   btn.hidden = !showWallet;
+  if (showWallet) {
+    btn.textContent = profile?.wallet?.connected ? 'Wallet connected' : 'Connect Wallet';
+    btn.disabled = !!profile?.wallet?.connected;
+    btn.classList.toggle('pm-side-btn--connected', !!profile?.wallet?.connected);
+  } else {
+    btn.disabled = false;
+    btn.classList.remove('pm-side-btn--connected');
+  }
 }
 
 function fillProfileData(profile) {
@@ -302,6 +318,7 @@ function initPlayerMenuEvents() {
 
   if (DOM.pmConnectTelegramBtn) {
     DOM.pmConnectTelegramBtn.addEventListener('click', () => {
+      if (isTelegramAuthMode()) return;
       if (!currentProfile?.telegram?.connected) {
         linkTelegram();
       }

--- a/js/state.js
+++ b/js/state.js
@@ -114,6 +114,7 @@ const DOM_IDS = {
   speedVal: 'speedVal',
   coinsCountVal: 'coinsCountVal',
   walletBtn: 'walletBtn',
+  tgAccountBadge: 'tgAccountBadge',
   walletInfo: 'walletInfo',
   walletRank: 'walletRank',
   walletBest: 'walletBest',


### PR DESCRIPTION
### Motivation
- Make Telegram Mini App UX consistent: use a unified round back-nav style and a single header area for account actions. 
- Hide wallet address where it should not be shown in Telegram mode and surface the Telegram account (username or ID) prominently. 
- Restore start-screen layout for Telegram: pin sound toggles to the top and lower the main title to match previous visual layout. 

### Description
- Added a Telegram account badge in the top-right header and wired it into the auth UI so it shows `@username` or `TG <id>` when in Telegram mode (`index.html`, `js/auth-ui.js`, `js/state.js`).
- Adjusted player menu structure and behavior by moving `Connect Wallet` to the top (after Best score), removing the duplicate side wallet button, and hiding `Connect Telegram` while in Telegram auth mode (`index.html`, `js/player-menu/controller.js`).
- Stopped rendering a compact linked-wallet short-address in the top info for Telegram sessions and exposed the telegram badge instead (`js/auth-ui.js`, `css/style.css`).
- Added `telegram-mini-app` body class during auth initialization and added CSS overrides to: pin global audio toggles to the top, lower the `URSASS TUBE` title ~100px, and hide the wallet corner button in Telegram mode; unified player-menu back button style with the circular store/rules nav (`js/auth-lifecycle.js`, `css/style.css`).

### Testing
- Ran `npm run check:syntax` and it completed successfully. 
- Ran `npm run test:request` and all tests passed (82 tests, 0 failures). 
- Pre-commit static analysis (`npm run check:static-analysis`) also ran as part of the commit hooks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f122be0d6c8320977c6a3734654884)