### PR TITLE
Add analytics tracking for wallet, donations, store, leaderboard and mirror select events to PostHog

### DIFF
--- a/js/auth-authentication.js
+++ b/js/auth-authentication.js
@@ -4,11 +4,13 @@ import { clearRuntimeConfig } from './store.js';
 import { authState } from './auth-state.js';
 import { logger } from './logger.js';
 import { notifyError } from './notifier.js';
+import { trackAnalyticsEvent } from './analytics.js';
 
 async function connectWalletAuthFlow({ applyAuthSession, updateAuthUI, runPostAuthSync, DOM }) {
   if (authState.isWalletAuthInProgress) return;
 
   authState.isWalletAuthInProgress = true;
+  trackAnalyticsEvent('wallet_connect_started');
   try {
     const timestamp = Date.now();
     const signedPayload = await requestWalletSignature({ flow: 'auth', timestamp });
@@ -25,6 +27,9 @@ async function connectWalletAuthFlow({ applyAuthSession, updateAuthUI, runPostAu
     });
 
     if (data.success) {
+      trackAnalyticsEvent('wallet_connect_success', {
+        wallet_type: 'evm'
+      });
       clearRuntimeConfig();
       applyAuthSession({
         nextAuthMode: 'wallet',
@@ -44,6 +49,9 @@ async function connectWalletAuthFlow({ applyAuthSession, updateAuthUI, runPostAu
       if (DOM.storeBtn) DOM.storeBtn.classList.remove('menu-hidden');
     }
   } catch (error) {
+    trackAnalyticsEvent('wallet_connect_failed', {
+      reason: error?.code === 4001 ? 'user_rejected' : 'connect_failed'
+    });
     logger.error('❌ Wallet auth error:', error);
     if (error.code === 4001) notifyError('❌ Request rejected');
     else notifyError(`❌ Error: ${error.message}`);

--- a/js/posthog-analytics.js
+++ b/js/posthog-analytics.js
@@ -26,6 +26,41 @@ function normalizeHost(host) {
   return String(host || '').replace(/\/+$/, '');
 }
 
+function buildMirroredPosthogEvents(name, payload = {}) {
+  if (name === 'onboarding_hint_shown') {
+    return [{ name: 'onboarding_started', payload: { version: 'v1', source: 'telegram' } }];
+  }
+  if (name === 'onboarding_hint_completed') {
+    return [{ name: 'onboarding_completed', payload: { version: 'v1' } }];
+  }
+  if (name === 'game_start') {
+    return [{
+      name: 'run_started',
+      payload: {
+        is_authorized: Boolean(payload.authenticated),
+        rides_left: Number(payload.rides_left ?? 0),
+        source: 'telegram'
+      }
+    }];
+  }
+  if (name === 'game_end') {
+    return [{
+      name: 'run_finished',
+      payload: {
+        score: payload.score,
+        distance: payload.distance,
+        coins_gold: payload.gold_coins,
+        coins_silver: payload.silver_coins,
+        duration_sec: payload.run_duration,
+        death_reason: payload.reason,
+        had_shield: false,
+        used_upgrade: 'unknown'
+      }
+    }];
+  }
+  return [];
+}
+
 function ensurePosthogGlobal() {
   const scope = window;
   if (scope.posthog && typeof scope.posthog.init === 'function') return scope.posthog;
@@ -107,6 +142,14 @@ async function initPosthogAnalytics() {
       ...analyticsEvent.payload,
       source: 'ursass_frontend',
       timestamp_ms: analyticsEvent.timestamp,
+    });
+    const mirroredEvents = buildMirroredPosthogEvents(analyticsEvent.name, analyticsEvent.payload);
+    mirroredEvents.forEach((mirroredEvent) => {
+      window.posthog?.capture?.(mirroredEvent.name, {
+        ...mirroredEvent.payload,
+        source: 'ursass_frontend',
+        timestamp_ms: analyticsEvent.timestamp,
+      });
     });
   });
 

--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -20,6 +20,7 @@ import {
   extractDonationTxRequest,
   invokeDonationWallet
 } from './donation-helpers.js';
+import { trackAnalyticsEvent } from '../analytics.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';
@@ -405,6 +406,10 @@ export function createDonationFlowActions({
     renderDonationPaymentModal();
 
     try {
+      trackAnalyticsEvent('donation_started', {
+        amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
+        currency: String(product?.currency || 'USDT')
+      });
       if (useTelegramStars) {
         await handleTelegramDonationBuy(product);
         return;
@@ -464,12 +469,21 @@ export function createDonationFlowActions({
         });
 
         await handleDonationSubmit({ txHash: donationPaymentState.txHash, submittedAt });
+        trackAnalyticsEvent('donation_success', {
+          amount_usd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
+          currency: String(donationPaymentState?.payment?.currency || product?.currency || 'USDT'),
+          source: 'game_modal'
+        });
       } catch (walletError) {
         const message = String(walletError?.message || walletError || 'Wallet transaction failed');
         const rejected = /user rejected|user denied|rejected the request|cancelled/i.test(message);
         donationPaymentState.walletError = rejected
           ? 'Transaction was rejected in your wallet. Retry when you are ready.'
           : `Wallet transaction failed: ${message}`;
+        trackAnalyticsEvent('donation_failed', {
+          amount_usd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
+          reason: rejected ? 'payment_cancelled' : 'wallet_tx_failed'
+        });
         await loadDonationHistory({ silent: true });
         donationPaymentState.status = { ...(donationPaymentState.status || {}), status: null };
       } finally {
@@ -480,6 +494,10 @@ export function createDonationFlowActions({
       donationPaymentState.error = useTelegramStars
         ? 'Failed to start Telegram Stars payment'
         : 'Failed to create payment';
+      trackAnalyticsEvent('donation_failed', {
+        amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
+        reason: 'payment_create_failed'
+      });
     } finally {
       donationPaymentState.isCreating = false;
       renderDonationProducts();

--- a/js/store/store-analytics.js
+++ b/js/store/store-analytics.js
@@ -64,6 +64,12 @@ function trackUpgradePurchaseAnalytics({
     value_tag: valueTag,
     success: true
   });
+  trackAnalyticsEvent('upgrade_purchased', {
+    upgrade_id: upgradeKey,
+    price_gold: Number(deltas.find((item) => item.currency === 'gold')?.amount || 0),
+    coins_gold_before: Number(previousBalance?.gold || 0),
+    coins_gold_after: Number(nextBalance?.gold || 0)
+  });
 
   for (const { currency, amount } of deltas) {
     trackAnalyticsEvent('currency_spent', {

--- a/js/ui.js
+++ b/js/ui.js
@@ -7,6 +7,7 @@ import { createElement, createIconAtlas, clearNode } from './dom-render.js';
 import { showStoreScreen, hideStoreScreen } from './screens.js';
 import { logger } from './logger.js';
 import { notifyWarn } from './notifier.js';
+import { trackAnalyticsEvent } from './analytics.js';
 
 const uiTextCache = {
   distance: '',
@@ -66,6 +67,9 @@ function showStore() {
     loadPlayerUpgrades().then(() => { updateStoreUI(); });
   }
   logger.info("🛒 Store opened");
+  trackAnalyticsEvent('store_opened', {
+    coins_gold: Number(gameState?.goldCoins || 0)
+  });
 }
 
 function hideStore() {
@@ -285,6 +289,9 @@ function renderGameOverLeaderboard(rows) {
 }
 
 function displayLeaderboard(leaderboard, playerPosition, options = {}) {
+  const previousRank = Number.isFinite(Number(leaderboardSnapshot.playerPosition))
+    ? Number(leaderboardSnapshot.playerPosition)
+    : null;
   const { userWallet = null, primaryId = null } = getAuthStateSnapshot();
   const startRows = [];
   const gameOverRows = [];
@@ -311,6 +318,17 @@ function displayLeaderboard(leaderboard, playerPosition, options = {}) {
       score: getEntryScore(entry)
     }));
     leaderboardSnapshot.playerPosition = Number.isFinite(Number(playerPosition)) ? Number(playerPosition) : null;
+    trackAnalyticsEvent('leaderboard_opened', {
+      player_rank: leaderboardSnapshot.playerPosition,
+      best_score: Number(options?.playerInsights?.bestScore || 0)
+    });
+    if (previousRank && leaderboardSnapshot.playerPosition && previousRank !== leaderboardSnapshot.playerPosition) {
+      trackAnalyticsEvent('leaderboard_rank_changed', {
+        old_rank: previousRank,
+        new_rank: leaderboardSnapshot.playerPosition,
+        best_score: Number(options?.playerInsights?.bestScore || 0)
+      });
+    }
     const topTen = sorted.slice(0, 10);
 
     if (topTen.length === 0) {


### PR DESCRIPTION
### Motivation
- Instrument frontend flows to capture analytics for wallet connect attempts, donation flows, store interactions, upgrades, and leaderboard changes.
- Mirror selected internal analytics events into PostHog with enriched payloads for downstream analysis and product metrics.

### Description
- Added `trackAnalyticsEvent` calls to `js/auth-authentication.js` to emit `wallet_connect_started`, `wallet_connect_success`, and `wallet_connect_failed` with basic metadata about wallet type and failure reason.
- Implemented `buildMirroredPosthogEvents` and mirroring logic in `js/posthog-analytics.js` to translate internal events like `onboarding_hint_*`, `game_start`, and `game_end` into additional PostHog captures and include them in `initPosthogAnalytics` event handling.
- Instrumented donation flow in `js/store/donation-flow.js` to emit `donation_started`, `donation_success`, and `donation_failed` events with amount and currency metadata for both create and wallet-invoke failure paths.
- Added additional analytics in `js/store/store-analytics.js` to emit `upgrade_purchased` alongside existing `upgrade_purchase` and `currency_spent` events, reporting price and gold balances.
- Instrumented UI interactions in `js/ui.js` to emit `store_opened` when the store is shown and `leaderboard_opened` and `leaderboard_rank_changed` when leaderboard is displayed, including rank and score metadata.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f13b4ec67c83209c086da481484893)