### PR TITLE
Detect 30fps cap, add Phaser FPS config, and add PostHog enable flag (README + runtime + perf + posthog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ See [`docs/player-menu-smoke.md`](docs/player-menu-smoke.md) for full manual smo
 <script>
   window.__URSASS_POSTHOG_KEY__ = 'phc_xxx';
   window.__URSASS_POSTHOG_HOST__ = 'https://eu.i.posthog.com';
+  window.__URSASS_POSTHOG_ENABLED__ = true; // переключатель для hotfix/perf-debug
 </script>
 ```
 
 Если `window.__URSASS_POSTHOG_KEY__` не задан, интеграция автоматически выключена.
+Для быстрого perf-диагноза можно полностью отключить PostHog флагом `window.__URSASS_POSTHOG_ENABLED__ = false` или `VITE_POSTHOG_ENABLED=false`.

--- a/js/perf.js
+++ b/js/perf.js
@@ -26,6 +26,7 @@ class PerformanceMonitor {
     this.lastPingTime = 0;
     this.currentPing = 0;
     this.qualityCooldown = 0;
+    this.thirtyFpsCapStreak = 0;
   }
 
   updateFPS() {
@@ -41,10 +42,20 @@ class PerformanceMonitor {
       this.lastTime = now;
       this.updateFpsUI();
       this.updateAdaptiveQuality();
+      this.detectPossibleFpsCap();
       this.publishPerfSample();
     }
 
     this.frameCount++;
+  }
+
+  detectPossibleFpsCap() {
+    const frameMs = Number(gameState?.debugStats?.frameMs) || 0;
+    const looksLikeThirtyCap = this.fps >= 28 && this.fps <= 32 && frameMs > 0 && frameMs < 22;
+    this.thirtyFpsCapStreak = looksLikeThirtyCap ? this.thirtyFpsCapStreak + 1 : 0;
+    if (this.thirtyFpsCapStreak === 5) {
+      logger.warn('⚠️ FPS appears capped around 30 by environment/VSync (WebView power mode, background throttling, or display limit).');
+    }
   }
 
   updateAdaptiveQuality() {

--- a/js/phaser/runtime.js
+++ b/js/phaser/runtime.js
@@ -32,6 +32,12 @@ async function createPhaserRuntime({ parent, snapshot, width, height, resolution
       zoom: 1
     },
     resolution,
+    fps: {
+      target: 60,
+      min: 30,
+      forceSetTimeOut: false,
+      smoothStep: true
+    },
     scene: [MainScene],
     callbacks: {
       postBoot(game) {

--- a/js/posthog.js
+++ b/js/posthog.js
@@ -6,6 +6,23 @@ let posthogInitialized = false;
 const POSTHOG_PREINIT_QUEUE_LIMIT = 20;
 const posthogPreinitQueue = [];
 
+function isPostHogEnabled() {
+  const envFlag = import.meta.env?.VITE_POSTHOG_ENABLED;
+  if (typeof envFlag === 'string') {
+    const normalized = envFlag.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
+  }
+
+  const runtimeFlag = window?.__URSASS_POSTHOG_ENABLED__;
+  if (typeof runtimeFlag === 'boolean') return runtimeFlag;
+  if (typeof runtimeFlag === 'string') {
+    const normalized = runtimeFlag.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0' || normalized === 'off') return false;
+  }
+
+  return true;
+}
+
 function getTelegramContext() {
   try {
     const tg = window?.Telegram?.WebApp;
@@ -80,6 +97,10 @@ function resetPostHogUser() {
 
 function initPostHog() {
   if (posthogInitialized || posthogReady) return;
+  if (!isPostHogEnabled()) {
+    logger.info('📊 PostHog disabled by config (VITE_POSTHOG_ENABLED / window.__URSASS_POSTHOG_ENABLED__).');
+    return;
+  }
 
   const key = import.meta.env?.VITE_POSTHOG_KEY || window?.__URSASS_POSTHOG_KEY__ || '';
   const host = import.meta.env?.VITE_POSTHOG_HOST || window?.__URSASS_POSTHOG_HOST__ || undefined;


### PR DESCRIPTION
### Motivation
- Improve runtime performance diagnostics by detecting when FPS is artificially capped around 30 and warning operators.
- Ensure Phaser runtime has explicit FPS target/min settings to stabilize behavior across environments.
- Allow runtime or build-time toggling of PostHog for quick perf/debugging and document the flag in the README.

### Description
- Added detection for a recurring ~30 FPS cap in `js/perf.js` by tracking `thirtyFpsCapStreak` and emitting a `logger.warn` when the streak reaches 5 via `detectPossibleFpsCap()`; this is invoked from `updateFPS()`.
- Configured Phaser FPS behavior in `js/phaser/runtime.js` by adding an `fps` block with `target: 60`, `min: 30`, `forceSetTimeOut: false`, and `smoothStep: true` to the game config.
- Introduced `isPostHogEnabled()` in `js/posthog.js` to respect `VITE_POSTHOG_ENABLED` and `window.__URSASS_POSTHOG_ENABLED__` (with string/boolean normalization) and early-return from `initPostHog()` when disabled, plus an info log explaining the reason.
- Updated `README.md` to document `window.__URSASS_POSTHOG_ENABLED__` and the ability to disable PostHog with `VITE_POSTHOG_ENABLED=false` for quick perf diagnosis.

### Testing
- Ran the repository automated test suite with `npm test` and all tests passed.
- Performed a production build with `npm run build` which completed successfully and emitted no build-time errors.
- Linting via `npm run lint` was executed and reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f288b232388320a3dacd094a10b957)