### PR TITLE
Add Terms of Use page and footer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
       </a>
     </div>
     <div class="footer-rules-link" id="rulesLink">📖 Rules</div>
+    <a class="footer-rules-link" href="/terms.html" target="_blank" rel="noopener noreferrer">📄 Terms of Use</a>
     Team<br>
     &copy; 2026 Ursass Tube &mdash; Powered by Justconnect
   </footer>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,160 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terms of Use — Ursass Tube</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      background: #0b0f1a;
+      color: #e5e7eb;
+      line-height: 1.6;
+    }
+    .container {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 32px 20px 64px;
+    }
+    h1, h2 { color: #fff; }
+    h1 { margin-bottom: 4px; }
+    .meta { color: #9ca3af; margin-bottom: 24px; }
+    section { margin-bottom: 22px; }
+    ul { margin-top: 8px; }
+    a { color: #60a5fa; }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <h1>Terms of Use — Ursass Tube</h1>
+    <div class="meta">Last updated: April 28, 2026</div>
+
+    <p>These Terms of Use govern your access to and use of Ursass Tube, a Telegram Mini App arcade runner game.</p>
+    <p>By using Ursass Tube, you agree to these Terms. If you do not agree, do not use the game.</p>
+
+    <section><h2>1. About Ursass Tube</h2>
+      <p>Ursass Tube is an arcade runner game where players control a character, collect in-game items, complete tasks, and compete on the leaderboard.</p>
+      <p>The current version of Ursass Tube is focused only on the game experience. Other possible Ursas ecosystem products, tokens, NFTs, marketplace features, or related services are not part of the current Ursass Tube launch unless explicitly announced in official channels.</p>
+    </section>
+
+    <section><h2>2. Eligibility</h2>
+      <p>You may use Ursass Tube only if:</p>
+      <ul>
+        <li>you are allowed to use Telegram in your jurisdiction;</li>
+        <li>you comply with these Terms;</li>
+        <li>your use of the game does not violate applicable laws or regulations.</li>
+      </ul>
+      <p>If you are under the legal age required in your jurisdiction to use online services, you must have permission from a parent or legal guardian.</p>
+    </section>
+
+    <section><h2>3. Telegram Account</h2>
+      <p>Ursass Tube works through Telegram. To use the game, you may need a Telegram account.</p>
+      <p>You are responsible for keeping your Telegram account secure. We are not responsible for losses caused by unauthorized access to your Telegram account.</p>
+    </section>
+
+    <section><h2>4. Game Rules</h2>
+      <p>When using Ursass Tube, you agree not to:</p>
+      <ul>
+        <li>cheat or manipulate scores;</li>
+        <li>use bots, scripts, emulators, automation tools, or modified clients to gain an unfair advantage;</li>
+        <li>exploit bugs or vulnerabilities;</li>
+        <li>interfere with the game servers or infrastructure;</li>
+        <li>attempt to reverse engineer, attack, or disrupt the game;</li>
+        <li>impersonate other users;</li>
+        <li>use offensive, illegal, or abusive usernames or behavior;</li>
+        <li>submit fake, manipulated, or fraudulent gameplay data.</li>
+      </ul>
+      <p>We may remove scores, reset progress, restrict access, or ban users who violate these rules.</p>
+    </section>
+
+    <section><h2>5. Leaderboard</h2>
+      <p>Ursass Tube may include a public leaderboard.</p>
+      <p>By submitting a score, you agree that your Telegram display name, username, rank, and score may be shown to other users.</p>
+      <p>We reserve the right to remove suspicious, fraudulent, offensive, or technically invalid scores from the leaderboard.</p>
+    </section>
+
+    <section><h2>6. In-Game Items and Progress</h2>
+      <p>Ursass Tube may include in-game coins, tasks, upgrades, ride limits, or other game progress mechanics.</p>
+      <p>Unless explicitly stated otherwise:</p>
+      <ul>
+        <li>in-game items have no real-money value;</li>
+        <li>in-game progress cannot be exchanged for money;</li>
+        <li>in-game balances are part of the game experience only;</li>
+        <li>we may adjust game balance, rewards, prices, and mechanics at any time.</li>
+      </ul>
+    </section>
+
+    <section><h2>7. Donations or Payments</h2>
+      <p>Ursass Tube may include optional donation or payment features.</p>
+      <p>Any donation or payment is voluntary unless clearly stated otherwise. Donations do not guarantee leaderboard placement, rewards, prizes, special treatment, or future financial benefit.</p>
+      <p>Payment availability may depend on Telegram, third-party providers, your location, and applicable law.</p>
+    </section>
+
+    <section><h2>8. No Guarantee of Rewards</h2>
+      <p>Unless we publish separate official campaign rules, Ursass Tube does not guarantee prizes, financial rewards, tokens, NFTs, or other assets.</p>
+      <p>Any future contest, event, season, giveaway, or reward campaign must have separate rules and eligibility requirements.</p>
+      <p>Do not use Ursass Tube with the expectation of earning money or receiving financial rewards.</p>
+    </section>
+
+    <section><h2>9. Fair Play and Anti-Cheat</h2>
+      <p>We may use technical and behavioral checks to detect cheating, abuse, fake activity, or manipulated scores.</p>
+      <p>We may reject score submissions or remove leaderboard entries if we believe they are invalid, suspicious, or unfair.</p>
+      <p>We are not required to disclose the details of our anti-cheat systems.</p>
+    </section>
+
+    <section><h2>10. Availability and Updates</h2>
+      <p>We try to keep Ursass Tube available and functional, but we do not guarantee uninterrupted access.</p>
+      <p>The game may be unavailable due to maintenance, technical issues, Telegram platform changes, hosting or infrastructure problems, updates, security incidents, or force majeure events.</p>
+      <p>We may update, modify, suspend, or discontinue parts of the game at any time.</p>
+    </section>
+
+    <section><h2>11. Intellectual Property</h2>
+      <p>Ursass Tube, including its name, characters, visuals, game design, interface, text, graphics, code, and related materials, belongs to the Ursass Tube project or its respective owners.</p>
+      <p>You may not copy, reproduce, distribute, modify, sell, or use Ursass Tube materials without permission, except as allowed by law.</p>
+    </section>
+
+    <section><h2>12. User Content</h2>
+      <p>If Ursass Tube allows you to submit usernames, messages, images, or other content, you are responsible for that content.</p>
+      <p>You must not submit content that is illegal, abusive, offensive, misleading, infringing, or harmful.</p>
+      <p>We may remove user content that violates these Terms or creates risk for the project or other users.</p>
+    </section>
+
+    <section><h2>13. Third-Party Services</h2>
+      <p>Ursass Tube may rely on third-party services, including Telegram, hosting providers, analytics tools, payment providers, or infrastructure services.</p>
+      <p>We are not responsible for the actions, availability, or policies of third-party services.</p>
+    </section>
+
+    <section><h2>14. Disclaimer</h2>
+      <p>Ursass Tube is provided “as is” and “as available.”</p>
+      <p>We do not guarantee that the game will always be available, free of bugs or errors, or that scores/progress will never be lost.</p>
+      <p>To the maximum extent permitted by law, we disclaim all warranties, express or implied.</p>
+    </section>
+
+    <section><h2>15. Limitation of Liability</h2>
+      <p>To the maximum extent permitted by law, Ursass Tube and its team are not liable for indirect, incidental, special, consequential, or punitive damages, including loss of data, loss of progress, loss of access, loss of profits, or loss of opportunity.</p>
+    </section>
+
+    <section><h2>16. Termination</h2>
+      <p>We may suspend or terminate your access to Ursass Tube if you violate these Terms, cheat or abuse the game, your activity creates risk for the game or other users, required by law or platform rules, or the game is discontinued.</p>
+    </section>
+
+    <section><h2>17. Changes to These Terms</h2>
+      <p>We may update these Terms from time to time.</p>
+      <p>If we make significant changes, we may notify users through the Telegram bot, the Mini App, or the website.</p>
+      <p>Your continued use of Ursass Tube after changes means that you accept the updated Terms.</p>
+    </section>
+
+    <section><h2>18. Contact</h2>
+      <p>For questions about these Terms, contact us:</p>
+      <p>
+        Team: Justconnect-1<br>
+        Project: Ursass Tube<br>
+        Contact: <a href="https://t.me/jamesbrowna" target="_blank" rel="noopener noreferrer">@jamesbrowna</a><br>
+        Website: <a href="https://ursasstube.fun" target="_blank" rel="noopener noreferrer">https://ursasstube.fun</a>
+      </p>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, easily accessible Terms of Use page so users can read the game rules and legal terms outside the embedded UI.
- Surface the Terms prominently from the site footer so users can open them in a new tab for reference.

### Description
- Add a new `terms.html` file containing the full "Terms of Use — Ursass Tube" content (18 sections, "Last updated: April 28, 2026") with a dark-themed local stylesheet.
- Update `index.html` footer to add a `📄 Terms of Use` link that points to `/terms.html` and opens in a new tab (`target="_blank" rel="noopener noreferrer`).
- Keep the page self-contained (no external build changes) so it can be served directly from the site root.

### Testing
- Ran `npm run -s check:syntax` and the script completed successfully.
- Project static-analysis checks executed during the pre-commit hooks (including `check:static-analysis`) and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1292d38a483209e5455fdb1243903)