### PR TITLE
PostHog host fallback, donation success analytics, and broadened success status handling

### DIFF
--- a/js/posthog.js
+++ b/js/posthog.js
@@ -70,7 +70,7 @@ function initPostHog() {
   if (posthogInitialized || posthogReady) return;
 
   const key = import.meta.env?.VITE_POSTHOG_KEY;
-  const host = import.meta.env?.VITE_POSTHOG_HOST;
+  const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
 
   if (!key) {
@@ -80,12 +80,14 @@ function initPostHog() {
 
   try {
     posthog.init(key, {
-      api_host: host,
+      ...(host ? { api_host: host } : {}),
       autocapture: false,
       capture_pageview: false,
       person_profiles: 'identified_only',
       disable_session_recording: true
     });
+
+    logger.info(`📊 PostHog init: host=${host || 'default'} env=${appEnv}`);
 
     posthogReady = true;
     posthogInitialized = true;

--- a/js/store/donation-controller.js
+++ b/js/store/donation-controller.js
@@ -17,6 +17,7 @@ import {
   mergeDonationHistoryWithPending
 } from './donation-helpers.js';
 import { createDonationFlowActions } from './donation-flow.js';
+import { trackAnalyticsEvent } from '../analytics.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';
@@ -34,6 +35,7 @@ export function createDonationController({
   let donationAbortController = null;
   let toastTimerCounter = 0;
   let donationRefreshCooldownTimers = {};
+  const donationSuccessTrackedIds = new Set();
 
   async function handleDonationBuy(...args) {
     return donationFlowActions.handleDonationBuy(...args);
@@ -356,6 +358,17 @@ export function createDonationController({
       }
 
       if (isDonationSuccessStatus(getClientSideDonationStatus(data))) {
+        const paymentId = String(data?.paymentId || data?.orderId || '').trim();
+        if (paymentId && !donationSuccessTrackedIds.has(paymentId)) {
+          donationSuccessTrackedIds.add(paymentId);
+          trackAnalyticsEvent('donation_success', {
+            amount_usd: Number(data?.amount || donationPaymentState?.payment?.amount || 0),
+            currency: String(data?.currency || donationPaymentState?.payment?.currency || (isTelegramStarsPayment(data) ? 'STARS' : 'USDT')).toUpperCase(),
+            source: 'history_refresh',
+            payment_method: isTelegramStarsPayment(data) ? 'telegram_stars' : 'wallet'
+          });
+        }
+
         showToast('Donation reward credited', 'success');
         await loadPlayerUpgrades();
         updateStoreUI();

--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -36,7 +36,7 @@ function normalizeDonationResultMeta(payload = null) {
 
 function isConfirmedSuccessResult(payload = null) {
   const { ok, status } = normalizeDonationResultMeta(payload);
-  return ok === true && (status === 'paid' || status === 'credited');
+  return ok === true && (isDonationSuccessStatus(status) || !status);
 }
 
 export function createDonationFlowActions({

--- a/js/store/donation-helpers.js
+++ b/js/store/donation-helpers.js
@@ -231,8 +231,16 @@ export function getTelegramStarsOrderId(payment = null) {
 }
 
 export function isDonationSuccessStatus(status = '') {
-  const normalizedStatus = String(status || '').toLowerCase();
-  return normalizedStatus === 'credited' || normalizedStatus === 'paid';
+  const normalizedStatus = String(status || '').trim().toLowerCase();
+  return (
+    normalizedStatus === 'credited'
+    || normalizedStatus === 'paid'
+    || normalizedStatus === 'completed'
+    || normalizedStatus === 'complete'
+    || normalizedStatus === 'succeeded'
+    || normalizedStatus === 'success'
+    || normalizedStatus === 'confirmed'
+  );
 }
 
 export function buildTelegramStarsConfirmPayload(payment = null, telegramInitData = '') {


### PR DESCRIPTION
### Motivation
- Allow configuring PostHog host from a global runtime value and avoid passing undefined `api_host` to `posthog.init` while adding an init log for diagnostics.
- Ensure donation success events are tracked once when refreshed from history and capture relevant metadata for analytics.
- Make donation success detection more robust by accepting additional status variants and trimming input.

### Description
- Updated `initPostHog` to read host from `import.meta.env.VITE_POSTHOG_HOST` or `window.__URSASS_POSTHOG_HOST__`, to only set `api_host` when present, and to log init details via `logger.info`.
- In `donation-controller` imported `trackAnalyticsEvent`, added a `donationSuccessTrackedIds` set to avoid duplicate tracking, and emit a `donation_success` event with `amount_usd`, `currency`, `source: 'history_refresh'`, and `payment_method` when a refreshed entry is a success.
- Modified `isConfirmedSuccessResult` in `donation-flow` to consider results successful when `isDonationSuccessStatus(status)` is true or when the status is empty.
- Expanded `isDonationSuccessStatus` in `donation-helpers` to `trim()` input and accept multiple synonyms such as `completed`, `complete`, `succeeded`, `success`, and `confirmed` in addition to `paid` and `credited`.

### Testing
- Ran the project's unit tests and linter against the modified code and they passed.
- Performed a local smoke test of app initialization and donation history refresh to verify PostHog init logging and a single `donation_success` analytics event was emitted when appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23e09f6688320ae109346f1fd7937)