### PR TITLE
Add PostHog identity lifecycle hooks to auth bootstrap

### DIFF
--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -18,6 +18,7 @@ import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } f
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { captureReferralFromUrl, sendReferralAfterAuth } from '../referral/referralCapture.js';
 import { SCREEN_CHANGED_EVENT } from '../runtime-events.js';
+import { identifyPostHogUser, resetPostHogUser } from '../posthog.js';
 
 captureReferralFromUrl();
 
@@ -417,6 +418,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     onLoadLeaderboard: loadAndDisplayLeaderboard,
     onUpdateRidesDisplay: updateRidesDisplay,
     onAuthDisconnected: () => {
+      resetPostHogUser();
       updatePlayerAvatarVisibility();
       resetAuthenticatedUiState();
       updateStartHook().catch(() => {});
@@ -432,6 +434,18 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
       _walletJustConnected = false;
       const snap = getAuthStateSnapshot();
       const primaryId = snap?.primaryId;
+      if (primaryId) {
+        const authMode = hasWalletAuthSession() ? 'wallet' : 'telegram';
+        identifyPostHogUser({
+          id: primaryId,
+          source: authMode,
+          properties: {
+            auth_mode: authMode,
+            has_wallet_session: hasWalletAuthSession(),
+            linked_wallet: Boolean(snap?.linkedWallet)
+          }
+        });
+      }
 
       // Invalidate profile cache unconditionally so getCachedProfile() fetches fresh data
       // from the server and returns an accurate rankDelta (cached data may be stale/anon).


### PR DESCRIPTION
### Motivation
- Identify users in PostHog immediately after successful auth so analytics has `primaryId` and auth context without leaking PII. 
- Reset PostHog identity when the auth session is disconnected to avoid attributing events to a stale user.

### Description
- Imported `identifyPostHogUser` and `resetPostHogUser` into `js/game/bootstrap.js` and updated `setAuthCallbacks` to call them. 
- Call `identifyPostHogUser(...)` in `onAuthAuthenticated` only when `primaryId` exists and set `source`/`auth_mode` to `wallet` or `telegram` via `hasWalletAuthSession()`, and include only `auth_mode`, `has_wallet_session`, and `linked_wallet` in `properties` (no PII is sent). 
- Call `resetPostHogUser()` in `onAuthDisconnected`. 
- Did not modify existing auth logic or change Telegram/wallet login flows.

### Testing
- Ran the repository syntax checks (`node scripts/check-syntax.mjs`) during pre-commit and they passed. 
- Ran static analysis (`node scripts/check-static-analysis.mjs`) during pre-commit and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22d52aea8832095533e2728737a82)