### PR TITLE
Forward select analytics events directly to PostHog and add sendBeacon transport fallback

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,6 +1,11 @@
 import { logger } from './logger.js';
 
 const ANALYTICS_TRACK_EVENT = 'ursas:analytics-track';
+const DIRECT_POSTHOG_EVENTS = new Set([
+  'donation_started',
+  'donation_success',
+  'donation_failed'
+]);
 
 function sanitizeAnalyticsPayload(payload = {}) {
   if (!payload || typeof payload !== 'object') return {};
@@ -13,12 +18,23 @@ function trackAnalyticsEvent(name, payload = {}) {
   const event = {
     name: String(name || '').trim(),
     payload: sanitizeAnalyticsPayload(payload),
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    forwardedToPostHog: false
   };
 
   if (!event.name) return null;
 
   logger.info('📊 Analytics event:', event);
+
+  if (DIRECT_POSTHOG_EVENTS.has(event.name)) {
+    if (typeof window !== 'undefined') {
+      const captureFn = window.__URSASS_POSTHOG__?.capturePostHogEvent;
+      if (typeof captureFn === 'function') {
+        captureFn(event.name, event.payload);
+        event.forwardedToPostHog = true;
+      }
+    }
+  }
 
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
     window.dispatchEvent(new CustomEvent(ANALYTICS_TRACK_EVENT, { detail: event }));

--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -57,6 +57,7 @@ function setupPostHogBridge() {
     const payload = analyticsEvent?.payload && typeof analyticsEvent.payload === 'object'
       ? analyticsEvent.payload
       : {};
+    const forwardedToPostHog = analyticsEvent?.forwardedToPostHog === true;
 
     if (eventName === 'game_start') {
       const normalizedPayload = normalizeGameStartPayload(payload);
@@ -73,7 +74,7 @@ function setupPostHogBridge() {
       return;
     }
 
-    if (!POSTHOG_EVENT_ALLOWLIST.has(eventName)) return;
+    if (!POSTHOG_EVENT_ALLOWLIST.has(eventName) || forwardedToPostHog) return;
 
     capturePostHogEvent(eventName, payload);
   });

--- a/vendor/posthog-js/index.js
+++ b/vendor/posthog-js/index.js
@@ -43,10 +43,17 @@ function send(body) {
   };
 
   try {
+    const serialized = JSON.stringify(payload);
+    const canUseBeacon = typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function';
+    if (canUseBeacon) {
+      const sentViaBeacon = navigator.sendBeacon(url, new Blob([serialized], { type: 'application/json' }));
+      if (sentViaBeacon) return;
+    }
+
     fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: serialized,
       keepalive: true,
       credentials: 'omit',
       mode: 'cors',


### PR DESCRIPTION
### Motivation

- Ensure select high-priority events (donation lifecycle) can be forwarded immediately to PostHog when a direct PostHog bridge is available to reduce duplication and latency.
- Prevent duplicate delivery by marking events that were forwarded so the global bridge does not resend them.
- Improve event delivery reliability from the embedded PostHog client by attempting `navigator.sendBeacon` before falling back to `fetch`.

### Description

- Added a `DIRECT_POSTHOG_EVENTS` set for `donation_started`, `donation_success`, and `donation_failed` and updated `trackAnalyticsEvent` to call `window.__URSASS_POSTHOG__?.capturePostHogEvent` for those events and set a `forwardedToPostHog` flag on the event object.
- Updated the analytics bridge in `setupPostHogBridge` to skip sending events to PostHog when `analyticsEvent.forwardedToPostHog === true` to avoid double-reporting.
- Enhanced the embedded PostHog client in `vendor/posthog-js/index.js` to serialize the payload once, try `navigator.sendBeacon` with a `Blob` payload, and fall back to `fetch` using the same serialized body.
- Preserved existing sanitization and dispatch logic by keeping `sanitizeAnalyticsPayload`, event logging via `logger.info`, and dispatching the `ANALYTICS_TRACK_EVENT` custom event.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f277c939708320a8764ecab27c17a2)