### PR TITLE
fix(posthog): fallback to injected host for app_opened delivery

### DIFF
--- a/js/posthog.js
+++ b/js/posthog.js
@@ -70,7 +70,7 @@ function initPostHog() {
   if (posthogInitialized || posthogReady) return;
 
   const key = import.meta.env?.VITE_POSTHOG_KEY;
-  const host = import.meta.env?.VITE_POSTHOG_HOST;
+  const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
 
   if (!key) {
@@ -80,12 +80,14 @@ function initPostHog() {
 
   try {
     posthog.init(key, {
-      api_host: host,
+      ...(host ? { api_host: host } : {}),
       autocapture: false,
       capture_pageview: false,
       person_profiles: 'identified_only',
       disable_session_recording: true
     });
+
+    logger.info(`📊 PostHog init: host=${host || 'default'} env=${appEnv}`);
 
     posthogReady = true;
     posthogInitialized = true;


### PR DESCRIPTION
### Motivation
- Events like `app_opened` were not visible because the PostHog SDK fell back to its default endpoint when `VITE_POSTHOG_HOST` was not set and the project injects host at runtime via `window.__URSASS_POSTHOG_HOST__`. 
- The change makes it easier to diagnose and avoid EU/US host mismatches that route events to the wrong PostHog project.

### Description
- Use `window.__URSASS_POSTHOG_HOST__` as a fallback for `VITE_POSTHOG_HOST` when determining the PostHog `api_host` in `js/posthog.js`. 
- Pass `api_host` to `posthog.init` only when a host value is actually available to avoid sending `undefined`. 
- Add an init log line `📊 PostHog init: host=... env=...` to make the selected host and environment visible for debugging.

### Testing
- Pre-commit checks ran automatically and `npm run check:syntax` completed successfully. 
- Static analysis guards ran and `npm run check:static-analysis` completed successfully. 
- Running `npm run -s lint` failed because the project does not define a `lint` script. 
- The change was validated by project static checks and syntax checks executed by the commit hooks and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23e09f6688320ae109346f1fd7937)