### PR TITLE
Add unused-code check and frontend unification docs

### DIFF
--- a/docs/deep-audit-2026-04-30-ru.md
+++ b/docs/deep-audit-2026-04-30-ru.md
@@ -1,0 +1,111 @@
+# Глубокий аудит Ursasstube (frontend) — 30.04.2026
+
+## Что проверено
+- Структура модулей `js/`, `scripts/`, `css/`.
+- Наличие неиспользуемого кода через текущие проектные гейты (`check:static-analysis`, `check:syntax`).
+- Потенциальные дубли и точки рефакторинга в UI/CSS и runtime-слоях.
+
+## Быстрые выводы
+1. **Критичных блокеров по синтаксису/guardrails нет** — проект проходит внутренние проверки.
+2. **Главный технический долг во фронтенде — стили UI**: много семейств кнопок с почти одинаковой механикой (`.btn-new`, `.go-btn`, `.store-nav-btn`, `.payment-secondary-btn`, `.pm-share-btn`, `.wallet-btn-corner`).
+3. **Дублирование логики анимаций и состояний** (`:hover`, `:active`, `muted/disabled/connected`) реализовано на уровне конкретных классов, а не дизайн-токенов/утилит.
+4. **Архитектурно код разделён неплохо** (game/store/phaser/auth), но присутствует риск «drift» между legacy-слоем (`js/*.js`) и подсистемами (`js/game/*`, `js/phaser/*`).
+
+---
+
+## Найденные зоны дублей/неэффективности
+
+### 1) CSS: кнопки и интерактивные элементы
+**Симптом:** повторяемые паттерны стеклянного фона, бордера, hover/active трансформаций.
+
+**Где видно:**
+- `wallet-btn-corner`
+- `link-btn`
+- `btn-new`
+- `go-btn`
+- `store-nav-btn`
+- `store-back-btn`
+- `payment-secondary-btn`
+- `pm-share-btn`
+
+**Риск:**
+- сложно поддерживать консистентность;
+- правка состояний/доступности требует каскадных изменений;
+- рост CSS и вероятность конфликтов по специфичности.
+
+**Рефакторинг:**
+- Ввести слой **component tokens** + базовые utility-классы:
+  - `.ui-btn`, `.ui-btn--primary`, `.ui-btn--secondary`, `.ui-btn--ghost`, `.ui-btn--danger`
+  - `.ui-btn--icon`, `.ui-btn--lg`, `.ui-btn--sm`
+  - состояния: `[data-state="connected"]`, `[aria-disabled="true"]`, `.is-muted`
+- Для текущих классов оставить обратную совместимость через composition (поэтапная миграция).
+
+### 2) Разрозненные точки ответственности в runtime/UI
+**Симптом:** большой набор файлов в корне `js/` плюс доменные директории `js/game`, `js/store`, `js/phaser`.
+
+**Риск:**
+- часть логики живёт в историческом слое,
+- тяжело быстро ответить «где источник истины» для конкретной фичи.
+
+**Рефакторинг:**
+- Зафиксировать правило: **новый код только в доменные папки**.
+- Ввести `js/core/` (event bus, lifecycle hooks, runtime contracts).
+- В legacy-файлах оставить thin adapters + deprecation-комментарии.
+
+### 3) Потенциальный «мертвый код» и устаревшие API
+Текущие гейты показывают baseline на неиспользуемый export/implicit global writes, но этого мало для фактической чистки.
+
+**Рефакторинг/оптимизация анализа:**
+- Добавить отчетность по импорту/экспорту (например, `knip` или кастомный graph-check script).
+- В CI: падать только при **новом** мертвом коде (baseline strategy уже частично используется — продолжить).
+
+### 4) Нагрузочные места для mobile perf
+Проект уже имеет mobile perf gate, но стили и эффекты всё ещё активно используют blur/glow/box-shadow.
+
+**Оптимизация:**
+- ввести `@media (prefers-reduced-motion: reduce)` и low-power theme;
+- централизовать тяжелые эффекты через токены `--fx-glow-*`, чтобы быстро деградировать на слабых девайсах.
+
+---
+
+## Pipeline №1: глубокая техпроверка (дубли, dead code, эффективность)
+
+### Этап A — статический слой (каждый PR)
+1. `npm run check:syntax`
+2. `npm run check:static-analysis`
+3. `npm run check:no-window-assign`
+4. `npm run check:asset-paths`
+5. Новый шаг: `npm run check:unused-code` (добавить)
+
+**Цель:** не пускать новый техдолг.
+
+### Этап B — quality gates (каждый PR)
+1. `npm run test:request`
+2. `npm run check:mobile-perf-gate`
+3. `npm run check:observability-gate`
+4. `npm run check:release-gates`
+5. `npm run check:rollback-gate`
+
+**Цель:** не ломать прод-качество и наблюдаемость.
+
+### Этап C — еженедельный аудит (scheduled)
+1. Отчет по дублированию CSS-селекторов и button variants.
+2. Отчет по orphan assets (`public/assets`, `public/img`).
+3. Отчет по runtime footprint (largest modules, hot paths, event listeners).
+
+### Этап D — ежемесячный burn-down
+1. Список deprecated-файлов в `js/` root.
+2. План удаления/слияния модулей.
+3. Прогресс против baseline (unused exports, implicit writes, oversized files).
+
+---
+
+## Отдельная задача: backend-ревью (репозиторий URSASS_Backend)
+Для комплексной проверки нужно зеркально применить этот же pipeline к backend-репозиторию:
+- архитектурные дубли сервисов,
+- неиспользуемые endpoints/DTO,
+- индексы и N+1,
+- caching policy,
+- observability/rollback gates.
+
+(В этом коммите выполнен аудит только текущего frontend-репозитория.)

--- a/docs/frontend-unification-plan-2026-04-30-ru.md
+++ b/docs/frontend-unification-plan-2026-04-30-ru.md
@@ -1,0 +1,70 @@
+# План №2: приведение фронтенда к единой понятной структуре и единым стилям
+
+## Цель
+Сделать UI предсказуемым и консистентным: одинаковые кнопки, тексты, состояния, отступы и поведение на всех экранах (start/game-over/store/player menu/auth).
+
+## Целевая структура
+
+### 1) CSS-архитектура (слои)
+- `css/tokens.css` — цвета, размеры, радиусы, тени, motion-токены.
+- `css/base.css` — reset, typography base, helpers.
+- `css/components/buttons.css` — единый button-system.
+- `css/components/inputs.css` — формы/переключатели.
+- `css/layout/*.css` — screen layout blocks.
+- `css/screens/*.css` — точечные экранные исключения.
+
+> На первом этапе можно не дробить физически файлы, а хотя бы ввести секции и naming policy в текущем `css/style.css`.
+
+### 2) Button Design System
+- База: `.ui-btn`
+- Варианты: `.ui-btn--primary`, `--secondary`, `--ghost`, `--danger`
+- Размеры: `--sm`, `--md`, `--lg`, `--icon`
+- Состояния: `:hover`, `:active`, `:focus-visible`, `[disabled]`, `.is-loading`, `.is-muted`
+
+Миграция:
+- `wallet-btn-corner` -> `ui-btn ui-btn--secondary ui-btn--sm`
+- `btn-new` -> `ui-btn ui-btn--primary ui-btn--lg`
+- `go-btn-share`/`go-btn-menu` -> `ui-btn ui-btn--secondary`
+- `store-nav-btn` -> `ui-btn ui-btn--icon`
+
+### 3) Типографика
+- Ввести scale: `--font-xs/sm/md/lg/xl`.
+- Вынести повторяемые text-styles:
+  - `.ui-title`, `.ui-subtitle`, `.ui-caption`, `.ui-mono-meta`.
+- Убрать точечные «магические» размеры, где это возможно.
+
+### 4) Единая структура JS по доменам
+- `js/core/` — общая инфраструктура (events, lifecycle, request wrappers).
+- `js/features/auth/`
+- `js/features/game/`
+- `js/features/store/`
+- `js/features/player-menu/`
+- `js/integrations/` (telegram/metamask/walletconnect/posthog)
+
+## Пошаговый rollout (без большого взрыва)
+
+### Этап 1 (1 спринт)
+1. Зафиксировать naming convention (BEM/utility hybrid).
+2. Добавить `ui-btn` и мигрировать 2 экрана: старт + game over.
+3. Добавить линт-правило/скрипт: запрет новых button-классов без `ui-btn`.
+
+### Этап 2 (1–2 спринта)
+1. Миграция store/player-menu/auth кнопок.
+2. Унификация typography scale.
+3. Удаление дублирующих CSS-блоков после миграции.
+
+### Этап 3 (1 спринт)
+1. Перенос legacy JS в feature-структуру.
+2. Thin-adapters для обратной совместимости.
+3. Финальная чистка dead selectors и orphan utils.
+
+## KPI успеха
+- Количество уникальных button-классов: снизить минимум на 40%.
+- Количество повторяющихся hover/active блоков: снизить минимум на 60%.
+- Время на добавление нового экрана: -25% (оценочно по velocity).
+- Mobile perf gate: без деградации p95 кадра/интеракций.
+
+## Definition of Done
+- Все новые кнопки используют только `ui-btn`-систему.
+- Нет прямого копирования старых button-стилей в новых фичах.
+- Документация по UI-конвенциям добавлена в `docs/`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "npm run check:conflicts && vite build",
     "preview": "vite preview",
-    "check": "npm run check:syntax && npm run check:static-analysis && npm run check:no-window-assign && npm run check:asset-paths && npm run check:no-legacy-canvas-runtime && npm run test:e2e-smoke && npm run test:request",
+    "check": "npm run check:syntax && npm run check:static-analysis && npm run check:unused-code && npm run check:no-window-assign && npm run check:asset-paths && npm run check:no-legacy-canvas-runtime && npm run test:e2e-smoke && npm run test:request",
     "check:security": "bash -lc \"unset NPM_CONFIG_HTTP_PROXY npm_config_http_proxy NPM_CONFIG_HTTPS_PROXY npm_config_https_proxy HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; npm audit --omit=dev --audit-level=moderate\"",
     "check:asset-paths": "node scripts/check-public-asset-paths.mjs",
     "check:mobile-perf-gate": "node scripts/check-mobile-perf-gate.mjs",
@@ -24,7 +24,8 @@
     "report:metrics": "node scripts/build-product-metrics-report.mjs",
     "check:syntax": "node scripts/check-syntax.mjs",
     "prepare": "node scripts/setup-hooks.mjs",
-    "check:conflicts": "node scripts/check-no-conflict-markers.mjs"
+    "check:conflicts": "node scripts/check-no-conflict-markers.mjs",
+    "check:unused-code": "node scripts/check-unused-code.mjs"
   },
   "devDependencies": {
     "vite": "^7.1.0"

--- a/scripts/check-unused-code.mjs
+++ b/scripts/check-unused-code.mjs
@@ -1,0 +1,91 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const BASELINE_UNUSED_EXPORTS = new Set([
+  'js/logger.js:logger',
+  'js/player-menu/controller.js:initPlayerMenu',
+  'js/player-menu/controller.js:openPlayerMenu',
+  'js/player-menu/controller.js:refreshPlayerMenu',
+  'js/player-menu/controller.js:isPlayerMenuOpen',
+  'js/game-runtime.js:initGameBootstrap',
+]);
+
+function getFiles() {
+  const out = execSync("rg --files js scripts -g '*.js' -g '*.mjs'", { cwd: rootDir, encoding: 'utf8' });
+  return out.trim().split('\n').filter(Boolean);
+}
+
+function resolveImport(fromFile, spec) {
+  if (!spec.startsWith('.')) return null;
+  const base = path.resolve(rootDir, path.dirname(fromFile), spec);
+  const candidates = [base, `${base}.js`, `${base}.mjs`, path.join(base, 'index.js')];
+  for (const c of candidates) {
+    const rel = path.relative(rootDir, c).replaceAll(path.sep, '/');
+    if (moduleMap.has(rel)) return rel;
+  }
+  return null;
+}
+
+const moduleMap = new Map();
+for (const file of getFiles()) {
+  const content = readFileSync(path.join(rootDir, file), 'utf8');
+  moduleMap.set(file, { content, exports: new Set(), imports: [] });
+}
+
+const exportDeclRE = /export\s+(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g;
+const exportListRE = /export\s*\{([^}]+)\}/g;
+const importNamedRE = /import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
+const importDefaultRE = /import\s+([A-Za-z_$][\w$]*)\s+from\s*['"]([^'"]+)['"]/g;
+
+for (const [file, info] of moduleMap.entries()) {
+  let m;
+  while ((m = exportDeclRE.exec(info.content)) !== null) info.exports.add(m[1]);
+  while ((m = exportListRE.exec(info.content)) !== null) {
+    const names = m[1].split(',').map((s) => s.trim()).filter(Boolean);
+    for (const n of names) {
+      const left = n.split(' as ')[0].trim();
+      if (left && left !== 'default') info.exports.add(left);
+    }
+  }
+
+  while ((m = importNamedRE.exec(info.content)) !== null) {
+    info.imports.push({ source: m[2], names: m[1].split(',').map((s) => s.trim().split(' as ')[0].trim()) });
+  }
+  while ((m = importDefaultRE.exec(info.content)) !== null) {
+    info.imports.push({ source: m[2], names: ['default'] });
+  }
+}
+
+const used = new Set();
+for (const [fromFile, info] of moduleMap.entries()) {
+  for (const imp of info.imports) {
+    const target = resolveImport(fromFile, imp.source);
+    if (!target) continue;
+    for (const name of imp.names) used.add(`${target}:${name}`);
+  }
+}
+
+const unused = [];
+for (const [file, info] of moduleMap.entries()) {
+  for (const name of info.exports) {
+    const key = `${file}:${name}`;
+    if (!used.has(key) && !BASELINE_UNUSED_EXPORTS.has(key)) unused.push(key);
+  }
+}
+
+if (unused.length > 0) {
+  console.error('❌ New unused exports detected:');
+  for (const key of unused) console.error(` - ${key}`);
+  process.exit(1);
+}
+
+console.log('✅ Unused-code check passed (no new unused exports outside baseline).');
+if (BASELINE_UNUSED_EXPORTS.size > 0) {
+  console.log(`ℹ️ Baseline tolerated: ${[...BASELINE_UNUSED_EXPORTS].join(', ')}`);
+}


### PR DESCRIPTION
### Motivation
- Add a CI-friendly static check to detect newly introduced unused exports and provide a baseline for tolerated legacy exports.
- Document audit findings and a concrete frontend unification/rollout plan to reduce CSS/JS duplication and technical debt.

### Description
- Introduce `scripts/check-unused-code.mjs`, a Node script that scans project JS modules, builds a simple import/export graph, and fails on any new unused exports outside a defined baseline.
- Add `check:unused-code` npm script and wire it into the main `check` workflow in `package.json` so unused-export detection runs as part of the project checks.
- Add two documentation files: `docs/deep-audit-2026-04-30-ru.md` with audit findings and `docs/frontend-unification-plan-2026-04-30-ru.md` with a stepwise unification plan for CSS/JS.
- Keep a small baseline (`BASELINE_UNUSED_EXPORTS`) inside the check script to tolerate known legacy exports during incremental cleanup.

### Testing
- Ran the new unused-code check directly with `node scripts/check-unused-code.mjs` and it completed successfully (no new unused exports detected).
- Verified `npm run check` to ensure the `check:unused-code` step integrates with the existing check pipeline and the overall check sequence completes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35e5f10c88320a3e6d20348bf2c42)