### PR TITLE
Capture PostHog events for Telegram user detection and app open

### DIFF
--- a/js/posthog-analytics.js
+++ b/js/posthog-analytics.js
@@ -129,6 +129,12 @@ function identifyTelegramUser() {
     language_code: user.language_code,
     is_premium: Boolean(user.is_premium),
   });
+  window.posthog?.capture?.('telegram_user_detected', {
+    platform: 'telegram',
+    language_code: user.language_code,
+    is_premium: Boolean(user.is_premium),
+    has_username: Boolean(user.username),
+  });
 
   return true;
 }
@@ -149,6 +155,9 @@ async function initPosthogAnalytics() {
     autocapture: false,
     capture_pageview: true,
     capture_pageleave: true,
+  });
+  window.posthog?.capture?.('app_opened', {
+    source: 'telegram',
   });
 
   window.addEventListener(ANALYTICS_TRACK_EVENT, (event) => {


### PR DESCRIPTION
### Motivation
- Improve analytics coverage by emitting PostHog events when a Telegram user is detected and when the app is opened in the Telegram context.

### Description
- `identifyTelegramUser()` now emits a `telegram_user_detected` event via `window.posthog.capture` with `platform`, `language_code`, `is_premium`, and `has_username` properties when a Telegram user is present.
- `initPosthogAnalytics()` now emits an `app_opened` event via `window.posthog.capture` with `source: 'telegram'` when PostHog is initialized.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f214ed83808320878899eb4dc42e13)