### PR TITLE
Restrict donation panel width and force single-column donation cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2388,7 +2388,8 @@ footer a:hover { color: #e0b0ff; }
 .store-panel[hidden] { display: none !important; }
 
 .store-donation-shell {
-  max-width: 1040px;
+  width: 100%;
+  max-width: 440px;
   margin: 0 auto;
   display: grid;
   gap: 16px;
@@ -2408,7 +2409,7 @@ footer a:hover { color: #e0b0ff; }
 
 .store-donation-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(560px, 100%), 1fr));
+  grid-template-columns: 1fr;
   gap: 14px;
 }
 


### PR DESCRIPTION
### Motivation
- Improve the donation area layout and responsiveness by constraining the container width and ensuring donation cards stack vertically.

### Description
- Update ` .store-donation-shell` to `width: 100%` with `max-width: 440px` (replacing the previous `max-width: 1040px`) and change `.store-donation-grid` `grid-template-columns` from `repeat(auto-fit, minmax(min(560px, 100%), 1fr))` to `1fr` so donation cards render as a single column.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26b173ae483209dac1901ca3e8b6b)