### PR TITLE
Send `second_run_started` with payload and forward to PostHog

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -41,7 +41,9 @@ export const analytics = {
     };
     trackAnalyticsEvent('run_started', payload);
     if (runNumber === 2) {
-      trackAnalyticsEvent('second_run_started');
+      trackAnalyticsEvent('second_run_started', {
+        run_number: 2,
+      });
     }
     trackAnalyticsEvent('game_start', {
       authenticated: Boolean(params.isAuthorized),

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -4,7 +4,8 @@ const ANALYTICS_TRACK_EVENT = 'ursas:analytics-track';
 const DIRECT_POSTHOG_EVENTS = new Set([
   'donation_started',
   'donation_success',
-  'donation_failed'
+  'donation_failed',
+  'second_run_started'
 ]);
 
 function sanitizeAnalyticsPayload(payload = {}) {

--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -14,7 +14,8 @@ const POSTHOG_EVENT_ALLOWLIST = new Set([
   'leaderboard_opened',
   'donation_started',
   'donation_success',
-  'donation_failed'
+  'donation_failed',
+  'second_run_started'
 ]);
 
 
@@ -63,9 +64,6 @@ function setupPostHogBridge() {
       const normalizedPayload = normalizeGameStartPayload(payload);
       capturePostHogEvent('run_started', normalizedPayload);
 
-      if (normalizedPayload.run_number === 2) {
-        capturePostHogEvent('second_run_started', normalizedPayload);
-      }
       return;
     }
 


### PR DESCRIPTION
### Motivation

- Ensure the `second_run_started` event includes the `run_number` payload and is forwarded to PostHog consistently instead of relying on a special-case bridge emission.

### Description

- Add a `run_number: 2` payload when emitting `second_run_started` in `js/analytics-events.js` by calling `trackAnalyticsEvent('second_run_started', { run_number: 2 })`.
- Register `'second_run_started'` in the `DIRECT_POSTHOG_EVENTS` set in `js/analytics.js` so it is forwarded directly when emitted from the app.
- Add `'second_run_started'` to the `POSTHOG_EVENT_ALLOWLIST` in `js/posthog-bridge.js` and remove the bridge's special-case capture of `second_run_started` on `game_start`, relying on the standalone event instead.
- Minor formatting adjustments to keep allowlists consistent.

### Testing

- Ran the project test suite with `npm test` and the tests completed successfully. 
- Performed an analytics bridge smoke test by dispatching `ANALYTICS_TRACK_EVENT` payloads for `game_start` and `second_run_started` and confirmed `capturePostHogEvent` was invoked for the `second_run_started` event; the smoke test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27e5ba1908320b34b553481d8743c)