### PR TITLE
Allow PostHog key from runtime window config

### DIFF
--- a/js/posthog.js
+++ b/js/posthog.js
@@ -69,12 +69,12 @@ function resetPostHogUser() {
 function initPostHog() {
   if (posthogInitialized || posthogReady) return;
 
-  const key = import.meta.env?.VITE_POSTHOG_KEY;
+  const key = import.meta.env?.VITE_POSTHOG_KEY || window?.__URSASS_POSTHOG_KEY__ || undefined;
   const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
 
   if (!key) {
-    logger.warn('⚠️ VITE_POSTHOG_KEY is missing. PostHog is disabled.');
+    logger.warn('⚠️ PostHog key is missing (VITE_POSTHOG_KEY/window.__URSASS_POSTHOG_KEY__). PostHog is disabled.');
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Some deployments inject the PostHog key at runtime into `window.__URSASS_POSTHOG_KEY__` (via `index.html`), but the code only checked `VITE_POSTHOG_KEY` so PostHog was incorrectly disabled and produced a warning.

### Description
- Update `js/posthog.js` to fall back to `window.__URSASS_POSTHOG_KEY__` when `VITE_POSTHOG_KEY` is not present and adjust the warning message to mention both sources.

### Testing
- Pre-commit automated checks (`npm run check:syntax` and `node scripts/check-static-analysis.mjs`) ran as part of the commit flow and passed. 
- An attempted `npm run build` in the environment failed due to an unrelated `Rollup failed to resolve import "posthog-js"` error, which is an environment/dependency issue and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f244b9d28c83208c5e47fb5275f41f)