### PR TITLE
Telegram mini-app: make top controls non-fixed and move Connect X under Wallet in player menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2023,6 +2023,7 @@ footer a:hover { color: #e0b0ff; }
   }
 
   body.telegram-mini-app #gameStart .start-audio-nav {
+    position: absolute;
     top: max(0px, env(safe-area-inset-top));
   }
 
@@ -2037,6 +2038,11 @@ footer a:hover { color: #e0b0ff; }
   #walletCorner {
     top: max(8px, env(safe-area-inset-top));
     right: 14px;
+  }
+
+  body.telegram-mini-app #walletCorner {
+    position: absolute;
+    top: max(6px, env(safe-area-inset-top));
   }
 
   body.telegram-mini-app #walletCorner .wallet-btn-corner {
@@ -2210,6 +2216,7 @@ footer a:hover { color: #e0b0ff; }
   }
 
   body.telegram-mini-app #gameStart .start-audio-nav {
+    position: absolute;
     top: max(0px, env(safe-area-inset-top));
   }
 
@@ -2272,6 +2279,7 @@ footer a:hover { color: #e0b0ff; }
   }
 
   body.telegram-mini-app #gameStart .start-audio-nav {
+    position: absolute;
     top: max(0px, env(safe-area-inset-top));
   }
 
@@ -3090,10 +3098,16 @@ footer a:hover { color: #e0b0ff; }
   background: rgba(244, 63, 94, .25);
 }
 
+
 @media (hover: none) {
   .pm-x-disconnect:not([hidden]) {
     display: block;
   }
+}
+
+body.telegram-mini-app .pm-side-x.pm-x-wrap--telegram-inline {
+  width: 100%;
+  margin-top: 6px;
 }
 
 /* Game Over share button variants */

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -194,6 +194,24 @@ function updateWalletBlock(profile) {
   }
 }
 
+
+function applyTelegramPlayerMenuLayout() {
+  if (!document.body.classList.contains('telegram-mini-app')) return;
+
+  const walletBtn = DOM.pmConnectWalletBtn;
+  const xBlock = DOM.pmXBlock;
+  const centerColumn = document.querySelector('.pm-center');
+  if (!walletBtn || !xBlock || !centerColumn) return;
+
+  const walletParent = walletBtn.parentElement;
+  if (walletParent !== centerColumn) return;
+
+  if (xBlock.previousElementSibling !== walletBtn) {
+    centerColumn.insertBefore(xBlock, walletBtn.nextSibling);
+  }
+  xBlock.classList.add('pm-x-wrap--telegram-inline');
+}
+
 function fillProfileData(profile) {
   currentProfile = profile;
 
@@ -272,6 +290,8 @@ function bindLongPress(element, callback) {
 function initPlayerMenuEvents() {
   if (eventsInitialized) return;
   eventsInitialized = true;
+
+  applyTelegramPlayerMenuLayout();
 
   if (DOM.pmBackBtn) {
     DOM.pmBackBtn.addEventListener('click', () => closePlayerMenu());


### PR DESCRIPTION
### Motivation
- Align Telegram mini-app UI with platform constraints by ensuring top controls (wallet, player menu, username) and audio toggles are not fixed and can scroll with the page. 
- Raise the top corner visual by ~2px on Telegram to avoid overlap with safe-area and to match requested offset. 
- Place the X (Connect X) block directly under the Connect Wallet button inside the player menu for a compact Telegram layout. 

### Description
- CSS: made `body.telegram-mini-app #gameStart .start-audio-nav` use `position: absolute` (breakpoints 768/480/360) so audio toggles sit at the top and are not fixed on scroll, and adjusted related start-audio rules in `css/style.css`.
- CSS: added `body.telegram-mini-app #walletCorner { position: absolute; top: max(6px, env(safe-area-inset-top)); }` to move the wallet/player corner 2px up and remove fixed positioning in `css/style.css`.
- CSS: added Telegram-specific inline styling `body.telegram-mini-app .pm-side-x.pm-x-wrap--telegram-inline` to support the relocated X block in `css/style.css`.
- JS: added `applyTelegramPlayerMenuLayout()` in `js/player-menu/controller.js` and invoke it from `initPlayerMenuEvents()` to move the `pmXBlock` immediately after the `pmConnectWalletBtn` in Telegram mode and to add the inline class for styling.

### Testing
- Ran `npm run check:syntax` and the project's JS syntax checks completed successfully (all listed files validated by `scripts/check-syntax.mjs`).
- Attempted `npm run check-syntax` which failed because the project script is named `check:syntax` (this was an expected invocation error and not a regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f291317fa88320a4e46ea16ea8a697)