### PR TITLE
Restrict forwarded PostHog events, add init guard, and remove deprecated upgrade event

### DIFF
--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -4,6 +4,20 @@ import { logger } from './logger.js';
 
 let bridgeStarted = false;
 
+const POSTHOG_EVENT_ALLOWLIST = new Set([
+  'app_opened',
+  'onboarding_completed',
+  'onboarding_hint_completed',
+  'wallet_connect_started',
+  'wallet_connect_success',
+  'wallet_connect_failed',
+  'leaderboard_opened',
+  'donation_started',
+  'donation_success',
+  'donation_failed'
+]);
+
+
 function toNumber(value) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : 0;
@@ -58,6 +72,8 @@ function setupPostHogBridge() {
       capturePostHogEvent('run_finished', normalizeGameEndPayload(payload));
       return;
     }
+
+    if (!POSTHOG_EVENT_ALLOWLIST.has(eventName)) return;
 
     capturePostHogEvent(eventName, payload);
   });

--- a/js/posthog.js
+++ b/js/posthog.js
@@ -2,6 +2,7 @@ import posthog from 'posthog-js';
 import { logger } from './logger.js';
 
 let posthogReady = false;
+let posthogInitialized = false;
 
 function getTelegramContext() {
   try {
@@ -66,6 +67,8 @@ function resetPostHogUser() {
 }
 
 function initPostHog() {
+  if (posthogInitialized || posthogReady) return;
+
   const key = import.meta.env?.VITE_POSTHOG_KEY;
   const host = import.meta.env?.VITE_POSTHOG_HOST;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
@@ -85,6 +88,7 @@ function initPostHog() {
     });
 
     posthogReady = true;
+    posthogInitialized = true;
     const tg = getTelegramContext();
     capturePostHogEvent('app_opened', {
       app_env: appEnv,

--- a/js/store/store-analytics.js
+++ b/js/store/store-analytics.js
@@ -64,13 +64,6 @@ function trackUpgradePurchaseAnalytics({
     value_tag: valueTag,
     success: true
   });
-  trackAnalyticsEvent('upgrade_purchased', {
-    upgrade_id: upgradeKey,
-    price_gold: Number(deltas.find((item) => item.currency === 'gold')?.amount || 0),
-    coins_gold_before: Number(previousBalance?.gold || 0),
-    coins_gold_after: Number(nextBalance?.gold || 0)
-  });
-
   for (const { currency, amount } of deltas) {
     trackAnalyticsEvent('currency_spent', {
       source: 'store_upgrade',


### PR DESCRIPTION
### Motivation
- Reduce noise and accidental leakage by only forwarding a curated set of analytics events to PostHog.
- Prevent multiple PostHog initializations during app lifetime to avoid duplicate side-effects.
- Stop sending a redundant `upgrade_purchased` event from the store analytics pipeline.

### Description
- Added a `POSTHOG_EVENT_ALLOWLIST` and updated `setupPostHogBridge` to ignore analytics events not present in the allowlist, while preserving special handling for `game_start` and `game_end` events.
- Introduced a `posthogInitialized` flag and an early return in `initPostHog` (`if (posthogInitialized || posthogReady) return;`) and set the flag when initialization succeeds to prevent double initialization.
- Removed the `upgrade_purchased` tracking call from `trackUpgradePurchaseAnalytics` to stop emitting the deprecated event.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22fda432c8320ab58aa135d970715)