### PR TITLE
Integrate PostHog for donation analytics and improve PostHog transport

### DIFF
--- a/js/store/donation-controller.js
+++ b/js/store/donation-controller.js
@@ -18,11 +18,17 @@ import {
 } from './donation-helpers.js';
 import { createDonationFlowActions } from './donation-flow.js';
 import { trackAnalyticsEvent } from '../analytics.js';
+import { capturePostHogEvent } from '../posthog.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';
 const DONATION_REFRESH_COOLDOWN_MS = 60 * 1000;
 const DONATION_PENDING_TIMEOUT_MS = 30 * 60 * 1000;
+
+function trackDonationAnalyticsEvent(name, payload = {}) {
+  trackAnalyticsEvent(name, payload);
+  capturePostHogEvent(name, payload);
+}
 
 export function createDonationController({
   loadPlayerUpgrades,
@@ -361,7 +367,7 @@ export function createDonationController({
         const paymentId = String(data?.paymentId || data?.orderId || '').trim();
         if (paymentId && !donationSuccessTrackedIds.has(paymentId)) {
           donationSuccessTrackedIds.add(paymentId);
-          trackAnalyticsEvent('donation_success', {
+          trackDonationAnalyticsEvent('donation_success', {
             amount_usd: Number(data?.amount || donationPaymentState?.payment?.amount || 0),
             currency: String(data?.currency || donationPaymentState?.payment?.currency || (isTelegramStarsPayment(data) ? 'STARS' : 'USDT')).toUpperCase(),
             source: 'history_refresh',

--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -21,6 +21,7 @@ import {
   invokeDonationWallet
 } from './donation-helpers.js';
 import { trackAnalyticsEvent } from '../analytics.js';
+import { capturePostHogEvent } from '../posthog.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';
@@ -37,6 +38,11 @@ function normalizeDonationResultMeta(payload = null) {
 function isConfirmedSuccessResult(payload = null) {
   const { ok, status } = normalizeDonationResultMeta(payload);
   return ok === true && (isDonationSuccessStatus(status) || !status);
+}
+
+function trackDonationEvent(name, payload) {
+  trackAnalyticsEvent(name, payload);
+  capturePostHogEvent(name, payload);
 }
 
 function resolveDonationProductPayload(product = null) {
@@ -98,7 +104,7 @@ export function createDonationFlowActions({
         reward: null
       };
       donationPaymentState.error = errorMessage || 'Telegram Stars payment was not completed.';
-      trackAnalyticsEvent('donation_failed', {
+      trackDonationEvent('donation_failed', {
         amount_usd: Number(paymentData?.amount || donationPaymentState?.payment?.amount || 0),
         currency: 'STARS',
         source: 'game_modal',
@@ -195,7 +201,7 @@ export function createDonationFlowActions({
 
       // Analytics donation_success must only be emitted after paid/credited status.
       if (isConfirmedSuccessResult(refreshed) || isDonationSuccessStatus(finalStatus)) {
-        trackAnalyticsEvent('donation_success', {
+        trackDonationEvent('donation_success', {
           amount_usd: Number(refreshed?.amount || paymentData?.amount || donationPaymentState?.payment?.amount || 0),
           currency: 'STARS',
           source: 'game_modal',
@@ -208,7 +214,7 @@ export function createDonationFlowActions({
         updateStoreUI();
         await loadDonationHistory({ silent: true });
       } else if (finalStatus === 'failed' || finalStatus === 'expired') {
-        trackAnalyticsEvent('donation_failed', {
+        trackDonationEvent('donation_failed', {
           amount_usd: Number(refreshed?.amount || paymentData?.amount || donationPaymentState?.payment?.amount || 0),
           currency: 'STARS',
           source: 'game_modal',
@@ -439,11 +445,25 @@ export function createDonationFlowActions({
   async function handleDonationBuy(product) {
     if (!product || donationPaymentState.isCreating) return;
 
-    const identifier = getDonationIdentifier();
     const useTelegramStars = canUseTelegramStarsFlow();
+    trackDonationEvent('donation_started', {
+      amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
+      currency: String(product?.currency || (useTelegramStars ? 'STARS' : 'USDT')),
+      source: 'game_modal',
+      payment_method: useTelegramStars ? 'telegram_stars' : 'wallet'
+    });
+
+    const identifier = getDonationIdentifier();
 
     if (!identifier) {
       showToast(useTelegramStars ? 'Telegram session not found' : 'Connect wallet first', 'error');
+      trackDonationEvent('donation_failed', {
+        amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
+        currency: String(product?.currency || (useTelegramStars ? 'STARS' : 'USDT')),
+        source: 'game_modal',
+        payment_method: useTelegramStars ? 'telegram_stars' : 'wallet',
+        reason: useTelegramStars ? 'telegram_session_missing' : 'wallet_missing'
+      });
       return;
     }
 
@@ -457,12 +477,6 @@ export function createDonationFlowActions({
     renderDonationPaymentModal();
 
     try {
-      trackAnalyticsEvent('donation_started', {
-        amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
-        currency: String(product?.currency || (useTelegramStars ? 'STARS' : 'USDT')),
-        source: 'game_modal',
-        payment_method: useTelegramStars ? 'telegram_stars' : 'wallet'
-      });
       if (useTelegramStars) {
         await handleTelegramDonationBuy(product);
         return;
@@ -525,7 +539,7 @@ export function createDonationFlowActions({
         const finalStatus = String(donationPaymentState?.status?.status || '').toLowerCase();
         // Analytics donation_success must only be emitted after paid/credited status.
         if (isConfirmedSuccessResult(donationPaymentState?.status) || isDonationSuccessStatus(finalStatus)) {
-          trackAnalyticsEvent('donation_success', {
+          trackDonationEvent('donation_success', {
             amount_usd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
             currency: 'USDT',
             source: 'game_modal',
@@ -538,7 +552,7 @@ export function createDonationFlowActions({
         donationPaymentState.walletError = rejected
           ? 'Transaction was rejected in your wallet. Retry when you are ready.'
           : `Wallet transaction failed: ${message}`;
-        trackAnalyticsEvent('donation_failed', {
+        trackDonationEvent('donation_failed', {
           amount_usd: Number(donationPaymentState?.payment?.amount || product?.priceUsd || 0),
           currency: String(donationPaymentState?.payment?.currency || product?.currency || 'USDT'),
           source: 'game_modal',
@@ -555,7 +569,7 @@ export function createDonationFlowActions({
       donationPaymentState.error = useTelegramStars
         ? 'Failed to start Telegram Stars payment'
         : 'Failed to create payment';
-      trackAnalyticsEvent('donation_failed', {
+      trackDonationEvent('donation_failed', {
         amount_usd: Number(product?.priceUsd || product?.amountUsd || product?.amount || 0),
         currency: String(product?.currency || (useTelegramStars ? 'STARS' : 'USDT')),
         source: 'game_modal',

--- a/vendor/posthog-js/index.js
+++ b/vendor/posthog-js/index.js
@@ -43,10 +43,17 @@ function send(body) {
   };
 
   try {
+    const serialized = JSON.stringify(payload);
+    const canUseBeacon = typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function';
+    if (canUseBeacon) {
+      const sentViaBeacon = navigator.sendBeacon(url, new Blob([serialized], { type: 'application/json' }));
+      if (sentViaBeacon) return;
+    }
+
     fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: serialized,
       keepalive: true,
       credentials: 'omit',
       mode: 'cors',


### PR DESCRIPTION
### Motivation
- Send donation analytics to PostHog in addition to the existing analytics pipeline and make the PostHog client transport more reliable in browsers.

### Description
- Add `capturePostHogEvent` usage and introduce `trackDonationAnalyticsEvent` / `trackDonationEvent` wrappers that call both `trackAnalyticsEvent` and `capturePostHogEvent`.
- Replace direct `trackAnalyticsEvent` calls in `js/store/donation-controller.js` and `js/store/donation-flow.js` with the new wrappers and add extra events (e.g. `donation_started` and `donation_failed` when a donation identifier is missing).
- Improve `vendor/posthog-js/index.js` transport by pre-serializing payloads, attempting `navigator.sendBeacon` when available, and falling back to `fetch` with a stable `body` value.

### Testing
- Ran the test suite with `npm test` and the tests completed successfully.
- Ran linting with `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f277c939708320a8764ecab27c17a2)