### PR TITLE
PostHog: allowlist bridge events and guard double initialization

### DIFF
--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -4,6 +4,20 @@ import { logger } from './logger.js';
 
 let bridgeStarted = false;
 
+const POSTHOG_EVENT_ALLOWLIST = new Set([
+  'app_opened',
+  'onboarding_completed',
+  'onboarding_hint_completed',
+  'wallet_connect_started',
+  'wallet_connect_success',
+  'wallet_connect_failed',
+  'leaderboard_opened',
+  'donation_started',
+  'donation_success',
+  'donation_failed'
+]);
+
+
 function toNumber(value) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : 0;
@@ -58,6 +72,8 @@ function setupPostHogBridge() {
       capturePostHogEvent('run_finished', normalizeGameEndPayload(payload));
       return;
     }
+
+    if (!POSTHOG_EVENT_ALLOWLIST.has(eventName)) return;
 
     capturePostHogEvent(eventName, payload);
   });

--- a/js/posthog.js
+++ b/js/posthog.js
@@ -2,6 +2,7 @@ import posthog from 'posthog-js';
 import { logger } from './logger.js';
 
 let posthogReady = false;
+let posthogInitialized = false;
 
 function getTelegramContext() {
   try {
@@ -66,6 +67,8 @@ function resetPostHogUser() {
 }
 
 function initPostHog() {
+  if (posthogInitialized || posthogReady) return;
+
   const key = import.meta.env?.VITE_POSTHOG_KEY;
   const host = import.meta.env?.VITE_POSTHOG_HOST;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
@@ -85,6 +88,7 @@ function initPostHog() {
     });
 
     posthogReady = true;
+    posthogInitialized = true;
     const tg = getTelegramContext();
     capturePostHogEvent('app_opened', {
       app_env: appEnv,


### PR DESCRIPTION
### Motivation

- Restrict which analytics events are forwarded to PostHog to avoid sending unapproved or noisy events.
- Prevent multiple PostHog initializations to avoid duplicate events or reinitialization side effects.

### Description

- Added `POSTHOG_EVENT_ALLOWLIST` in `js/posthog-bridge.js` and early-return logic `if (!POSTHOG_EVENT_ALLOWLIST.has(eventName)) return;` to only forward approved event names.
- Kept special handling for `game_start` and `game_end` events and preserved additional `second_run_started` emission when `run_number === 2`.
- Introduced `posthogInitialized` flag in `js/posthog.js` and added a guard `if (posthogInitialized || posthogReady) return;` in `initPostHog`, and set `posthogInitialized = true` after successful initialization.

### Testing

- Ran the existing frontend test suite and smoke-checked analytics flows; tests passed with no regressions.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22fda432c8320ab58aa135d970715)