### PR TITLE
Add payload for automatic `second_run_started` event when run_number is 2

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -41,7 +41,9 @@ export const analytics = {
     };
     trackAnalyticsEvent('run_started', payload);
     if (runNumber === 2) {
-      trackAnalyticsEvent('second_run_started');
+      trackAnalyticsEvent('second_run_started', {
+        run_number: 2,
+      });
     }
     trackAnalyticsEvent('game_start', {
       authenticated: Boolean(params.isAuthorized),


### PR DESCRIPTION
### Motivation
- Ensure the automatically emitted `second_run_started` event includes a structured payload so downstream consumers can detect the second run without guessing when `run_number === 2`.

### Description
- Updated `js/analytics-events.js` so `analytics.runStarted` calls `trackAnalyticsEvent('second_run_started', { run_number: 2 })` when `runNumber === 2`, keeping the existing `run_started` and `game_start` logic unchanged.

### Testing
- Ran `node --test scripts/analytics.test.mjs` and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27e5ba1908320b34b553481d8743c)