### PR TITLE
Handle injected Ethereum provider collisions safely

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,3 +1,4 @@
+import { getInjectedEthereumProvider } from './ethereum-provider.js';
 import { logger } from './logger.js';
 // @ts-check
 
@@ -153,8 +154,8 @@ async function signMessage(message) {
       return null;
     }
     if (!isAuthenticated()) return null;
-    if (window.ethereum) {
-      const signature = await window.ethereum.request({
+    if (getInjectedEthereumProvider()) {
+      const signature = await getInjectedEthereumProvider().request({
         method: 'personal_sign',
         params: [message, walletForSignature]
       });

--- a/js/auth-wallet-connector.js
+++ b/js/auth-wallet-connector.js
@@ -1,3 +1,4 @@
+import { getInjectedEthereumProvider } from './ethereum-provider.js';
 import { WC } from './walletconnect.js';
 
 async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
@@ -6,8 +7,8 @@ async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
 
   const normalizedFlow = flow === 'link' ? 'link' : 'auth';
 
-  if (window.ethereum) {
-    const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+  if (getInjectedEthereumProvider()) {
+    const accounts = await getInjectedEthereumProvider().request({ method: 'eth_requestAccounts' });
     if (!accounts || accounts.length === 0) return null;
 
     walletAddress = accounts[0];
@@ -18,7 +19,7 @@ async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
       timestamp,
     });
 
-    signature = await window.ethereum.request({
+    signature = await getInjectedEthereumProvider().request({
       method: 'personal_sign',
       params: [message, walletAddress],
     });
@@ -26,7 +27,7 @@ async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
     return {
       walletAddress,
       signature,
-      provider: window.ethereum,
+      provider: getInjectedEthereumProvider(),
     };
   }
 

--- a/js/ethereum-provider.js
+++ b/js/ethereum-provider.js
@@ -1,0 +1,24 @@
+function hasRequest(provider) {
+  return !!(provider && typeof provider.request === 'function');
+}
+
+function pickFromProviders(providers = []) {
+  if (!Array.isArray(providers) || providers.length === 0) return null;
+
+  const preferred = providers.find((provider) => provider?.isMetaMask && hasRequest(provider));
+  if (preferred) return preferred;
+
+  return providers.find((provider) => hasRequest(provider)) || null;
+}
+
+export function getInjectedEthereumProvider() {
+  if (typeof window === 'undefined') return null;
+
+  const rootProvider = window.ethereum;
+  if (!rootProvider) return null;
+
+  const fromList = pickFromProviders(rootProvider.providers);
+  if (fromList) return fromList;
+
+  return hasRequest(rootProvider) ? rootProvider : null;
+}

--- a/js/game/integrations/metamask.js
+++ b/js/game/integrations/metamask.js
@@ -1,10 +1,11 @@
 import { initializeMetaMaskLifecycle } from '../../runtime-lifecycle.js';
+import { getInjectedEthereumProvider } from '../../ethereum-provider.js';
 import { logger } from '../../logger.js';
 
 let cleanupMetaMaskLifecycle = () => {};
 
 function initializeMetaMaskIntegration({ onDisconnect, onReconnect, onChainChanged }) {
-  if (!window.ethereum) {
+  if (!getInjectedEthereumProvider()) {
     return false;
   }
 

--- a/js/runtime-lifecycle.js
+++ b/js/runtime-lifecycle.js
@@ -1,3 +1,4 @@
+import { getInjectedEthereumProvider } from './ethereum-provider.js';
 import { logger } from './logger.js';
 import { initializePerfStabilizationLifecycle } from './perf-stabilization.js';
 import { APP_VISIBILITY_EVENT, VIEWPORT_SYNC_EVENT } from './runtime-events.js';
@@ -77,7 +78,7 @@ function initializeTelegramViewportLifecycle() {
 }
 
 function initializeMetaMaskLifecycle({ onDisconnect, onReconnect, onChainChanged }) {
-  if (!window.ethereum) return () => {};
+  if (!getInjectedEthereumProvider()) return () => {};
   if (!metamaskAccountsHandler) {
     metamaskAccountsHandler = (accounts) => {
       logger.info('🔄 Account changed');
@@ -87,7 +88,7 @@ function initializeMetaMaskLifecycle({ onDisconnect, onReconnect, onChainChanged
         onReconnect();
       }
     };
-    window.ethereum.on('accountsChanged', metamaskAccountsHandler);
+    getInjectedEthereumProvider().on('accountsChanged', metamaskAccountsHandler);
   }
 
   if (!metamaskChainHandler) {
@@ -95,11 +96,11 @@ function initializeMetaMaskLifecycle({ onDisconnect, onReconnect, onChainChanged
       logger.info('⛓️ Network changed — reloading');
       onChainChanged();
     };
-    window.ethereum.on('chainChanged', metamaskChainHandler);
+    getInjectedEthereumProvider().on('chainChanged', metamaskChainHandler);
   }
 
   return () => {
-    const ethereum = window.ethereum;
+    const ethereum = getInjectedEthereumProvider();
     const removeListener = ethereum?.removeListener?.bind(ethereum) || ethereum?.off?.bind(ethereum);
     if (!removeListener) return;
     if (metamaskAccountsHandler) {

--- a/js/store/donation-helpers.js
+++ b/js/store/donation-helpers.js
@@ -1,4 +1,5 @@
 import { logger } from '../logger.js';
+import { getInjectedEthereumProvider } from '../ethereum-provider.js';
 import { WC } from '../walletconnect.js';
 
 const DONATION_PENDING_STORAGE_KEY = 'ursassDonationPendingPayments';
@@ -409,7 +410,8 @@ export function hasDonationExpired(payment = null, status = null) {
 }
 
 function getDonationWalletProvider() {
-  if (window.ethereum?.request) return window.ethereum;
+  const injectedProvider = getInjectedEthereumProvider();
+  if (injectedProvider?.request) return injectedProvider;
   if (WC?.provider?.request) return WC.provider;
   return null;
 }

--- a/vendor/walletconnect-ethereum-provider/index.js
+++ b/vendor/walletconnect-ethereum-provider/index.js
@@ -1,7 +1,8 @@
+import { getInjectedEthereumProvider } from '../../js/ethereum-provider.js';
 class InjectedEthereumProviderBridge {
   constructor(options = {}) {
     this.options = options;
-    this.ethereum = typeof window !== 'undefined' ? window.ethereum ?? null : null;
+    this.ethereum = typeof window !== 'undefined' ? getInjectedEthereumProvider() ?? null : null;
     this.accounts = [];
     this.listeners = new Map();
   }


### PR DESCRIPTION
### Motivation
- Some browser extension stacks inject multiple EIP-1193 providers or lock `window.ethereum` as non-configurable, causing runtime errors like `Cannot redefine property: ethereum` in Chrome; a unified resolver avoids brittle direct `window.ethereum` access.
- Prefer a deterministic provider selection that favors MetaMask and falls back to any provider implementing `request` to improve compatibility across environments.

### Description
- Added `js/ethereum-provider.js` with `getInjectedEthereumProvider()` and helpers (`hasRequest`, `pickFromProviders`) to safely resolve the injected provider from `window.ethereum` and `window.ethereum.providers`.
- Replaced direct `window.ethereum` usage with `getInjectedEthereumProvider()` in `js/api.js`, `js/auth-wallet-connector.js`, `js/runtime-lifecycle.js`, `js/game/integrations/metamask.js`, and `js/store/donation-helpers.js` so signing, account requests and event subscriptions use the resolved provider.
- Updated the local WalletConnect bridge shim (`vendor/walletconnect-ethereum-provider/index.js`) to reuse the same provider resolver for consistent behavior.

### Testing
- Ran `npm run check:syntax` and static analysis checks, which completed successfully.
- Executed `node --test scripts/runtime-lifecycle.test.mjs scripts/auth-service.test.mjs scripts/donation-service.test.mjs`, and all tests passed.
- Pre-commit hooks and project test suite validations ran as part of the commit process and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20d509ef88320a082253a7fba38e9)