### PR TITLE
Forward donation analytics events directly to PostHog to avoid drops

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,6 +1,11 @@
 import { logger } from './logger.js';
 
 const ANALYTICS_TRACK_EVENT = 'ursas:analytics-track';
+const DIRECT_POSTHOG_EVENTS = new Set([
+  'donation_started',
+  'donation_success',
+  'donation_failed'
+]);
 
 function sanitizeAnalyticsPayload(payload = {}) {
   if (!payload || typeof payload !== 'object') return {};
@@ -13,12 +18,23 @@ function trackAnalyticsEvent(name, payload = {}) {
   const event = {
     name: String(name || '').trim(),
     payload: sanitizeAnalyticsPayload(payload),
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    forwardedToPostHog: false
   };
 
   if (!event.name) return null;
 
   logger.info('📊 Analytics event:', event);
+
+  if (DIRECT_POSTHOG_EVENTS.has(event.name)) {
+    if (typeof window !== 'undefined') {
+      const captureFn = window.__URSASS_POSTHOG__?.capturePostHogEvent;
+      if (typeof captureFn === 'function') {
+        captureFn(event.name, event.payload);
+        event.forwardedToPostHog = true;
+      }
+    }
+  }
 
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
     window.dispatchEvent(new CustomEvent(ANALYTICS_TRACK_EVENT, { detail: event }));

--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -57,6 +57,7 @@ function setupPostHogBridge() {
     const payload = analyticsEvent?.payload && typeof analyticsEvent.payload === 'object'
       ? analyticsEvent.payload
       : {};
+    const forwardedToPostHog = analyticsEvent?.forwardedToPostHog === true;
 
     if (eventName === 'game_start') {
       const normalizedPayload = normalizeGameStartPayload(payload);
@@ -73,7 +74,7 @@ function setupPostHogBridge() {
       return;
     }
 
-    if (!POSTHOG_EVENT_ALLOWLIST.has(eventName)) return;
+    if (!POSTHOG_EVENT_ALLOWLIST.has(eventName) || forwardedToPostHog) return;
 
     capturePostHogEvent(eventName, payload);
   });


### PR DESCRIPTION
### Motivation
- Donation events (`donation_started`, `donation_success`) were sometimes missing in PostHog due to bridge/listener timing, preventing reliable charting and dashboards.

### Description
- Forward critical donation events (`donation_started`, `donation_success`, `donation_failed`) directly to PostHog from `trackAnalyticsEvent` in `js/analytics.js` using `window.__URSASS_POSTHOG__.capturePostHogEvent`.
- Add a `forwardedToPostHog` boolean marker on analytics events so receivers can detect events that were already forwarded.
- Update `js/posthog-bridge.js` to ignore events that are already forwarded and to continue respecting the existing allowlist to avoid duplicates.
- Changes are limited to `js/analytics.js` and `js/posthog-bridge.js`.

### Testing
- Ran `node scripts/analytics.test.mjs`, which passed (2 tests: sanitization and event dispatch behavior).
- Verified no runtime errors when dispatching donation events locally by exercising `trackAnalyticsEvent` in the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f277c939708320a8764ecab27c17a2)