### PR TITLE
Allow runtime PostHog key via window global and improve init logging

### DIFF
--- a/js/posthog.js
+++ b/js/posthog.js
@@ -69,12 +69,12 @@ function resetPostHogUser() {
 function initPostHog() {
   if (posthogInitialized || posthogReady) return;
 
-  const key = import.meta.env?.VITE_POSTHOG_KEY;
+  const key = import.meta.env?.VITE_POSTHOG_KEY || window?.__URSASS_POSTHOG_KEY__ || undefined;
   const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;
   const appEnv = import.meta.env?.VITE_APP_ENV || 'unknown';
 
   if (!key) {
-    logger.warn('⚠️ VITE_POSTHOG_KEY is missing. PostHog is disabled.');
+    logger.info('📊 PostHog disabled: no key configured. Set VITE_POSTHOG_KEY or window.__URSASS_POSTHOG_KEY__.');
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Allow configuring the PostHog key at runtime (e.g. injected into the page) and make the missing-key message less noisy.

### Description
- Update `initPostHog` to read `VITE_POSTHOG_KEY` from `import.meta.env` or fall back to `window.__URSASS_POSTHOG_KEY__` so the key can be provided at runtime.
- Change the missing-key log from `logger.warn` to `logger.info` with a clearer message about how to configure the key.
- Leave existing PostHog initialization behavior intact and still respect the optional host fallback and other init options.

### Testing
- Ran the project lint and test suite with `npm run lint` and `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f244b9d28c83208c5e47fb5275f41f)