### PR TITLE
Replace noop PostHog client with lightweight fetch-based implementation

### DIFF
--- a/vendor/posthog-js/index.js
+++ b/vendor/posthog-js/index.js
@@ -1,10 +1,108 @@
-const noop = () => {};
+const DEFAULT_API_HOST = 'https://eu.i.posthog.com';
+const EVENT_ENDPOINT_PATH = '/e/';
+
+let state = {
+  apiKey: '',
+  apiHost: DEFAULT_API_HOST,
+  distinctId: null,
+  superProperties: {},
+};
+
+function safeUuid() {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (_) {
+    // ignore
+  }
+
+  return `anon_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+function normalizeHost(host) {
+  const value = String(host || '').trim();
+  if (!value) return DEFAULT_API_HOST;
+  return value.replace(/\/$/, '');
+}
+
+function ensureDistinctId() {
+  if (!state.distinctId) {
+    state.distinctId = safeUuid();
+  }
+  return state.distinctId;
+}
+
+function send(body) {
+  if (!state.apiKey || typeof fetch !== 'function') return;
+
+  const url = `${state.apiHost}${EVENT_ENDPOINT_PATH}`;
+  const payload = {
+    api_key: state.apiKey,
+    ...body,
+  };
+
+  try {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+      credentials: 'omit',
+      mode: 'cors',
+    }).catch(() => {});
+  } catch (_) {
+    // ignore transport failures
+  }
+}
 
 const posthog = {
-  init: noop,
-  capture: noop,
-  identify: noop,
-  reset: noop,
+  init(apiKey, config = {}) {
+    state = {
+      ...state,
+      apiKey: String(apiKey || '').trim(),
+      apiHost: normalizeHost(config?.api_host || DEFAULT_API_HOST),
+    };
+    ensureDistinctId();
+  },
+
+  capture(event, properties = {}) {
+    const eventName = String(event || '').trim();
+    if (!eventName) return;
+
+    send({
+      event: eventName,
+      distinct_id: ensureDistinctId(),
+      properties: {
+        ...state.superProperties,
+        ...(properties && typeof properties === 'object' ? properties : {}),
+      },
+      timestamp: new Date().toISOString(),
+    });
+  },
+
+  identify(id, setProperties = {}) {
+    const distinctId = String(id || '').trim();
+    if (!distinctId) return;
+    state.distinctId = distinctId;
+
+    const personProperties = setProperties && typeof setProperties === 'object' ? setProperties : {};
+    if (Object.keys(personProperties).length > 0) {
+      send({
+        event: '$identify',
+        distinct_id: distinctId,
+        properties: {
+          $set: personProperties,
+        },
+        timestamp: new Date().toISOString(),
+      });
+    }
+  },
+
+  reset() {
+    state.distinctId = safeUuid();
+    state.superProperties = {};
+  },
 };
 
 export default posthog;


### PR DESCRIPTION
### Motivation
- The vendored `posthog-js` was a noop stub and therefore client-side captures (including `app_opened`) were never sent to PostHog, making those events invisible in analytics. 

### Description
- Replaced `vendor/posthog-js/index.js` with a lightweight client implementing `init`, `capture`, `identify`, and `reset` that sends events to the PostHog `/e/` endpoint via `fetch`. 
- Added `distinct_id` generation, `api_host` normalization, and preservation of `properties` and `timestamp` in the outgoing payload. 
- Made transport best-effort by using `keepalive` and swallowing network/feature errors so the client does not throw when `fetch` is unavailable, while keeping the existing app integration contract unchanged. 

### Testing
- Ran the automated test command `node --test scripts/analytics.test.mjs scripts/analytics-delivery.test.mjs`. 
- All tests passed (6 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26ec57a388320b537ef880a23bd25)