### PR TITLE
Add PostHog runtime kill switch for FPS diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ See [`docs/player-menu-smoke.md`](docs/player-menu-smoke.md) for full manual smo
 <script>
   window.__URSASS_POSTHOG_KEY__ = 'phc_xxx';
   window.__URSASS_POSTHOG_HOST__ = 'https://eu.i.posthog.com';
+  window.__URSASS_POSTHOG_ENABLED__ = true; // переключатель для hotfix/perf-debug
 </script>
 ```
 
 Если `window.__URSASS_POSTHOG_KEY__` не задан, интеграция автоматически выключена.
+Для быстрого perf-диагноза можно полностью отключить PostHog флагом `window.__URSASS_POSTHOG_ENABLED__ = false` или `VITE_POSTHOG_ENABLED=false`.

--- a/js/posthog.js
+++ b/js/posthog.js
@@ -6,6 +6,23 @@ let posthogInitialized = false;
 const POSTHOG_PREINIT_QUEUE_LIMIT = 20;
 const posthogPreinitQueue = [];
 
+function isPostHogEnabled() {
+  const envFlag = import.meta.env?.VITE_POSTHOG_ENABLED;
+  if (typeof envFlag === 'string') {
+    const normalized = envFlag.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
+  }
+
+  const runtimeFlag = window?.__URSASS_POSTHOG_ENABLED__;
+  if (typeof runtimeFlag === 'boolean') return runtimeFlag;
+  if (typeof runtimeFlag === 'string') {
+    const normalized = runtimeFlag.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
+  }
+
+  return true;
+}
+
 function getTelegramContext() {
   try {
     const tg = window?.Telegram?.WebApp;
@@ -80,6 +97,10 @@ function resetPostHogUser() {
 
 function initPostHog() {
   if (posthogInitialized || posthogReady) return;
+  if (!isPostHogEnabled()) {
+    logger.info('📊 PostHog disabled by config (VITE_POSTHOG_ENABLED / window.__URSASS_POSTHOG_ENABLED__).');
+    return;
+  }
 
   const key = import.meta.env?.VITE_POSTHOG_KEY || window?.__URSASS_POSTHOG_KEY__ || '';
   const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;


### PR DESCRIPTION
### Motivation
- Provide a zero-deploy toggle to quickly isolate whether PostHog integration contributes to runtime FPS regressions during perf debugging.
- Allow operators to disable all PostHog initialization/traffic without rebuilding the frontend for quick A/B diagnosis.
- Keep existing safeguards (e.g., `disable_session_recording`) intact while adding an explicit runtime switch.

### Description
- Added `isPostHogEnabled()` helper to `js/posthog.js` to read `VITE_POSTHOG_ENABLED` and `window.__URSASS_POSTHOG_ENABLED__` runtime flags.
- `initPostHog()` now early-returns when PostHog is disabled by the new flag, preventing initialization and event delivery.
- Documented the runtime toggle in `README.md` and showed how to set `window.__URSASS_POSTHOG_ENABLED__ = false` or `VITE_POSTHOG_ENABLED=false` for perf-debug.

### Testing
- Ran the full test suite with `npm run -s test:request` which completed successfully.
- All automated tests passed (`82` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f288b232388320a3dacd094a10b957)