### PR TITLE
Fix donation payload product identifiers for USDT checkout

### DIFF
--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -39,6 +39,22 @@ function isConfirmedSuccessResult(payload = null) {
   return ok === true && (isDonationSuccessStatus(status) || !status);
 }
 
+function resolveDonationProductPayload(product = null) {
+  if (!product || typeof product !== 'object') return { productKey: '' };
+  const productKey = String(
+    product.productKey
+    ?? product.key
+    ?? product.slug
+    ?? product.code
+    ?? ''
+  ).trim();
+  const productId = String(product.productId ?? product.id ?? '').trim();
+  return {
+    productKey,
+    ...(productId ? { productId } : {})
+  };
+}
+
 export function createDonationFlowActions({
   getDonationIdentifier,
   getTelegramWebApp,
@@ -452,7 +468,7 @@ export function createDonationFlowActions({
         return;
       }
 
-      const requestPayload = buildDonationRequestPayload({ productKey: product.key });
+      const requestPayload = buildDonationRequestPayload(resolveDonationProductPayload(product));
       if (!requestPayload) {
         donationPaymentState.error = 'Failed to prepare donation payment request';
         return;


### PR DESCRIPTION
### Motivation
- The USDT checkout create-payment flow could send a malformed product identifier when catalog entries used non-`key` fields (e.g. Basic Pack), which led to backend 500 errors.

### Description
- Added a helper `resolveDonationProductPayload` in `js/store/donation-flow.js` that derives a resilient `productKey` from `productKey`, `key`, `slug`, or `code` and includes `productId` when present.
- Replaced the previous hard-coded `{ productKey: product.key }` call with `buildDonationRequestPayload(resolveDonationProductPayload(product))` in `handleDonationBuy` to send normalized identifiers to the backend.
- This makes `createDonationPayment` requests robust for catalog records that don't expose `key` or use alternate identifier fields.

### Testing
- Ran focused Node tests: `node --test scripts/donation-service.test.mjs scripts/request.test.mjs`, all tests passed.
- Pre-commit checks including `check:syntax` and `check:static-analysis` passed during the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24dffe75c8320b42c5b8d1f343dc2)