### PR TITLE
Make PostHog host configurable at runtime and broaden donation success status checks

### DIFF
--- a/js/posthog.js
+++ b/js/posthog.js
@@ -70,7 +70,7 @@ function initPostHog() {
   if (posthogInitialized || posthogReady) return;
 
   const key = import.meta.env?.VITE_POSTHOG_KEY;
-  const host = import.meta.env?.VITE_POSTHOG_HOST;
+  const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
 
   if (!key) {
@@ -80,12 +80,14 @@ function initPostHog() {
 
   try {
     posthog.init(key, {
-      api_host: host,
+      ...(host ? { api_host: host } : {}),
       autocapture: false,
       capture_pageview: false,
       person_profiles: 'identified_only',
       disable_session_recording: true
     });
+
+    logger.info(`📊 PostHog init: host=${host || 'default'} env=${appEnv}`);
 
     posthogReady = true;
     posthogInitialized = true;

--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -36,7 +36,7 @@ function normalizeDonationResultMeta(payload = null) {
 
 function isConfirmedSuccessResult(payload = null) {
   const { ok, status } = normalizeDonationResultMeta(payload);
-  return ok === true && (status === 'paid' || status === 'credited');
+  return ok === true && (isDonationSuccessStatus(status) || !status);
 }
 
 export function createDonationFlowActions({

--- a/js/store/donation-helpers.js
+++ b/js/store/donation-helpers.js
@@ -231,8 +231,16 @@ export function getTelegramStarsOrderId(payment = null) {
 }
 
 export function isDonationSuccessStatus(status = '') {
-  const normalizedStatus = String(status || '').toLowerCase();
-  return normalizedStatus === 'credited' || normalizedStatus === 'paid';
+  const normalizedStatus = String(status || '').trim().toLowerCase();
+  return (
+    normalizedStatus === 'credited'
+    || normalizedStatus === 'paid'
+    || normalizedStatus === 'completed'
+    || normalizedStatus === 'complete'
+    || normalizedStatus === 'succeeded'
+    || normalizedStatus === 'success'
+    || normalizedStatus === 'confirmed'
+  );
 }
 
 export function buildTelegramStarsConfirmPayload(payment = null, telegramInitData = '') {


### PR DESCRIPTION
### Motivation

- Allow PostHog API host to be injected at runtime and avoid sending `undefined` as `api_host` when not set. 
- Provide an informative init log for PostHog to aid debugging of analytics configuration. 
- Accept a wider range of payment status values as successful to handle different provider conventions.

### Description

- In `initPostHog` read host from `VITE_POSTHOG_HOST` or the global `window.__URSASS_POSTHOG_HOST__`, and only pass `api_host` to `posthog.init` when a host is present. 
- Add a `logger.info` call in `initPostHog` to report the resolved PostHog host and application environment. 
- Expand `isDonationSuccessStatus` to normalize and accept multiple success synonyms (`completed`, `complete`, `succeeded`, `success`, `confirmed`) and trim input. 
- Update `isConfirmedSuccessResult` to treat results as confirmed success when `isDonationSuccessStatus(status)` returns true or when the `status` is empty.

### Testing

- Ran the repository automated test suite with `npm test` and all tests passed. 
- Ran linting and a production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23e09f6688320ae109346f1fd7937)