### PR TITLE
Add Telegram-safe PostHog identify flow

### DIFF
--- a/js/game-runtime.js
+++ b/js/game-runtime.js
@@ -4,7 +4,7 @@ import { initGame } from './game.js';
 import { initializeCoreLifecycle } from './runtime-lifecycle.js';
 import { logger } from './logger.js';
 import { setupAnalyticsDelivery } from './analytics-delivery.js';
-import { initPosthogAnalytics } from './posthog-analytics.js';
+import { initPosthogAnalytics, identifyTelegramUser } from './posthog-analytics.js';
 
 function onDomReady(callback) {
   if (document.readyState === 'loading') {
@@ -20,6 +20,7 @@ function initializeRuntimeDependencies() {
   initializeCoreLifecycle();
   setupAnalyticsDelivery();
   initPosthogAnalytics();
+  identifyTelegramUser();
 }
 
 let gameBootstrapInitialized = false;

--- a/js/posthog-analytics.js
+++ b/js/posthog-analytics.js
@@ -117,6 +117,22 @@ function loadPosthogScript(apiHost) {
   });
 }
 
+
+function identifyTelegramUser() {
+  if (typeof window === 'undefined') return false;
+
+  const user = window.Telegram?.WebApp?.initDataUnsafe?.user;
+  if (!user?.id) return false;
+
+  window.posthog?.identify?.(String(user.id), {
+    platform: 'telegram',
+    language_code: user.language_code,
+    is_premium: Boolean(user.is_premium),
+  });
+
+  return true;
+}
+
 async function initPosthogAnalytics() {
   if (posthogStarted || typeof window === 'undefined') return false;
 
@@ -164,4 +180,4 @@ async function initPosthogAnalytics() {
   }
 }
 
-export { initPosthogAnalytics };
+export { initPosthogAnalytics, identifyTelegramUser };


### PR DESCRIPTION
### Motivation
- Ensure analytics identify Telegram Mini App users without leaking PII by using only a stable Telegram identifier and minimal non-sensitive traits.
- Avoid sending username, display name, phone number, avatar or other unnecessary Telegram fields to PostHog.
- Call identification immediately after PostHog initialization so events are associated with the Telegram identity when available.

### Description
- Added `identifyTelegramUser()` to `js/posthog-analytics.js` that reads `window.Telegram?.WebApp?.initDataUnsafe?.user.id` and calls `posthog.identify` with only `platform`, `language_code`, and `is_premium` traits.
- Exported `identifyTelegramUser` from `js/posthog-analytics.js`.
- Imported and invoked `identifyTelegramUser()` right after `initPosthogAnalytics()` in `js/game-runtime.js` so identification runs on startup when running inside Telegram Mini App.

### Testing
- Ran `node --test scripts/observability-gate.test.mjs`, and the observability gate test suite passed (all subtests OK).
- Pre-commit `check:syntax` completed and reported success for the codebase files touched.
- Static analysis via `check:static-analysis` completed successfully with no rule violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f316e3e08320a067c9122876a580)