### PR TITLE
Emit explicit second_run_started and include run_number in analytics

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -7,6 +7,17 @@ function toNumberOrUndefined(value) {
   return Number.isFinite(normalized) ? normalized : undefined;
 }
 
+
+function nextRunCountFromStorage() {
+  if (typeof window === 'undefined' || !window.localStorage) return undefined;
+
+  const runsCount = Number(window.localStorage.getItem('runs_count') || 0);
+  const safeRunsCount = Number.isFinite(runsCount) && runsCount >= 0 ? runsCount : 0;
+  const nextRunsCount = safeRunsCount + 1;
+  window.localStorage.setItem('runs_count', String(nextRunsCount));
+  return nextRunsCount;
+}
+
 export const analytics = {
   onboardingStarted() {
     trackAnalyticsEvent('onboarding_started');
@@ -17,12 +28,17 @@ export const analytics = {
   },
 
   runStarted(params = {}) {
+    const runNumber = nextRunCountFromStorage();
     const payload = {
       is_authorized: Boolean(params.isAuthorized),
       rides_left: toNumberOrUndefined(params.ridesLeft),
       source: params.source || 'unknown',
+      run_number: runNumber,
     };
     trackAnalyticsEvent('run_started', payload);
+    if (runNumber === 2) {
+      trackAnalyticsEvent('second_run_started');
+    }
     trackAnalyticsEvent('game_start', {
       authenticated: Boolean(params.isAuthorized),
       mode: params.mode,


### PR DESCRIPTION
### Motivation
- Ensure the funnel step `second_run_started` is recorded explicitly because it won't appear automatically unless emitted from the client, preventing a broken analytics funnel.

### Description
- In `js/analytics-events.js` add `nextRunCountFromStorage()` to persist and increment `runs_count` in `localStorage`, include `run_number` in `run_started` payload, and emit a separate `second_run_started` event when `run_number === 2`.

### Testing
- Pre-commit hooks ran `npm run check:syntax` and `npm run check:static-analysis` as part of the commit process and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f213eb8fcc8320af4eceae93cf4cea)