### PR TITLE
Implement lightweight PostHog client in vendor/posthog-js

### DIFF
--- a/vendor/posthog-js/index.js
+++ b/vendor/posthog-js/index.js
@@ -1,10 +1,114 @@
-const noop = () => {};
+const DEFAULT_API_HOST = 'https://eu.i.posthog.com';
+const EVENT_ENDPOINT_PATH = '/capture/';
+
+let state = {
+  apiKey: '',
+  apiHost: DEFAULT_API_HOST,
+  distinctId: null,
+  superProperties: {},
+};
+
+function safeUuid() {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (_) {
+    // ignore
+  }
+
+  return `anon_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+function normalizeHost(host) {
+  const value = String(host || '').trim();
+  if (!value) return DEFAULT_API_HOST;
+  return value.replace(/\/$/, '');
+}
+
+function ensureDistinctId() {
+  if (!state.distinctId) {
+    state.distinctId = safeUuid();
+  }
+  return state.distinctId;
+}
+
+function send(body) {
+  if (!state.apiKey || typeof fetch !== 'function') return;
+
+  const url = `${state.apiHost}${EVENT_ENDPOINT_PATH}`;
+  const payload = {
+    api_key: state.apiKey,
+    ...body,
+  };
+
+  try {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+      credentials: 'omit',
+      mode: 'cors',
+    }).catch(() => {});
+  } catch (_) {
+    // ignore transport failures
+  }
+}
 
 const posthog = {
-  init: noop,
-  capture: noop,
-  identify: noop,
-  reset: noop,
+  init(apiKey, config = {}) {
+    state = {
+      ...state,
+      apiKey: String(apiKey || '').trim(),
+      apiHost: normalizeHost(config?.api_host || DEFAULT_API_HOST),
+    };
+    ensureDistinctId();
+  },
+
+  capture(event, properties = {}) {
+    const eventName = String(event || '').trim();
+    if (!eventName) return;
+
+    send({
+      event: eventName,
+      distinct_id: ensureDistinctId(),
+      properties: {
+        token: state.apiKey,
+        distinct_id: ensureDistinctId(),
+        $lib: 'posthog-js-lite',
+        ...state.superProperties,
+        ...(properties && typeof properties === 'object' ? properties : {}),
+      },
+      timestamp: new Date().toISOString(),
+    });
+  },
+
+  identify(id, setProperties = {}) {
+    const distinctId = String(id || '').trim();
+    if (!distinctId) return;
+    state.distinctId = distinctId;
+
+    const personProperties = setProperties && typeof setProperties === 'object' ? setProperties : {};
+    if (Object.keys(personProperties).length > 0) {
+      send({
+        event: '$identify',
+        distinct_id: distinctId,
+        properties: {
+          token: state.apiKey,
+          distinct_id: distinctId,
+          $set: personProperties,
+          $lib: 'posthog-js-lite',
+        },
+        timestamp: new Date().toISOString(),
+      });
+    }
+  },
+
+  reset() {
+    state.distinctId = safeUuid();
+    state.superProperties = {};
+  },
 };
 
 export default posthog;


### PR DESCRIPTION
### Motivation
- Replace noop stubs with a minimal working PostHog client to send events from the vendor bundle and manage a local client state.

### Description
- Add persistent `state` and constants `DEFAULT_API_HOST` and `EVENT_ENDPOINT_PATH` to configure API host and endpoint.
- Introduce `safeUuid`, `normalizeHost`, and `ensureDistinctId` helpers to generate and manage distinct IDs robustly.
- Implement `send` using `fetch` to POST event payloads to `apiHost + EVENT_ENDPOINT_PATH` with JSON bodies and safe error handling.
- Implement `init`, `capture`, `identify`, and `reset` methods that assemble payloads, include `superProperties`, and send `$identify` or event captures as appropriate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f26ec57a388320b537ef880a23bd25)