### PR TITLE
Add missing analytics events for PostHog / Telegram Apps Center readiness

### DIFF
--- a/js/auth-authentication.js
+++ b/js/auth-authentication.js
@@ -6,7 +6,7 @@ import { logger } from './logger.js';
 import { notifyError } from './notifier.js';
 import { trackAnalyticsEvent } from './analytics.js';
 
-async function connectWalletAuthFlow({ applyAuthSession, updateAuthUI, runPostAuthSync, DOM }) {
+async function connectWalletAuthFlow({ applyAuthSession, updateAuthUI, runPostAuthSync, DOM, isWalletAuthMode }) {
   if (authState.isWalletAuthInProgress) return;
 
   authState.isWalletAuthInProgress = true;
@@ -26,8 +26,11 @@ async function connectWalletAuthFlow({ applyAuthSession, updateAuthUI, runPostAu
     });
 
     if (data.success) {
+      const walletType = typeof isWalletAuthMode === 'function' && isWalletAuthMode()
+        ? 'wallet'
+        : 'telegram_linked_wallet';
       trackAnalyticsEvent('wallet_connect_success', {
-        wallet_type: 'evm'
+        wallet_type: walletType
       });
       clearRuntimeConfig();
       applyAuthSession({

--- a/js/auth.js
+++ b/js/auth.js
@@ -34,8 +34,16 @@ const getTelegramAuthIdentifier = () => getTelegramAuthIdentifierState();
 const getAuthStateSnapshot = () => getAuthStateSnapshotState();
 
 async function connectWalletAuth() {
-  trackAnalyticsEvent('wallet_connect_started');
-  await connectWalletAuthFlow({ applyAuthSession: applyAuthSessionState, updateAuthUI, runPostAuthSync, DOM });
+  trackAnalyticsEvent('wallet_connect_started', {
+    source: 'wallet_button'
+  });
+  await connectWalletAuthFlow({
+    applyAuthSession: applyAuthSessionState,
+    updateAuthUI,
+    runPostAuthSync,
+    DOM,
+    isWalletAuthMode
+  });
 }
 
 function disconnectAuth() {

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -11,6 +11,7 @@ import { initializeTelegramIntegration } from './integrations/telegram.js';
 import { initializeMetaMaskIntegration } from './integrations/metamask.js';
 import { logger } from '../logger.js';
 import { notifyError, notifySuccess } from '../notifier.js';
+import { trackAnalyticsEvent } from '../analytics.js';
 import { initAiMode } from '../ai-mode.js';
 import { shouldShowFirstRunHint } from './onboarding-hints.js';
 import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } from '../player-menu/index.js';
@@ -331,6 +332,13 @@ function bindUiEventHandlers({ startGame, restartFromGameOver, goToMainMenu, sho
   if (DOM.playerAvatarBtn) {
     DOM.playerAvatarBtn.addEventListener('click', () => openPlayerMenu());
   }
+  document.querySelectorAll('.lb-title').forEach((el) => {
+    el.addEventListener('click', () => {
+      trackAnalyticsEvent('leaderboard_opened', {
+        source: 'top_button'
+      });
+    });
+  });
 
   if (DOM.menuBtn) DOM.menuBtn.addEventListener('click', goToMainMenu);
   if (DOM.storeBackBtn) DOM.storeBackBtn.addEventListener('click', hideStore);

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -286,7 +286,12 @@ function createGameSessionController({
         const timelineTotalMs = getOnboardingTimelineTotalDuration(timeline);
         setTimeout(() => {
           if (gameState.running) {
-                analytics.onboardingCompleted();
+            trackAnalyticsEvent('onboarding_hint_completed', {
+              type: 'first_run_hint', input_profile: inputProfile
+            });
+            trackAnalyticsEvent('onboarding_completed', {
+              type: 'first_run_hint', input_profile: inputProfile
+            });
           }
         }, timelineTotalMs + 300);
         markFirstRunHintShown(storage);

--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -21,7 +21,6 @@ import {
   invokeDonationWallet
 } from './donation-helpers.js';
 import { trackAnalyticsEvent } from '../analytics.js';
-import { analytics } from '../analytics-events.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';
@@ -69,6 +68,13 @@ export function createDonationFlowActions({
         reward: null
       };
       donationPaymentState.error = errorMessage || 'Telegram Stars payment was not completed.';
+      trackAnalyticsEvent('donation_failed', {
+        amount_usd: Number(paymentData?.amount || donationPaymentState?.payment?.amount || 0),
+        currency: 'STARS',
+        source: 'game_modal',
+        payment_method: 'telegram_stars',
+        reason: normalizedInvoiceStatus || 'invoice_not_paid'
+      });
       renderDonationPaymentModal();
       return;
     }
@@ -158,6 +164,12 @@ export function createDonationFlowActions({
       const finalStatus = String(refreshed?.status || '').toLowerCase();
 
       if (isDonationSuccessStatus(finalStatus)) {
+        trackAnalyticsEvent('donation_success', {
+          amount_usd: Number(refreshed?.amount || paymentData?.amount || donationPaymentState?.payment?.amount || 0),
+          currency: 'STARS',
+          source: 'game_modal',
+          payment_method: 'telegram_stars'
+        });
         donationPaymentState.invoiceUrl = '';
         donationPaymentState.error = '';
         showToast('Telegram Stars payment paid', 'success');
@@ -165,6 +177,13 @@ export function createDonationFlowActions({
         updateStoreUI();
         await loadDonationHistory({ silent: true });
       } else if (finalStatus === 'failed' || finalStatus === 'expired') {
+        trackAnalyticsEvent('donation_failed', {
+          amount_usd: Number(refreshed?.amount || paymentData?.amount || donationPaymentState?.payment?.amount || 0),
+          currency: 'STARS',
+          source: 'game_modal',
+          payment_method: 'telegram_stars',
+          reason: finalStatus
+        });
         donationPaymentState.invoiceUrl = '';
         donationPaymentState.error = errorMessage || refreshed?.failureReason || 'Telegram Stars payment failed.';
         showToast('Telegram Stars payment failed', 'error');
@@ -409,7 +428,9 @@ export function createDonationFlowActions({
     try {
       trackAnalyticsEvent('donation_started', {
         amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
-        currency: String(product?.currency || 'USDT')
+        currency: String(product?.currency || (useTelegramStars ? 'STARS' : 'USDT')),
+        source: 'game_modal',
+        payment_method: useTelegramStars ? 'telegram_stars' : 'wallet'
       });
       if (useTelegramStars) {
         await handleTelegramDonationBuy(product);
@@ -472,10 +493,11 @@ export function createDonationFlowActions({
         await handleDonationSubmit({ txHash: donationPaymentState.txHash, submittedAt });
         const finalStatus = String(donationPaymentState?.status?.status || '').toLowerCase();
         if (isDonationSuccessStatus(finalStatus)) {
-          analytics.donationSuccess({
-            amountUsd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
-            currency: String(donationPaymentState?.payment?.currency || product?.currency || 'USDT'),
-            source: 'game_modal'
+          trackAnalyticsEvent('donation_success', {
+            amount_usd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
+            currency: 'USDT',
+            source: 'game_modal',
+            payment_method: 'wallet'
           });
         }
       } catch (walletError) {
@@ -486,6 +508,9 @@ export function createDonationFlowActions({
           : `Wallet transaction failed: ${message}`;
         trackAnalyticsEvent('donation_failed', {
           amount_usd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
+          currency: String(donationPaymentState?.payment?.currency || product?.currency || 'USDT'),
+          source: 'game_modal',
+          payment_method: 'wallet',
           reason: rejected ? 'payment_cancelled' : 'wallet_tx_failed'
         });
         await loadDonationHistory({ silent: true });
@@ -500,6 +525,9 @@ export function createDonationFlowActions({
         : 'Failed to create payment';
       trackAnalyticsEvent('donation_failed', {
         amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
+        currency: String(product?.currency || (useTelegramStars ? 'STARS' : 'USDT')),
+        source: 'game_modal',
+        payment_method: useTelegramStars ? 'telegram_stars' : 'wallet',
         reason: 'payment_create_failed'
       });
     } finally {


### PR DESCRIPTION
### Motivation

- Add missing product analytics events required by PostHog and Telegram Apps Center readiness while keeping the existing analytics delivery pipeline intact.  
- Ensure all events are emitted through the existing `trackAnalyticsEvent(name, payload)` helper and never call `posthog.capture()` directly.  
- Emit events only on real user actions and only after backend-confirmed success for payments to avoid false positives.

### Description

- Emit `wallet_connect_started` with `source: 'wallet_button'` at the wallet button handler before invoking the auth flow in `js/auth.js`.  
- Emit `wallet_connect_success` with `wallet_type` determined by `isWalletAuthMode()` after successful wallet authentication in `js/auth-authentication.js`.  
- Add first-run onboarding payloads: emit `onboarding_hint_completed` and `onboarding_completed` with `{ type: 'first_run_hint', input_profile }` when the onboarding hint timeline completes in `js/game/session.js`.  
- Track `leaderboard_opened` only on a real user click of the TOP title (`source: 'top_button'`) by wiring a click listener on `.lb-title` in `js/game/bootstrap.js`.  
- Enhance donation flow analytics in `js/store/donation-flow.js`: expand `donation_started` payload to include `amount_usd`, `currency`, `source: 'game_modal'`, and `payment_method`; emit `donation_success` only after confirmed final backend status for wallet (`currency: 'USDT', payment_method: 'wallet'`) and Telegram Stars (`currency: 'STARS', payment_method: 'telegram_stars'`); emit `donation_failed` on cancellations/errors/failed/expired with structured `reason`, `amount_usd`, `currency`, `source`, and `payment_method`.  
- All new tracking calls use `trackAnalyticsEvent(...)` and no existing backend-required events were removed.

### Testing

- Pre-commit syntax checks were executed via the repository guardrails (`node scripts/check-syntax.mjs`) and succeeded.  
- Static analysis checks were executed (`node scripts/check-static-analysis.mjs`) and succeeded.  
- An attempt to run `npm test` failed with `Missing script: "test"`, which is expected for this repo and does not block the pre-commit guards that ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2280626cc83208c7a6329bcbdc145)