### PR TITLE
Include payload for second_run_started and forward it via PostHog allowlist

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -41,7 +41,9 @@ export const analytics = {
     };
     trackAnalyticsEvent('run_started', payload);
     if (runNumber === 2) {
-      trackAnalyticsEvent('second_run_started');
+      trackAnalyticsEvent('second_run_started', {
+        run_number: 2,
+      });
     }
     trackAnalyticsEvent('game_start', {
       authenticated: Boolean(params.isAuthorized),

--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -14,7 +14,8 @@ const POSTHOG_EVENT_ALLOWLIST = new Set([
   'leaderboard_opened',
   'donation_started',
   'donation_success',
-  'donation_failed'
+  'donation_failed',
+  'second_run_started'
 ]);
 
 
@@ -63,9 +64,6 @@ function setupPostHogBridge() {
       const normalizedPayload = normalizeGameStartPayload(payload);
       capturePostHogEvent('run_started', normalizedPayload);
 
-      if (normalizedPayload.run_number === 2) {
-        capturePostHogEvent('second_run_started', normalizedPayload);
-      }
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the `second_run_started` event carries an explicit `run_number` payload so downstream consumers have deterministic data.
- Route `second_run_started` through the existing PostHog bridge allowlist instead of a special-case emission during `game_start` handling to keep event forwarding consistent.

### Description
- In `js/analytics-events.js` add a payload `{ run_number: 2 }` when emitting the `second_run_started` event.
- In `js/posthog-bridge.js` add `'second_run_started'` to `POSTHOG_EVENT_ALLOWLIST` so the bridge forwards it normally.
- Remove the special-case capture of `second_run_started` inside the `game_start` branch so the allowlisted event path is used instead.

### Testing
- Ran the existing automated unit test suite and linters locally and they completed successfully.
- Verified event forwarding behavior via the updated allowlist through the bridge in automated tests with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27e5ba1908320b34b553481d8743c)