### PR TITLE
Add PostHog frontend bridge via existing analytics event bus

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,21 @@
 import { initLogger } from './logger.js';
 import { stabilizeMenuLoad } from './stabilize-menu.js';
+import {
+  initPostHog,
+  capturePostHogEvent,
+  identifyPostHogUser,
+  resetPostHogUser
+} from './posthog.js';
 import '../css/style.css';
+
+if (typeof window !== 'undefined') {
+  window.__URSASS_POSTHOG__ = {
+    initPostHog,
+    capturePostHogEvent,
+    identifyPostHogUser,
+    resetPostHogUser
+  };
+}
 
 function renderBootstrapFallback(error) {
   const existing = document.getElementById('bootstrapFatalOverlay');
@@ -37,6 +52,7 @@ async function bootstrap() {
   try {
     initLogger();
     stabilizeMenuLoad();
+    initPostHog();
 
     const { initGameBootstrap } = await import('./game-runtime.js');
     initGameBootstrap();

--- a/js/posthog.js
+++ b/js/posthog.js
@@ -1,0 +1,127 @@
+import posthog from 'posthog-js';
+import { ANALYTICS_TRACK_EVENT } from './analytics.js';
+import { logger } from './logger.js';
+
+let posthogReady = false;
+let bridgeBound = false;
+
+function getTelegramContext() {
+  try {
+    const tg = window?.Telegram?.WebApp;
+    const tgUser = tg?.initDataUnsafe?.user;
+
+    return {
+      isTelegram: Boolean(tg),
+      platform: tg?.platform || null,
+      version: tg?.version || null,
+      startParam: tg?.initDataUnsafe?.start_param || null,
+      userLanguage: tgUser?.language_code || null,
+      userIsPremium: typeof tgUser?.is_premium === 'boolean' ? tgUser.is_premium : null
+    };
+  } catch (error) {
+    logger.warn('⚠️ Failed to read Telegram WebApp context for PostHog:', error);
+    return {
+      isTelegram: false,
+      platform: null,
+      version: null,
+      startParam: null,
+      userLanguage: null,
+      userIsPremium: null
+    };
+  }
+}
+
+function capturePostHogEvent(name, payload = {}) {
+  const eventName = String(name || '').trim();
+  if (!eventName || !posthogReady) return;
+
+  try {
+    posthog.capture(eventName, payload && typeof payload === 'object' ? payload : {});
+  } catch (error) {
+    logger.warn(`⚠️ Failed to capture PostHog event "${eventName}":`, error);
+  }
+}
+
+function identifyPostHogUser({ id, source, properties } = {}) {
+  if (!posthogReady || !id) return;
+
+  try {
+    const distinctId = String(id).trim();
+    if (!distinctId) return;
+    posthog.identify(distinctId, {
+      source: source || 'unknown',
+      ...(properties && typeof properties === 'object' ? properties : {})
+    });
+  } catch (error) {
+    logger.warn('⚠️ Failed to identify PostHog user:', error);
+  }
+}
+
+function resetPostHogUser() {
+  if (!posthogReady) return;
+
+  try {
+    posthog.reset();
+  } catch (error) {
+    logger.warn('⚠️ Failed to reset PostHog user:', error);
+  }
+}
+
+function bindAnalyticsBridge() {
+  if (bridgeBound || typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
+
+  window.addEventListener(ANALYTICS_TRACK_EVENT, (event) => {
+    const analyticsEvent = event?.detail;
+    if (!analyticsEvent?.name) return;
+    capturePostHogEvent(analyticsEvent.name, analyticsEvent.payload || {});
+  });
+
+  bridgeBound = true;
+}
+
+function initPostHog() {
+  const key = import.meta.env?.VITE_POSTHOG_KEY;
+  const host = import.meta.env?.VITE_POSTHOG_HOST;
+  const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
+
+  if (!key) {
+    logger.warn('⚠️ VITE_POSTHOG_KEY is missing. PostHog is disabled.');
+    bindAnalyticsBridge();
+    return;
+  }
+
+  try {
+    posthog.init(key, {
+      api_host: host,
+      autocapture: false,
+      capture_pageview: false,
+      person_profiles: 'identified_only',
+      disable_session_recording: true
+    });
+
+    posthogReady = true;
+    bindAnalyticsBridge();
+
+    const tg = getTelegramContext();
+    capturePostHogEvent('app_opened', {
+      app_env: appEnv,
+      path: window?.location?.pathname || '/',
+      referrer: document?.referrer || null,
+      is_telegram: tg.isTelegram,
+      tg_platform: tg.platform,
+      tg_version: tg.version,
+      tg_start_param: tg.startParam,
+      tg_user_language: tg.userLanguage,
+      tg_user_is_premium: tg.userIsPremium
+    });
+  } catch (error) {
+    logger.warn('⚠️ Failed to init PostHog:', error);
+  }
+}
+
+export {
+  initPostHog,
+  capturePostHogEvent,
+  identifyPostHogUser,
+  resetPostHogUser
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@walletconnect/ethereum-provider": "file:vendor/walletconnect-ethereum-provider",
-    "phaser": "^3.90.0"
+    "phaser": "^3.90.0",
+    "posthog-js": "^1.302.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
### Motivation
- Integrate PostHog analytics on the frontend without scattering `posthog.capture()` calls across the codebase and without breaking the existing backend analytics delivery.
- Provide a safe, environment-driven initialization path that works outside Telegram WebApp and avoids impacting game bootstrap or runtime logic.

### Description
- Added a new bridge module `js/posthog.js` that exports `initPostHog()`, `capturePostHogEvent(name, payload)`, `identifyPostHogUser({ id, source, properties })`, and `resetPostHogUser()` and performs safe PostHog init using `import.meta.env` (`VITE_POSTHOG_KEY`, `VITE_POSTHOG_HOST`, `VITE_APP_ENV`).
- The bridge listens to the existing analytics event bus (`ANALYTICS_TRACK_EVENT` / `ursas:analytics-track`) and forwards events to PostHog without touching the backend `/api/telemetry/events` flow.
- `initPostHog()` uses `posthog.init()` with `autocapture: false`, `capture_pageview: false`, `person_profiles: 'identified_only'`, and `disable_session_recording: true`, and emits an `app_opened` event enriched with `app_env`, `path`, `referrer` and Telegram context (`is_telegram`, `tg_platform`, `tg_version`, `tg_start_param`, `tg_user_language`, `tg_user_is_premium`).
- Imported and initialized the bridge once in `js/main.js` before `initGameBootstrap()` and exposed helpers on `window.__URSASS_POSTHOG__` for safe external access; updated `package.json` to declare `posthog-js` as a dependency.

### Testing
- Ran `npm run check:syntax` and the syntax checks succeeded for all files including the new `js/posthog.js`.
- Pre-commit static analysis (`check:static-analysis`) passed and the changes were accepted by the repository checks.
- Attempted `npm install posthog-js` in this environment but network/registry access failed (`403` / `ENETUNREACH`), so the dependency declaration was added to `package.json` but the package could not be fetched here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f223a323cc832099f958e251b86ca2)