### PR TITLE
Enforce Base wallet network and sticky wrong-network notifications

### DIFF
--- a/js/auth-wallet-connector.js
+++ b/js/auth-wallet-connector.js
@@ -1,5 +1,44 @@
 import { getInjectedEthereumProvider } from './ethereum-provider.js';
 import { WC } from './walletconnect.js';
+import { notifyError } from './notifier.js';
+
+const BASE_CHAIN_ID_HEX = '0x2105';
+const WRONG_NETWORK_TOAST_KEY = 'wrong-network-base';
+
+function showWrongNetworkToast() {
+  notifyError('❌ Wrong network: switch wallet to Base to continue.', {
+    sticky: true,
+    toastKey: WRONG_NETWORK_TOAST_KEY,
+  });
+}
+
+async function ensureBaseNetwork(provider) {
+  if (!provider?.request) return;
+
+  try {
+    const currentChainId = await provider.request({ method: 'eth_chainId' });
+    if (String(currentChainId || '').toLowerCase() === BASE_CHAIN_ID_HEX) return;
+
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: BASE_CHAIN_ID_HEX }],
+    });
+  } catch (error) {
+    showWrongNetworkToast();
+    throw new Error('Wrong network. Please switch wallet to Base (8453).');
+  }
+}
+
+function subscribeWrongNetworkListener(provider) {
+  if (!provider?.on || provider.__ursassBaseListenerAttached) return;
+
+  provider.on('chainChanged', (chainId) => {
+    if (String(chainId || '').toLowerCase() !== BASE_CHAIN_ID_HEX) {
+      showWrongNetworkToast();
+    }
+  });
+  provider.__ursassBaseListenerAttached = true;
+}
 
 async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
   let walletAddress;
@@ -8,8 +47,12 @@ async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
   const normalizedFlow = flow === 'link' ? 'link' : 'auth';
 
   if (getInjectedEthereumProvider()) {
-    const accounts = await getInjectedEthereumProvider().request({ method: 'eth_requestAccounts' });
+    const provider = getInjectedEthereumProvider();
+    const accounts = await provider.request({ method: 'eth_requestAccounts' });
     if (!accounts || accounts.length === 0) return null;
+
+    await ensureBaseNetwork(provider);
+    subscribeWrongNetworkListener(provider);
 
     walletAddress = accounts[0];
     const message = buildSigningMessage({
@@ -27,12 +70,15 @@ async function requestWalletSignature({ flow, primaryId = null, timestamp }) {
     return {
       walletAddress,
       signature,
-      provider: getInjectedEthereumProvider(),
+      provider,
     };
   }
 
   const connected = await WC.connect();
   if (!connected) return null;
+
+  await ensureBaseNetwork(WC.provider);
+  subscribeWrongNetworkListener(WC.provider);
 
   walletAddress = WC.accounts[0];
   const message = buildSigningMessage({

--- a/js/notifier.js
+++ b/js/notifier.js
@@ -1,5 +1,6 @@
 const TOAST_ROOT_ID = 'appToastRoot';
 const DEFAULT_DURATION_MS = 4200;
+const ACTIVE_TOAST_KEYS = new Set();
 
 function ensureToastRoot() {
   if (typeof document === 'undefined') return null;
@@ -19,6 +20,8 @@ function ensureToastRoot() {
 
 function dismissToast(toast) {
   if (!toast) return;
+  const toastKey = toast.getAttribute('data-toast-key');
+  if (toastKey) ACTIVE_TOAST_KEYS.delete(toastKey);
   toast.classList.add('toast--leaving');
   setTimeout(() => {
     toast.remove();
@@ -36,11 +39,19 @@ function notify(message, options = {}) {
     durationMs = DEFAULT_DURATION_MS,
     sticky = false,
     sub = null,
+    toastKey = '',
   } = options;
+
+  const normalizedToastKey = String(toastKey || '').trim();
+  if (normalizedToastKey && ACTIVE_TOAST_KEYS.has(normalizedToastKey)) return;
 
   const toast = document.createElement('div');
   const toastType = type === 'warn' ? 'error' : type;
   toast.className = `toast toast--${toastType}`;
+  if (normalizedToastKey) {
+    toast.setAttribute('data-toast-key', normalizedToastKey);
+    ACTIVE_TOAST_KEYS.add(normalizedToastKey);
+  }
   toast.textContent = String(message);
 
   if (sub) {

--- a/js/store/donation-helpers.js
+++ b/js/store/donation-helpers.js
@@ -1,8 +1,11 @@
 import { logger } from '../logger.js';
 import { getInjectedEthereumProvider } from '../ethereum-provider.js';
 import { WC } from '../walletconnect.js';
+import { notifyError } from '../notifier.js';
 
 const DONATION_PENDING_STORAGE_KEY = 'ursassDonationPendingPayments';
+const BASE_CHAIN_ID_HEX = '0x2105';
+const WRONG_NETWORK_TOAST_KEY = 'wrong-network-base';
 
 export function getDonationStarsPrice(product = null) {
   return product?.starsPrice
@@ -489,7 +492,7 @@ export function extractDonationTxRequest(paymentData = null) {
 }
 
 async function ensureDonationWalletChain(provider, txRequest) {
-  const requestedChainId = txRequest?.chainId;
+  const requestedChainId = txRequest?.chainId || BASE_CHAIN_ID_HEX;
   if (!provider?.request || !requestedChainId) return;
 
   let currentChainId = null;
@@ -508,6 +511,10 @@ async function ensureDonationWalletChain(provider, txRequest) {
       params: [{ chainId: requestedChainId }]
     });
   } catch (error) {
+    notifyError('❌ Wrong network: switch wallet to Base to continue.', {
+      sticky: true,
+      toastKey: WRONG_NETWORK_TOAST_KEY
+    });
     throw new Error(`Switch wallet network to ${requestedChainId} and retry. ${error?.message || error}`);
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure wallet interactions use the Base network (chainId `0x2105` / 8453) so payments and signatures operate on the expected chain. 
- Provide a persistent UI indication when the user is on the wrong network so they cannot miss network-related failures during connect or payments. 
- Prevent spammy duplicate persistent toasts when the wrong-network notification is triggered multiple times.

### Description

- Added `BASE_CHAIN_ID_HEX`, `ensureBaseNetwork(provider)` and `subscribeWrongNetworkListener(provider)` to `js/auth-wallet-connector.js` and enforce Base during injected and WalletConnect connects. 
- Subscribed to provider `chainChanged` to show a sticky wrong-network toast when the user switches away from Base in-session. 
- Updated `js/store/donation-helpers.js` to default donation flow chain checks to Base, show the same sticky wrong-network toast on `wallet_switchEthereumChain` failure, and use Base when backend omits `chainId`. 
- Extended `js/notifier.js` with a `toastKey` option and `ACTIVE_TOAST_KEYS` deduplication so persistent wrong-network toasts are not duplicated and can only be dismissed explicitly.

### Testing

- Ran `npm run check:syntax` and the syntax checks completed successfully. 
- Pre-commit checks (which include static analysis) ran as part of the commit and passed (`check:static-analysis` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26873cbe88320ab13d33bc5a0bccb)