### PR TITLE
Add centralized analytics helper for game run lifecycle events

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -1,0 +1,76 @@
+import { trackAnalyticsEvent } from './analytics.js';
+
+export const analytics = {
+  onboardingStarted() {
+    trackAnalyticsEvent('onboarding_started');
+  },
+
+  onboardingCompleted() {
+    trackAnalyticsEvent('onboarding_completed');
+  },
+
+  runStarted(params = {}) {
+    const payload = {
+      is_authorized: Boolean(params.isAuthorized),
+      rides_left: params.ridesLeft,
+      source: params.source || 'unknown',
+    };
+    trackAnalyticsEvent('run_started', payload);
+    trackAnalyticsEvent('game_start', {
+      authenticated: Boolean(params.isAuthorized),
+      mode: params.mode,
+      run_index: params.runIndex,
+      difficulty_segment: params.difficultySegment,
+      rides_left: params.ridesLeft,
+    });
+  },
+
+  runFinished(params = {}) {
+    const payload = {
+      score: params.score,
+      distance: params.distance,
+      coins_gold: params.coinsGold,
+      coins_silver: params.coinsSilver,
+      duration_sec: params.durationSec,
+      death_reason: params.deathReason,
+      had_shield: params.hadShield || false,
+    };
+    trackAnalyticsEvent('run_finished', payload);
+    trackAnalyticsEvent('game_end', {
+      reason: params.deathReason,
+      run_duration: params.durationSec,
+      score: params.score,
+      distance: params.distance,
+      gold_coins: params.coinsGold,
+      silver_coins: params.coinsSilver,
+      run_index: params.runIndex,
+      difficulty_segment: params.difficultySegment,
+      ...params.extra,
+    });
+  },
+
+  walletConnectStarted() {
+    trackAnalyticsEvent('wallet_connect_started');
+  },
+
+  walletConnectSuccess(walletType) {
+    trackAnalyticsEvent('wallet_connect_success', {
+      wallet_type: walletType,
+    });
+  },
+
+  leaderboardOpened(params = {}) {
+    trackAnalyticsEvent('leaderboard_opened', {
+      player_rank: params.playerRank,
+      best_score: params.bestScore,
+    });
+  },
+
+  donationSuccess(params = {}) {
+    trackAnalyticsEvent('donation_success', {
+      amount_usd: params.amountUsd,
+      currency: params.currency,
+      source: params.source,
+    });
+  },
+};

--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -1,5 +1,12 @@
 import { trackAnalyticsEvent } from './analytics.js';
 
+
+function toNumberOrUndefined(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  const normalized = Number(value);
+  return Number.isFinite(normalized) ? normalized : undefined;
+}
+
 export const analytics = {
   onboardingStarted() {
     trackAnalyticsEvent('onboarding_started');
@@ -12,38 +19,38 @@ export const analytics = {
   runStarted(params = {}) {
     const payload = {
       is_authorized: Boolean(params.isAuthorized),
-      rides_left: params.ridesLeft,
+      rides_left: toNumberOrUndefined(params.ridesLeft),
       source: params.source || 'unknown',
     };
     trackAnalyticsEvent('run_started', payload);
     trackAnalyticsEvent('game_start', {
       authenticated: Boolean(params.isAuthorized),
       mode: params.mode,
-      run_index: params.runIndex,
+      run_index: toNumberOrUndefined(params.runIndex),
       difficulty_segment: params.difficultySegment,
-      rides_left: params.ridesLeft,
+      rides_left: toNumberOrUndefined(params.ridesLeft),
     });
   },
 
   runFinished(params = {}) {
     const payload = {
-      score: params.score,
-      distance: params.distance,
-      coins_gold: params.coinsGold,
-      coins_silver: params.coinsSilver,
-      duration_sec: params.durationSec,
+      score: toNumberOrUndefined(params.score),
+      distance: toNumberOrUndefined(params.distance),
+      coins_gold: toNumberOrUndefined(params.coinsGold),
+      coins_silver: toNumberOrUndefined(params.coinsSilver),
+      duration_sec: toNumberOrUndefined(params.durationSec),
       death_reason: params.deathReason,
       had_shield: params.hadShield || false,
     };
     trackAnalyticsEvent('run_finished', payload);
     trackAnalyticsEvent('game_end', {
       reason: params.deathReason,
-      run_duration: params.durationSec,
-      score: params.score,
-      distance: params.distance,
-      gold_coins: params.coinsGold,
-      silver_coins: params.coinsSilver,
-      run_index: params.runIndex,
+      run_duration: toNumberOrUndefined(params.durationSec),
+      score: toNumberOrUndefined(params.score),
+      distance: toNumberOrUndefined(params.distance),
+      gold_coins: toNumberOrUndefined(params.coinsGold),
+      silver_coins: toNumberOrUndefined(params.coinsSilver),
+      run_index: toNumberOrUndefined(params.runIndex),
       difficulty_segment: params.difficultySegment,
       ...params.extra,
     });
@@ -61,14 +68,14 @@ export const analytics = {
 
   leaderboardOpened(params = {}) {
     trackAnalyticsEvent('leaderboard_opened', {
-      player_rank: params.playerRank,
-      best_score: params.bestScore,
+      player_rank: toNumberOrUndefined(params.playerRank),
+      best_score: toNumberOrUndefined(params.bestScore),
     });
   },
 
   donationSuccess(params = {}) {
     trackAnalyticsEvent('donation_success', {
-      amount_usd: params.amountUsd,
+      amount_usd: toNumberOrUndefined(params.amountUsd),
       currency: params.currency,
       source: params.source,
     });

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -8,6 +8,7 @@ import { logger } from '../logger.js';
 import { notifyWarn } from '../notifier.js';
 import { isTelegramMiniApp } from '../auth-telegram.js';
 import { trackAnalyticsEvent } from '../analytics.js';
+import { analytics } from '../analytics-events.js';
 import { getInputProfile, getOnboardingHintTimelineByProfile, getOnboardingTimelineTotalDuration, markFirstRunHintShown, shouldShowFirstRunHint } from './onboarding-hints.js';
 import { buildCollisionReactionMetrics } from './collision-reaction-metrics.js';
 import { buildInputFeedbackMetrics } from './input-feedback-metrics.js';
@@ -285,26 +286,22 @@ function createGameSessionController({
         const timelineTotalMs = getOnboardingTimelineTotalDuration(timeline);
         setTimeout(() => {
           if (gameState.running) {
-            trackAnalyticsEvent('onboarding_hint_completed', {
-              hints: timeline.length,
-              input_profile: inputProfile
-            });
+                analytics.onboardingCompleted();
           }
         }, timelineTotalMs + 300);
         markFirstRunHintShown(storage);
         if (typeof document !== 'undefined') {
           document.body.classList.remove('onboarding-first-run');
         }
-        trackAnalyticsEvent('onboarding_hint_shown', {
-          hints: timeline.length,
-          input_profile: inputProfile
-        });
+        analytics.onboardingStarted();
       }
-      trackAnalyticsEvent('game_start', {
-        authenticated: isAuthenticated(),
+      analytics.runStarted({
+        isAuthorized: isAuthenticated(),
+        ridesLeft: Number(getPlayerRides()?.totalRides ?? 0),
+        source: isTelegramMiniApp() ? 'telegram' : 'web',
         mode: isUnauthRuntimeMode() ? 'unauth' : 'auth',
-        run_index: currentRunIndex,
-        difficulty_segment: getDifficultySegment(currentRunIndex),
+        runIndex: currentRunIndex,
+        difficultySegment: getDifficultySegment(currentRunIndex),
       });
 
       audioManager.playRandomGameMusic();
@@ -439,17 +436,17 @@ function createGameSessionController({
       inputLatencySumMs: gameState.inputLatencySumMs,
       inputLatencySampleCount: gameState.inputLatencySampleCount,
     });
-    trackAnalyticsEvent('game_end', {
-      reason: prettyReason,
-      run_duration: runDurationSec,
+    analytics.runFinished({
       score: Math.floor(gameState.score),
       distance: Math.floor(gameState.distance),
-      gold_coins: gameState.goldCoins,
-      silver_coins: gameState.silverCoins,
-      ...collisionReactionMetrics,
-      ...inputFeedbackMetrics,
-      run_index: currentRunIndex,
-      difficulty_segment: getDifficultySegment(currentRunIndex),
+      coinsGold: gameState.goldCoins,
+      coinsSilver: gameState.silverCoins,
+      durationSec: runDurationSec,
+      deathReason: prettyReason,
+      hadShield: false,
+      runIndex: currentRunIndex,
+      difficultySegment: getDifficultySegment(currentRunIndex),
+      extra: { ...collisionReactionMetrics, ...inputFeedbackMetrics },
     });
     const darkScreen = DOM.darkScreen;
     if (darkScreen) {


### PR DESCRIPTION
### Motivation
- Reduce duplication of analytics calls and centralize event shaping to a single helper to avoid scattering `posthog.capture`/`trackAnalyticsEvent` across the codebase.
- Provide strongly-shaped, reusable methods for common game lifecycle events (`run_started` / `run_finished`, onboarding, wallet/connect, donation, leaderboard) while keeping compatibility with existing `game_start` / `game_end` events.

### Description
- Added a new helper module `js/analytics-events.js` which exposes `analytics` methods: `onboardingStarted`, `onboardingCompleted`, `runStarted`, `runFinished`, `walletConnectStarted`, `walletConnectSuccess`, `leaderboardOpened`, and `donationSuccess`, each calling `trackAnalyticsEvent` with normalized payloads.
- The `runStarted` and `runFinished` methods emit both the new `run_started`/`run_finished` events and legacy `game_start`/`game_end` events (keeps backward compatibility and existing metrics pipelines).
- Updated `js/game/session.js` to import `analytics` and replaced in-file scattered analytics calls with `analytics.onboardingStarted()`, `analytics.onboardingCompleted()`, `analytics.runStarted({...})`, and `analytics.runFinished({...})`, including passing run metadata and extra metrics.

### Testing
- Ran `npm run check:syntax` which completed successfully and validated the modified files.
- Ran `npm run check:static-analysis` which completed successfully and the static analysis checks passed.
- Pre-commit hooks and local syntax/static-analysis checks completed successfully during the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f61318608320b6fdead602149113)