### PR TITLE
Add Privacy/Terms footer links and legal pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1816,6 +1816,24 @@ footer a:hover { color: #e0b0ff; }
   border-color: rgba(192, 132, 252, .9);
   box-shadow: 0 0 18px rgba(192, 132, 252, .35);
 }
+.footer-legal-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: -2px;
+  margin-bottom: 10px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+}
+.footer-legal-link {
+  color: rgba(248, 250, 252, .75);
+  text-decoration: none;
+  transition: color .2s ease;
+}
+.footer-legal-link:hover { color: #c084fc; }
+.footer-legal-sep { color: rgba(248, 250, 252, .45); }
 
 /* ===== RULES OVERLAY ===== */
 #rulesScreen {

--- a/index.html
+++ b/index.html
@@ -157,6 +157,11 @@
       </a>
     </div>
     <div class="footer-rules-link" id="rulesLink">📖 Rules</div>
+    <div class="footer-legal-links">
+      <a href="/privacy" class="footer-legal-link" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+      <span class="footer-legal-sep">&amp;</span>
+      <a href="/terms" class="footer-legal-link" target="_blank" rel="noopener noreferrer">Terms</a>
+    </div>
     Team<br>
     &copy; 2026 Ursass Tube &mdash; Powered by Justconnect
   </footer>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy — Ursass Tube</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0a0714; color: #f8fafc; line-height: 1.55; }
+    .wrap { max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }
+    h1,h2 { font-family: Orbitron, Inter, sans-serif; margin: 0 0 12px; }
+    h1 { font-size: 30px; }
+    h2 { font-size: 20px; margin-top: 28px; }
+    p, li { color: rgba(248,250,252,.92); }
+    ul { margin: 8px 0 0 20px; }
+    .meta { color: rgba(248,250,252,.7); margin-bottom: 24px; }
+    a { color: #c084fc; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Privacy Policy — Ursass Tube</h1>
+    <p class="meta">Last updated: April 28, 2026</p>
+
+    <p>This Privacy Policy explains how Ursass Tube collects, uses, stores, and protects user information when you use our Telegram Mini App and related bot.</p>
+    <p>Ursass Tube is an arcade runner game available through Telegram. The current version of the product is focused only on the Ursass Tube game experience: gameplay, score tracking, leaderboard, tasks, and related in-game features.</p>
+
+    <h2>1. Information We Collect</h2>
+    <h2>1.1 Telegram account information</h2>
+    <p>When you open Ursass Tube through Telegram, Telegram may provide us with limited account information, such as:</p>
+    <ul><li>Telegram user ID;</li><li>username;</li><li>first name;</li><li>profile photo, if available;</li><li>language code;</li><li>Telegram Mini App launch data.</li></ul>
+    <p>We use this information to identify your game profile, save your progress, and display your result in the leaderboard.</p>
+    <h2>1.2 Game data</h2>
+    <p>We may collect and store game-related data, including:</p>
+    <ul><li>current score;</li><li>best score;</li><li>leaderboard position;</li><li>coins or other in-game progress;</li><li>completed tasks;</li><li>ride/session history;</li><li>referral or invite activity, if used;</li><li>gameplay events needed for analytics and anti-cheat protection.</li></ul>
+    <h2>1.3 Technical data</h2>
+    <p>We may collect technical information needed to operate and improve the game, such as:</p>
+    <ul><li>device type;</li><li>operating system;</li><li>browser or Telegram client information;</li><li>app version;</li><li>error logs;</li><li>session timestamps;</li><li>approximate performance data.</li></ul>
+    <h2>1.4 Analytics data</h2>
+    <p>We may collect basic analytics events, such as:</p>
+    <ul><li>app opened;</li><li>game started;</li><li>game finished;</li><li>score submitted;</li><li>leaderboard opened;</li><li>task completed;</li><li>share button clicked.</li></ul>
+
+    <h2>2. How We Use Information</h2>
+    <p>We use collected information to provide access to the game; create and maintain your game profile; save your progress and scores; display leaderboard results; prevent cheating, abuse, and fake score submissions; improve gameplay, performance, and user experience; fix bugs and technical issues; analyze product usage; and communicate important product updates through the Telegram bot, where permitted.</p>
+
+    <h2>3. Leaderboard and Public Game Data</h2>
+    <p>If you submit a score, some information may be visible to other users in the leaderboard, such as username or display name, score, rank, and best result.</p>
+    <p>Do not use Ursass Tube if you do not want your public game result to appear in the leaderboard.</p>
+
+    <h2>4. Data Sharing</h2>
+    <p>We do not sell your personal data.</p>
+    <p>We may share limited information only when necessary: with infrastructure providers used to host and operate the game; with analytics or error-monitoring tools; if required by law or legal process; to protect the game from fraud, cheating, abuse, or security threats.</p>
+
+    <h2>5. Telegram Platform</h2>
+    <p>Ursass Tube operates as a Telegram Mini App. Your use of Telegram is also governed by Telegram’s own Privacy Policy and Terms of Service.</p>
+    <p>We are responsible only for the data processed by Ursass Tube. We do not control how Telegram processes your data.</p>
+
+    <h2>6. Data Security</h2>
+    <p>We take reasonable technical and organizational measures to protect user data.</p>
+    <p>Telegram Mini App launch data is validated on the server before being used for authentication or score-related features. We do not rely only on unsafe client-side data.</p>
+    <p>However, no system is completely secure, and we cannot guarantee absolute protection against all risks.</p>
+
+    <h2>7. Data Retention</h2>
+    <p>We keep user data only as long as needed to provide the game; maintain leaderboards; prevent abuse; analyze and improve the product; and comply with legal obligations.</p>
+    <p>We may delete inactive accounts, old gameplay sessions, or outdated technical logs at our discretion.</p>
+
+    <h2>8. User Rights</h2>
+    <p>Depending on your location, you may have the right to request access to your data, request correction of inaccurate data, request deletion of your data, object to certain processing, and request limitation of processing.</p>
+    <p>To make a request, contact us using the contact details below.</p>
+
+    <h2>9. Children</h2>
+    <p>Ursass Tube is not intended for children under the age required by applicable law to use online services without parental consent.</p>
+
+    <h2>10. Changes to This Privacy Policy</h2>
+    <p>We may update this Privacy Policy from time to time. If we make significant changes, we may notify users through the Telegram bot, the Mini App, or our website.</p>
+    <p>Your continued use of Ursass Tube after changes means that you accept the updated Privacy Policy.</p>
+
+    <h2>11. Contact</h2>
+    <p>Team: Justconnect-1<br>Project: Ursass Tube<br>Contact: @jamesbrowna<br>Website: <a href="https://ursasstube.fun">https://ursasstube.fun</a></p>
+  </main>
+</body>
+</html>

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terms — Ursass Tube</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0a0714; color: #f8fafc; display: grid; place-items: center; min-height: 100vh; }
+    .card { max-width: 760px; padding: 28px 20px; }
+    h1 { font-family: Orbitron, Inter, sans-serif; }
+    a { color: #c084fc; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Terms — Ursass Tube</h1>
+    <p>Terms of Service page is being finalized and will be published soon.</p>
+    <p>For urgent questions, contact <b>@jamesbrowna</b> or visit <a href="https://ursasstube.fun">https://ursasstube.fun</a>.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide two small legal links next to the existing `Rules` footer control so users can open a separate Privacy Policy and Terms page. 
- Ship the supplied Privacy Policy content with the indicated last-updated date and a placeholder Terms page so each link resolves to its own URL (`/privacy` and `/terms`).

### Description
- Added a compact horizontal block under the `Rules` button in the footer with `Privacy Policy` and `Terms` links that open `
/privacy` and `/terms` in a new tab. 
- Added CSS styles for `.footer-legal-links`, `.footer-legal-link`, and `.footer-legal-sep` to render the two links on one line with hover effects. 
- Created `privacy/index.html` and populated it with the provided Privacy Policy text (Last updated: April 28, 2026). 
- Created `terms/index.html` as a placeholder Terms page so the Terms link resolves to a separate page.

### Testing
- Ran `npm run build` which completed successfully and produced the production `dist` output. 
- Project pre-commit checks including `check:syntax` and `check:static-analysis` passed during the change validation. 
- Verified generated pages and local markup/CSS changes by building the site; no build-time errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1275584888320ae27d9b1d89c8356)