### PR TITLE
Enhance analytics events API and integrate PostHog identification on auth lifecycle

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -19,12 +19,16 @@ function nextRunCountFromStorage() {
 }
 
 export const analytics = {
+  appOpened(payload = {}) {
+    trackAnalyticsEvent('app_opened', payload);
+  },
+
   onboardingStarted() {
     trackAnalyticsEvent('onboarding_started');
   },
 
-  onboardingCompleted() {
-    trackAnalyticsEvent('onboarding_completed');
+  onboardingCompleted(payload = {}) {
+    trackAnalyticsEvent('onboarding_completed', payload);
   },
 
   runStarted(params = {}) {
@@ -72,14 +76,23 @@ export const analytics = {
     });
   },
 
-  walletConnectStarted() {
-    trackAnalyticsEvent('wallet_connect_started');
+  secondRunStarted(payload = {}) {
+    trackAnalyticsEvent('second_run_started', payload);
   },
 
-  walletConnectSuccess(walletType) {
-    trackAnalyticsEvent('wallet_connect_success', {
-      wallet_type: walletType,
-    });
+  walletConnectStarted(payload = {}) {
+    trackAnalyticsEvent('wallet_connect_started', payload);
+  },
+
+  walletConnectSuccess(payload = {}) {
+    const normalizedPayload = (payload && typeof payload === 'object')
+      ? payload
+      : { wallet_type: payload };
+    trackAnalyticsEvent('wallet_connect_success', normalizedPayload);
+  },
+
+  walletConnectFailed(payload = {}) {
+    trackAnalyticsEvent('wallet_connect_failed', payload);
   },
 
   leaderboardOpened(params = {}) {
@@ -98,11 +111,43 @@ export const analytics = {
     });
   },
 
+  storeOpened(payload = {}) {
+    trackAnalyticsEvent('store_opened', payload);
+  },
+
+  upgradePurchased(payload = {}) {
+    trackAnalyticsEvent('upgrade_purchased', payload);
+  },
+
+  donationStarted(payload = {}) {
+    trackAnalyticsEvent('donation_started', payload);
+  },
+
+  donationFailed(payload = {}) {
+    trackAnalyticsEvent('donation_failed', payload);
+  },
 
   shareResultClicked(params = {}) {
-    trackAnalyticsEvent('result_success', {
+    trackAnalyticsEvent('share_result_clicked', {
       context: params.context || 'unknown',
       source: params.source || 'share_result_button',
     });
+  },
+
+  // Deprecated typo aliases. Do not use in new code.
+  donationSuccsses(payload = {}) {
+    this.donationSuccess(payload);
+  },
+
+  donationSuccssesUsdt(payload = {}) {
+    this.donationSuccess({ ...payload, currency: payload.currency || 'USDT' });
+  },
+
+  donationSuccssesStars(payload = {}) {
+    this.donationSuccess({ ...payload, currency: payload.currency || 'STARS' });
+  },
+
+  resultSuccsses(payload = {}) {
+    this.shareResultClicked(payload);
   },
 };

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -18,6 +18,7 @@ import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } f
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { captureReferralFromUrl, sendReferralAfterAuth } from '../referral/referralCapture.js';
 import { SCREEN_CHANGED_EVENT } from '../runtime-events.js';
+import { identifyPostHogUser, resetPostHogUser } from '../posthog.js';
 
 captureReferralFromUrl();
 
@@ -417,6 +418,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     onLoadLeaderboard: loadAndDisplayLeaderboard,
     onUpdateRidesDisplay: updateRidesDisplay,
     onAuthDisconnected: () => {
+      resetPostHogUser();
       updatePlayerAvatarVisibility();
       resetAuthenticatedUiState();
       updateStartHook().catch(() => {});
@@ -432,6 +434,18 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
       _walletJustConnected = false;
       const snap = getAuthStateSnapshot();
       const primaryId = snap?.primaryId;
+      if (primaryId) {
+        const authMode = hasWalletAuthSession() ? 'wallet' : 'telegram';
+        identifyPostHogUser({
+          id: primaryId,
+          source: authMode,
+          properties: {
+            auth_mode: authMode,
+            has_wallet_session: hasWalletAuthSession(),
+            linked_wallet: Boolean(snap?.linkedWallet)
+          }
+        });
+      }
 
       // Invalidate profile cache unconditionally so getCachedProfile() fetches fresh data
       // from the server and returns an accurate rankDelta (cached data may be stale/anon).


### PR DESCRIPTION
### Motivation
- Standardize and expand analytics event helpers to support richer payloads and new event types for tracking app and commerce flows. 
- Ensure PostHog receives user identity and session state on authentication lifecycle events to improve user analytics and session attribution.

### Description
- Extended `analytics` API in `js/analytics-events.js` with new event methods including `appOpened`, `storeOpened`, `upgradePurchased`, `donationStarted`, `donationFailed`, `secondRunStarted`, and `walletConnectFailed`, and made many methods accept an optional `payload` object. 
- Normalized `walletConnectSuccess` to accept either an object or legacy string and adjusted `shareResultClicked` event name to `share_result_clicked` (replacing prior `result_success`).
- Added currency normalization in `donationSuccess` and included deprecated typo aliases (`donationSuccsses*`, `resultSuccsses`) that forward to the correct handlers for backwards compatibility. 
- In `js/game/bootstrap.js` imported `identifyPostHogUser` and `resetPostHogUser`, wired `resetPostHogUser()` on auth disconnect, and call `identifyPostHogUser()` with `primaryId` and auth-related properties on auth success. 

### Testing
- Ran lint with `npm run lint` and the codebase passed linting checks. 
- Executed the unit test suite with `npm test` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22d52aea8832095533e2728737a82)