### PR TITLE
Defer Phaser renderer and main loop until Start Game to reduce menu CPU/GPU load

### DIFF
--- a/docs/start-screen-overheating-patch-plan-2026-04-30-ru.md
+++ b/docs/start-screen-overheating-patch-plan-2026-04-30-ru.md
@@ -1,0 +1,69 @@
+# Ursass Tube — Patch Plan: перегрев на стартовом экране (Telegram Mini App)
+
+**Дата:** 30 апреля 2026  
+**Контекст:** предрелизный критический perf-issue на мобильных устройствах
+
+## Проблема
+
+На стартовом экране до нажатия `Start Game` запускался тяжёлый runtime/рендер-path, что приводило к повышенной CPU/GPU нагрузке и нагреву устройства.
+
+## Подтверждённые причины
+
+1. Инициализация Phaser renderer происходила на bootstrap (до старта ранa).
+2. Main loop запускался слишком рано.
+3. Стартовое меню было UI-оверлеем, но игровой runtime уже существовал.
+
+## Цель патча
+
+- Поднимать Phaser только после нажатия `Start Game`.
+- Держать меню лёгким (без фонового тяжёлого рендера).
+- После выхода в меню — опускать нагрузку обратно.
+- Сохранить игровой feel: target FPS **не снижать**.
+
+## Технический план (по файлам)
+
+### 1) `js/game.js`
+
+- Ввести ленивый lifecycle renderer:
+  - `ensureRendererReady()`
+  - `destroyRenderer()`
+  - сериализация через `rendererInitPromise`.
+- Убрать eager renderer init из `initGame()`.
+- Передать lifecycle-функции в session controller.
+
+### 2) `js/game/session.js`
+
+- В `startGame` перед `actualStartGame` вызывать `ensureRendererReady()`.
+- После инициализации делать `syncViewport()` и только потом запуск run.
+- На `goToMainMenu()` вызывать `destroyRenderer()` для полного teardown.
+- Запуск loop только при первом gameplay (`gameplayLoopStarted`).
+
+### 3) `js/game/bootstrap.js`
+
+- Убрать автоматический вызов `startMainLoop()` на bootstrap.
+- Оставить deferred-подход: loop стартует в gameplay-пути.
+
+## Риски и контроль
+
+- **Риск:** первый старт ранa может занять немного больше времени.
+  - **Митигировать:** использовать transition/preload слой и fallback на ошибку init.
+- **Риск:** race-condition при повторных нажатиях `Start`.
+  - **Митигировать:** единый `rendererInitPromise`.
+
+## Acceptance criteria
+
+1. На меню до `Start Game` Phaser runtime не выполняет тяжёлую отрисовку.
+2. После `Start Game` runtime и сцена поднимаются в рамках transition/preload.
+3. После `Game Over -> Menu` нагрузка снова падает.
+4. FPS gameplay остаётся 60-target.
+
+## Smoke-checklist
+
+1. Open app -> 60s idle on menu (без заметного нагрева).
+2. Start Game -> корректный preload -> старт ранa.
+3. Game Over -> Menu -> повторный idle (нагрузка ниже gameplay).
+4. Повторить цикл 3–5 раз (без деградации/утечек).
+
+## Статус
+
+План оформлен в репозитории как отдельный документ для трекинга и ревью.

--- a/js/game.js
+++ b/js/game.js
@@ -18,6 +18,8 @@ import { logger } from './logger.js';
 
 let activeRenderer = null;
 let viewportSyncBound = false;
+let rendererInitPromise = null;
+let mainLoopStarted = false;
 const PHASER_LOADING_OVERLAY_ID = 'phaserLoadingOverlay';
 let loadingOverlayElements = null;
 
@@ -44,6 +46,51 @@ function bindViewportSyncLifecycle() {
   if (viewportSyncBound) return;
   window.addEventListener(VIEWPORT_SYNC_EVENT, syncRendererViewport);
   viewportSyncBound = true;
+}
+
+function isRendererReady() {
+  return Boolean(activeRenderer);
+}
+
+async function ensureRendererReady({ forceRecreate = false } = {}) {
+  if (forceRecreate && activeRenderer) {
+    activeRenderer.destroy();
+    activeRenderer = null;
+  }
+
+  if (activeRenderer) {
+    return activeRenderer;
+  }
+
+  if (!rendererInitPromise) {
+    rendererInitPromise = (async () => {
+      const { width, height } = getViewportDimensions();
+      const initialSnapshot = createSnapshotForRenderer(width, height);
+      const renderer = await createGameRenderer(initialSnapshot);
+      activeRenderer = renderer;
+      bindViewportSyncLifecycle();
+      syncRendererViewport();
+      return renderer;
+    })();
+  }
+
+  try {
+    return await rendererInitPromise;
+  } finally {
+    rendererInitPromise = null;
+  }
+}
+
+function destroyRenderer() {
+  rendererInitPromise = null;
+  activeRenderer?.destroy?.();
+  activeRenderer = null;
+}
+
+function startMainLoopOnce() {
+  if (mainLoopStarted) return;
+  mainLoopStarted = true;
+  loopController.startMainLoop();
 }
 
 function requestViewportSync() {
@@ -186,23 +233,19 @@ const sessionController = createGameSessionController({
   getBestScore,
   setBestDistance,
   getBestDistance,
+  ensureRendererReady,
+  destroyRenderer,
   initializeGameplayRun,
   applyGameplayUpgradeState,
   clearGameplayCollections
 });
 
 async function initGame() {
-  const { width, height } = getViewportDimensions();
-  const initialSnapshot = createSnapshotForRenderer(width, height);
-  activeRenderer = await createGameRenderer(initialSnapshot);
-  bindViewportSyncLifecycle();
-  syncRendererViewport();
-
   await initGameBootstrapFlow({
     startGame: sessionController.startGame,
     restartFromGameOver: sessionController.restartFromGameOver,
     goToMainMenu: sessionController.goToMainMenu,
-    startMainLoop: loopController.startMainLoop,
+    startMainLoop: startMainLoopOnce,
     showStore,
     hideStore,
     showRules,

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -512,8 +512,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     prepareViewport();
   }
 
-  logger.info('▶️ Starting main loop...');
-  startMainLoop();
+  logger.info('⏸ Main loop deferred until first gameplay start');
 
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
     const screen = event.detail?.screen;

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -22,7 +22,6 @@ const CRASH_FLY_DEFAULT_DURATION_MS = 6000;
 const START_TRANSITION_STATIC_EYES_SRC = 'img/eyes.png';
 const MENU_EYES_STATIC_SRC = 'img/eyes.png';
 const RUN_INDEX_STORAGE_KEY = 'ursas_run_index';
-
 function createGameSessionController({
   DOM,
   gameState,
@@ -45,6 +44,8 @@ function createGameSessionController({
   getBestScore,
   setBestDistance,
   getBestDistance,
+  ensureRendererReady,
+  destroyRenderer,
   initializeGameplayRun,
   applyGameplayUpgradeState,
   clearGameplayCollections
@@ -54,7 +55,7 @@ function createGameSessionController({
   let currentRunIndex = 1;
   let latestGameOverSummary = null;
   let gameOverRunToken = 0;
-
+  let gameplayLoopStarted = false;
   function getLocalStorageSafe() {
     if (typeof window === 'undefined') return null;
     try {
@@ -63,7 +64,6 @@ function createGameSessionController({
       return null;
     }
   }
-
   function bumpRunIndex() {
     const storage = getLocalStorageSafe();
     const previous = normalizeRunIndex(storage?.getItem(RUN_INDEX_STORAGE_KEY) || 0);
@@ -250,26 +250,24 @@ function createGameSessionController({
   function actualStartGame() {
     if (gameState.running) return;
     endGameInProgress = false;
-
+    if (!gameplayLoopStarted) {
+      loopController.startMainLoop();
+      gameplayLoopStarted = true;
+    }
     stopMenuLaunchAnimation();
     showGameplayScreen();
-
     loopController.runAfterLayoutStabilizes(() => {
       syncViewport();
-
       resetGameSessionState();
       showGameplayScreen();
-
       initializeGameplayRun({
         now: performance.now(),
         speed: CONFIG.SPEED_START,
         nextCurveDirection: Math.random() * Math.PI * 2,
         nextCurveStrength: 0.5 + Math.random() * 0.5
       });
-
       clearGameplayCollections();
       clearParticles();
-
       applyPlayerUpgrades();
       beginAiRun();
       runStartedAt = Date.now();
@@ -308,7 +306,6 @@ function createGameSessionController({
         runIndex: currentRunIndex,
         difficultySegment: getDifficultySegment(currentRunIndex),
       });
-
       audioManager.playRandomGameMusic();
       loopController.scheduleResizeStabilization();
       logger.info('✅ Game started!');
@@ -321,17 +318,14 @@ function createGameSessionController({
       setTimeout(startGame, 500);
       return;
     }
-
     if (isAuthenticated() || hasRideLimit()) {
       await loadPlayerRides();
       const playerRides = getPlayerRides();
-
       if (hasRideLimit() && (playerRides.totalRides || 0) <= 0) {
         resetUiAfterRideFailure();
         notifyWarn(`🎟 No rides! ⏰ Resets in ${playerRides.resetInFormatted}. 💰 Buy a ride pack in the Store!`, { durationMs: 7000 });
         return;
       }
-
       const canPlay = await useRide();
       if (hasRideLimit() && !canPlay) {
         const currentRides = getPlayerRides();
@@ -340,29 +334,38 @@ function createGameSessionController({
         return;
       }
     }
-
     logger.info('▶️ Starting game...');
     audioManager.stopAll();
-
     showMainMenuScreen();
     playStartTransitionAnimation();
     playMenuLaunchAnimation();
     audioManager.playSFX('gamestart');
+    const startAfterTransition = async (phase) => {
+      try {
+        await ensureRendererReady();
+        syncViewport();
+        stopStartTransitionAnimation();
+        stopMenuLaunchAnimation();
+        actualStartGame();
+      } catch (error) {
+        logger.error(`❌ Phaser init failed on ${phase}:`, error);
+        stopStartTransitionAnimation();
+        stopMenuLaunchAnimation();
+        showMainMenuScreen();
+        showBonusText('⚠️ Loading failed. Please try again.');
+      }
+    };
 
     const onEnd = () => {
       audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
-      stopStartTransitionAnimation();
-      stopMenuLaunchAnimation();
-      actualStartGame();
+      startAfterTransition('start');
     };
     audioManager.sfx.gamestart.addEventListener('ended', onEnd);
 
     setTimeout(() => {
       if (!gameState.running) {
         audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
-        stopStartTransitionAnimation();
-        stopMenuLaunchAnimation();
-        actualStartGame();
+        startAfterTransition('start fallback');
       }
     }, 5000);
   }
@@ -374,7 +377,6 @@ function createGameSessionController({
     if (DOM.darkScreen) DOM.darkScreen.style.display = 'none';
     startGame();
   }
-
   function endGame(reason = 'Unknown') {
     if (endGameInProgress) return;
     endGameInProgress = true;
@@ -553,10 +555,8 @@ function createGameSessionController({
     logger.info('🏠 Return to main menu');
     audioManager.stopAll();
     stopMenuLaunchAnimation();
-
     showMainMenuScreen();
     gameState.running = false;
-
     clearGameplayCollections();
     clearParticles();
 
@@ -572,6 +572,7 @@ function createGameSessionController({
     gameState.spinCooldown = 0;
 
     resetGameSessionState();
+    destroyRenderer?.();
     audioManager.playMusic('menu');
 
     if (runStartedAt) {
@@ -595,5 +596,4 @@ function createGameSessionController({
     startGame
   };
 }
-
 export { createGameSessionController };


### PR DESCRIPTION
### Motivation

- Prevent heavy runtime/renderer work from running on the main menu to reduce mobile device CPU/GPU usage and overheating. 
- Lazily initialize the Phaser renderer and only start the main loop when gameplay actually begins to minimize background load. 
- Ensure proper teardown and safe re-entry to menu so load drops after gameplay ends and avoid races on repeated starts. 

### Description

- Added lazy renderer lifecycle in `js/game.js` with `ensureRendererReady()`, `destroyRenderer()`, a `rendererInitPromise` guard, and `startMainLoopOnce()` to prevent eager init and duplicate loop starts. 
- Stopped eager renderer creation in `initGame()` and passed `ensureRendererReady`/`destroyRenderer` into the session controller. 
- Deferred main loop startup in `js/game/bootstrap.js` by removing the automatic `startMainLoop()` call and logging that it is deferred until gameplay. 
- Updated `js/game/session.js` to call `ensureRendererReady()` during `startGame()` (before `actualStartGame()`), to start the main loop only once (`gameplayLoopStarted`), and to call `destroyRenderer()` on `goToMainMenu()`; added init error handling and a fallback path for the start transition. 
- Added a new document `docs/start-screen-overheating-patch-plan-2026-04-30-ru.md` describing the patch plan, risks, acceptance criteria and smoke checklist. 

### Testing

- No automated tests were executed as part of this rollout; please run CI/unit tests and the described smoke checklist (`60s idle on menu`, `Start Game -> preload -> start run`, `Game Over -> Menu idle`) to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37ddf30c48320888ca3e3205a153d)