### PR TITLE
Add optional client-side PostHog analytics (EU) and wire into runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,18 @@ A full-screen overlay (`z-index: 150`) providing:
 
 ### Smoke tests
 See [`docs/player-menu-smoke.md`](docs/player-menu-smoke.md) for full manual smoke scenarios.
+
+## PostHog analytics (EU)
+
+Подключена клиентская интеграция PostHog, которая слушает внутренние события `trackAnalyticsEvent(...)` и отправляет их в PostHog.
+
+Для включения задайте глобальные переменные в `index.html` (или через ваш runtime-inject):
+
+```html
+<script>
+  window.__URSASS_POSTHOG_KEY__ = 'phc_xxx';
+  window.__URSASS_POSTHOG_HOST__ = 'https://eu.i.posthog.com';
+</script>
+```
+
+Если `window.__URSASS_POSTHOG_KEY__` не задан, интеграция автоматически выключена.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">
   <!-- Intentional external runtime dependency for Telegram Mini App APIs -->
   <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
+  <script>
+    window.__URSASS_POSTHOG_KEY__ = 'phc_p2r2EqChDVqD6DWTLRnWwtoNjDteiupmjPzM6w6pY55K';
+    window.__URSASS_POSTHOG_HOST__ = 'https://eu.i.posthog.com';
+  </script>
 </head>
 
 

--- a/js/game-runtime.js
+++ b/js/game-runtime.js
@@ -4,6 +4,7 @@ import { initGame } from './game.js';
 import { initializeCoreLifecycle } from './runtime-lifecycle.js';
 import { logger } from './logger.js';
 import { setupAnalyticsDelivery } from './analytics-delivery.js';
+import { initPosthogAnalytics } from './posthog-analytics.js';
 
 function onDomReady(callback) {
   if (document.readyState === 'loading') {
@@ -18,6 +19,7 @@ function initializeRuntimeDependencies() {
   initInputHandlers();
   initializeCoreLifecycle();
   setupAnalyticsDelivery();
+  initPosthogAnalytics();
 }
 
 let gameBootstrapInitialized = false;

--- a/js/posthog-analytics.js
+++ b/js/posthog-analytics.js
@@ -1,0 +1,124 @@
+import { ANALYTICS_TRACK_EVENT } from './analytics.js';
+import { logger } from './logger.js';
+
+const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
+const POSTHOG_SCRIPT_PATH = '/static/array.js';
+
+let posthogStarted = false;
+
+function resolvePosthogConfig() {
+  if (typeof window === 'undefined') return null;
+
+  const apiKey = typeof window.__URSASS_POSTHOG_KEY__ === 'string'
+    ? window.__URSASS_POSTHOG_KEY__.trim()
+    : '';
+
+  if (!apiKey) return null;
+
+  const apiHost = typeof window.__URSASS_POSTHOG_HOST__ === 'string' && window.__URSASS_POSTHOG_HOST__.trim()
+    ? window.__URSASS_POSTHOG_HOST__.trim()
+    : DEFAULT_POSTHOG_HOST;
+
+  return { apiKey, apiHost };
+}
+
+function normalizeHost(host) {
+  return String(host || '').replace(/\/+$/, '');
+}
+
+function ensurePosthogGlobal() {
+  const scope = window;
+  if (scope.posthog && typeof scope.posthog.init === 'function') return scope.posthog;
+
+  const posthog = [];
+  posthog._i = [];
+  posthog.__SV = 1;
+  posthog.init = function init(token, config, name) {
+    const targetName = name || 'posthog';
+    const target = scope[targetName] = scope[targetName] || [];
+    target.people = target.people || [];
+    target.toString = function toString(append) {
+      let base = 'posthog';
+      if (targetName !== 'posthog') base += `.${targetName}`;
+      return append ? `${base} (stub)` : base;
+    };
+
+    const methods = ['capture', 'identify', 'set_config', 'register', 'unregister', 'reset', 'group', 'alias'];
+    for (const method of methods) {
+      target[method] = function stubMethod(...args) {
+        target.push([method, ...args]);
+      };
+    }
+
+    posthog._i.push([token, config, targetName]);
+  };
+
+  scope.posthog = posthog;
+  return posthog;
+}
+
+function loadPosthogScript(apiHost) {
+  const scriptUrl = `${normalizeHost(apiHost)}${POSTHOG_SCRIPT_PATH}`;
+  const existing = document.querySelector(`script[data-posthog-url="${scriptUrl}"]`);
+  if (existing) {
+    return new Promise((resolve, reject) => {
+      if (existing.dataset.loaded === '1') return resolve();
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error('PostHog script failed to load.')), { once: true });
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = scriptUrl;
+    script.dataset.posthogUrl = scriptUrl;
+    script.addEventListener('load', () => {
+      script.dataset.loaded = '1';
+      resolve();
+    }, { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${scriptUrl}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+async function initPosthogAnalytics() {
+  if (posthogStarted || typeof window === 'undefined') return false;
+
+  const config = resolvePosthogConfig();
+  if (!config) {
+    logger.info('📊 PostHog disabled: missing window.__URSASS_POSTHOG_KEY__.');
+    return false;
+  }
+
+  const posthog = ensurePosthogGlobal();
+  posthog.init(config.apiKey, {
+    api_host: config.apiHost,
+    person_profiles: 'identified_only',
+    autocapture: false,
+    capture_pageview: true,
+    capture_pageleave: true,
+  });
+
+  window.addEventListener(ANALYTICS_TRACK_EVENT, (event) => {
+    const analyticsEvent = event?.detail;
+    if (!analyticsEvent?.name) return;
+    window.posthog?.capture?.(analyticsEvent.name, {
+      ...analyticsEvent.payload,
+      source: 'ursass_frontend',
+      timestamp_ms: analyticsEvent.timestamp,
+    });
+  });
+
+  try {
+    await loadPosthogScript(config.apiHost);
+    posthogStarted = true;
+    logger.info('📊 PostHog analytics initialized.');
+    return true;
+  } catch (error) {
+    logger.warn('⚠️ PostHog script load failed:', error);
+    return false;
+  }
+}
+
+export { initPosthogAnalytics };


### PR DESCRIPTION
### Motivation
- Add an optional client-side analytics integration to forward internal `trackAnalyticsEvent(...)` events to PostHog (EU) for product analytics. 
- Allow the integration to be enabled via runtime/global variables so it can be toggled per-deployment or injected at runtime. 
- Keep the integration disabled by default when no API key is provided to avoid accidental data collection. 

### Description
- Introduces `js/posthog-analytics.js` which resolves config from `window.__URSASS_POSTHOG_KEY__` and `window.__URSASS_POSTHOG_HOST__`, bootstraps a PostHog stub, loads the PostHog script, and listens for `ANALYTICS_TRACK_EVENT` to forward events via `posthog.capture`.
- Hooks the analytics initializer into the app startup by importing `initPosthogAnalytics` in `js/game-runtime.js` and calling it from `initializeRuntimeDependencies()`.
- Documents the feature in `README.md` with instructions to enable by setting `window.__URSASS_POSTHOG_KEY__` and optionally `window.__URSASS_POSTHOG_HOST__`, and explains that the integration is disabled when the key is absent.
- Adds example/global defaults to `index.html` that set `window.__URSASS_POSTHOG_KEY__` and `window.__URSASS_POSTHOG_HOST__` (this can be replaced by environment/runtime injection in production).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13386b4d083208e518ff29c2cf7d1)