### PR TITLE
Unify UI button system, migrate templates, and introduce feature/core entrypoints

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,11 @@
 /* ===== TOKENS / BASE ===== */
 :root {
+  /* === UI TOKENS: typography === */
+  --font-xs: 10px;
+  --font-sm: 12px;
+  --font-md: 14px;
+  --font-lg: 16px;
+  --font-xl: 18px;
   --color-bg: #05030b;
   --color-text: #fff;
   --color-glass: rgba(255, 255, 255, .06);
@@ -32,6 +38,60 @@
   --sal: env(safe-area-inset-left, 0px);
   --sar: env(safe-area-inset-right, 0px);
   --start-ui-offset-y: 100px;
+}
+
+/* ===== UI NAMING CONVENTION (BEM + utility hybrid) =====
+   Block: .ui-*
+   Element: .ui-__*
+   Modifier: .ui-*--*
+   State: .is-*
+*/
+
+/* ===== UI BUTTON SYSTEM ===== */
+.ui-btn {
+  min-height: 40px;
+  padding: 10px 18px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, .22);
+  font-family: 'Orbitron', sans-serif;
+  font-size: var(--font-md);
+  font-weight: 600;
+  letter-spacing: .6px;
+  color: var(--text);
+  background: var(--glass2);
+  backdrop-filter: blur(12px);
+  cursor: pointer;
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease, opacity .2s ease;
+}
+
+.ui-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px rgba(140, 80, 255, .22);
+  border-color: rgba(140, 80, 255, .5);
+}
+
+.ui-btn:active { transform: scale(0.96); }
+.ui-btn:focus-visible { outline: 2px solid rgba(129, 140, 248, .85); outline-offset: 2px; }
+.ui-btn[disabled],
+.ui-btn.is-muted { opacity: .5; cursor: not-allowed; box-shadow: none; }
+.ui-btn.is-loading { pointer-events: none; }
+
+.ui-btn--primary { border-color: rgba(99, 102, 241, .62); }
+.ui-btn--secondary { border-color: rgba(96, 165, 250, .45); }
+.ui-btn--ghost { background: rgba(255, 255, 255, .05); border-color: rgba(255, 255, 255, .18); }
+.ui-btn--danger { border-color: rgba(248, 113, 113, .52); box-shadow: 0 0 10px rgba(248, 113, 113, .14); }
+
+.ui-btn--sm { min-height: 34px; padding: 8px 14px; font-size: var(--font-sm); }
+.ui-btn--md { min-height: 40px; font-size: var(--font-md); }
+.ui-btn--lg { min-height: 56px; padding: 14px 30px; font-size: var(--font-lg); }
+.ui-btn--icon {
+  width: 40px;
+  min-height: 40px;
+  padding: 0;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 * {
@@ -161,16 +221,9 @@ input:checked + .slider:before {
 
 .wallet-btn-corner {
   padding: 8px 16px;
-  font-family: 'Orbitron', sans-serif;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
   background: var(--glass);
-  backdrop-filter: blur(12px);
   border: 1px solid var(--border-accent);
   border-radius: var(--radius-pill);
-  cursor: pointer;
-  transition: .3s;
   white-space: nowrap;
 }
 
@@ -407,18 +460,7 @@ body.ui-stable #gameStart {
 
 .btn-new {
   width: 100%;
-  min-height: 56px;
   padding: 16px 40px;
-  background: var(--glass2);
-  backdrop-filter: blur(15px);
-  border: 1px solid var(--border-accent);
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: .4s;
-  color: var(--text);
-  font-family: 'Orbitron', sans-serif;
-  font-size: 16px;
-  font-weight: 600;
   letter-spacing: 1px;
   position: relative;
   overflow: hidden;
@@ -1282,8 +1324,8 @@ body.start-launching #walletCorner {
 
 
 .go-btn-share {
-  background: rgba(14, 116, 144, .16);
-  border: 1px solid rgba(56, 189, 248, .30);
+  background: rgba(14, 116, 144, .18);
+  border-color: rgba(56, 189, 248, .30);
   font-size: 13px;
   padding-top: 12px;
   padding-bottom: 12px;
@@ -1302,8 +1344,8 @@ body.start-launching #walletCorner {
 }
 
 .go-btn-menu {
-  background: rgba(255, 255, 255, .03);
-  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(255, 255, 255, .04);
+  border-color: rgba(255,255,255,.12);
   color: rgba(255,255,255,.62);
   font-size: 12px;
   padding-top: 10px;
@@ -1415,15 +1457,8 @@ body.start-launching #walletCorner {
   display: flex;
   align-items: center; justify-content: center;
   font-size: 18px;
-  color: var(--text);
-  background: var(--glass);
-  backdrop-filter: blur(14px);
-  border: 1px solid var(--border-accent);
   border-radius: 50%;
-  cursor: pointer;
-  transition: .3s;
   padding: 0; line-height: 1;
-  font-family: 'Orbitron', sans-serif;
 }
 
 .store-nav-btn:hover {
@@ -1434,56 +1469,6 @@ body.start-launching #walletCorner {
 
 .store-nav-btn:active { transform: scale(0.92); }
 .store-nav-btn.muted { opacity: 0.4; border-color: rgba(255,255,255,.08); }
-
-/* Store back fixed */
-.store-back-fixed {
-  position: fixed;
-  left: 16px;
-  top: 50%; transform: translateY(-50%);
-  z-index: 110;
-  width: 44px; height: 44px;
-  display: flex;
-  align-items: center; justify-content: center;
-  font-family: 'Orbitron', sans-serif;
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--text);
-  background: var(--glass);
-  backdrop-filter: blur(14px);
-  border: 1px solid var(--border-accent);
-  border-radius: 50%;
-  cursor: pointer;
-  transition: .3s;
-}
-
-.store-back-fixed:hover {
-  box-shadow: 0 0 20px rgba(140, 80, 255, .3);
-  transform: translateY(-50%) scale(1.08);
-  border-color: rgba(140, 80, 255, .7);
-}
-
-.store-back-fixed:active { transform: translateY(-50%) scale(0.94); }
-
-.store-back-btn {
-  padding: 8px 20px;
-  font-family: 'Orbitron', sans-serif;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
-  background: var(--glass2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: .3s;
-  margin-top: 20px;
-}
-
-.store-back-btn:hover {
-  border-color: var(--border-accent);
-  box-shadow: 0 0 15px rgba(140, 80, 255, .2);
-}
-
-.store-back-btn:active { transform: scale(0.96); }
 
 .store-list {
   width: 100%;
@@ -2167,7 +2152,6 @@ footer a:hover { color: #e0b0ff; }
   .rules-section-text { font-size: 11px; }
   .rules-fixed-nav { left: 8px; top: 16px; gap: 8px; }
   #storeScreen { padding: 20px 15px 20px 55px; }
-  .store-back-fixed { left: 10px; width: 38px; height: 38px; font-size: 16px; }
   .game-audio-nav { right: 10px; bottom: 65px; gap: 6px; }
   .game-audio-btn { width: 34px; height: 34px; font-size: 14px; }
 
@@ -2257,7 +2241,6 @@ footer a:hover { color: #e0b0ff; }
   }
   .store-nav-btn { width: 34px; height: 34px; font-size: 14px; }
   #storeScreen { padding: 15px 10px 15px 48px; }
-  .store-back-fixed { left: 8px; width: 34px; height: 34px; font-size: 14px; }
   .game-audio-nav { right: 8px; bottom: 60px; }
   .game-audio-btn { width: 30px; height: 30px; font-size: 12px; }
   .rules-title { font-size: 18px; }
@@ -3064,13 +3047,13 @@ footer a:hover { color: #e0b0ff; }
   color: rgba(34, 211, 238, .85);
 }
 
-.pm-x-wrap {
-  position: relative;
-}
-
 .pm-side-btn--connected {
   border-color: rgba(34, 211, 238, .4);
   background: rgba(34, 211, 238, .08);
+}
+
+.pm-x-wrap {
+  position: relative;
 }
 
 .pm-x-disconnect {

--- a/docs/frontend-unification-plan-2026-04-30-ru.md
+++ b/docs/frontend-unification-plan-2026-04-30-ru.md
@@ -44,19 +44,19 @@
 ## Пошаговый rollout (без большого взрыва)
 
 ### Этап 1 (1 спринт)
-1. Зафиксировать naming convention (BEM/utility hybrid).
-2. Добавить `ui-btn` и мигрировать 2 экрана: старт + game over.
-3. Добавить линт-правило/скрипт: запрет новых button-классов без `ui-btn`.
+1. ✅ Зафиксировать naming convention (BEM/utility hybrid).
+2. ✅ Добавить `ui-btn` и мигрировать 2 экрана: старт + game over.
+3. ✅ Добавить линт-правило/скрипт: запрет новых button-классов без `ui-btn`.
 
 ### Этап 2 (1–2 спринта)
-1. Миграция store/player-menu/auth кнопок.
-2. Унификация typography scale.
-3. Удаление дублирующих CSS-блоков после миграции.
+1. ✅ Миграция store/player-menu/auth кнопок.
+2. ✅ Унификация typography scale.
+3. ✅ Удаление дублирующих/осиротевших CSS-блоков после миграции выполнено.
 
 ### Этап 3 (1 спринт)
-1. Перенос legacy JS в feature-структуру.
-2. Thin-adapters для обратной совместимости.
-3. Финальная чистка dead selectors и orphan utils.
+1. 🔄 Частично: добавлены feature/core/integration entry-points, начат перенос точек входа (main/game/store/posthog + runtime imports).
+2. 🔄 Частично: добавлены thin-adapters (re-export), переведены ключевые game/bootstrap/runtime/ui/api/player-menu/share/store импорты на feature/core adapters.
+3. ⏳ Финальная чистка dead selectors и orphan utils.
 
 ## KPI успеха
 - Количество уникальных button-классов: снизить минимум на 40%.
@@ -65,6 +65,6 @@
 - Mobile perf gate: без деградации p95 кадра/интеракций.
 
 ## Definition of Done
-- Все новые кнопки используют только `ui-btn`-систему.
+- ✅ Все новые кнопки используют только `ui-btn`-систему (проверяется скриптом `check-ui-buttons`).
 - Нет прямого копирования старых button-стилей в новых фичах.
 - Документация по UI-конвенциям добавлена в `docs/`.

--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
 <!-- ===== WALLET + INFO ===== -->
 <div id="walletCorner">
   <div class="wallet-corner-row">
-    <button class="wallet-btn-corner" id="walletBtn">Connect Wallet</button>
+    <button class="wallet-btn-corner ui-btn ui-btn--secondary ui-btn--sm" id="walletBtn">Connect Wallet</button>
     <span class="tg-account-badge" id="tgAccountBadge" hidden></span>
-    <button class="player-avatar-btn" id="playerAvatarBtn" hidden aria-label="Open player menu">
+    <button class="player-avatar-btn ui-btn ui-btn--icon ui-btn--ghost" id="playerAvatarBtn" hidden aria-label="Open player menu">
       <img src="img/ursas_bear_head_white.svg" class="player-avatar-icon" alt="" aria-hidden="true">
     </button>
   </div>
@@ -97,8 +97,8 @@
 
       <!-- In-game audio toggles -->
       <div class="game-audio-nav">
-        <button class="game-audio-btn" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-        <button class="game-audio-btn" id="gameMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameMusicBtn" data-action="toggle-music" title="Music">🎵</button>
       </div>
 
     </div>
@@ -109,8 +109,8 @@
 <div id="gameStart">
 
   <div class="start-audio-nav">
-    <button class="store-nav-btn" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
   </div>
 
   <div class="bear-wrapper" id="bear3d">
@@ -125,9 +125,9 @@
   <div class="new-title">URSASS TUBE</div>
 
   <div class="new-buttons">
-    <button class="btn-new btn-new-store menu-hidden" id="storeBtn" data-action="show-store">STORE</button>
+    <button class="btn-new btn-new-store menu-hidden ui-btn ui-btn--secondary ui-btn--lg" id="storeBtn" data-action="show-store">STORE</button>
     <div class="start-btn-wrap">
-      <button class="btn-new btn-new-primary" id="startBtn" data-action="start-game"><span class="btn-label">START GAME</span></button>
+      <button class="btn-new btn-new-primary ui-btn ui-btn--primary ui-btn--lg" id="startBtn" data-action="start-game"><span class="btn-label">START GAME</span></button>
       <div id="startHook" class="start-hook" hidden aria-hidden="true">
         <span class="start-hook-main">
           <span class="start-hook-arrow">←</span>
@@ -178,8 +178,8 @@
 
   <!-- Game Over audio toggles (same style as Store) -->
   <div class="go-audio-nav">
-    <button class="store-nav-btn" id="goSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn" id="goMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="goSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="goMusicBtn" data-action="toggle-music" title="Music">🎵</button>
   </div>
 
   <div class="go-title" id="goTitle">GAME OVER</div>
@@ -203,9 +203,9 @@
   </div>
 
   <div class="go-buttons">
-    <button class="go-btn go-btn-restart" id="restartBtn"><span class="btn-label">PLAY AGAIN</span></button>
-    <button class="go-btn go-btn-share" id="shareResultBtn">SHARE RESULT</button>
-    <button class="go-btn go-btn-menu" id="menuBtn">MENU</button>
+    <button class="go-btn go-btn-restart ui-btn ui-btn--primary ui-btn--lg" id="restartBtn"><span class="btn-label">PLAY AGAIN</span></button>
+    <button class="go-btn go-btn-share ui-btn ui-btn--secondary" id="shareResultBtn">SHARE RESULT</button>
+    <button class="go-btn go-btn-menu ui-btn ui-btn--ghost" id="menuBtn">MENU</button>
   </div>
 
   <div class="go-lb-wrap">
@@ -230,20 +230,20 @@
 
 <!-- ===== PLAYER MENU OVERLAY ===== -->
 <div id="playerMenuOverlay" class="player-menu-overlay" hidden>
-  <button class="pm-back-btn" id="pmBackBtn" aria-label="Back">←</button>
+  <button class="pm-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="pmBackBtn" aria-label="Back">←</button>
 
   <div class="pm-content">
     <!-- Center column -->
     <div class="pm-center">
       <div class="pm-rank">You're <span id="pmRankNumber">#—</span></div>
       <div class="pm-best">Best score: <span id="pmBestScore">0</span></div>
-      <button class="pm-side-btn pm-connect-wallet-top" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
+      <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
 
       <div class="pm-row pm-nickname-row">
         <label for="pmNicknameInput" class="pm-label">Nickname</label>
         <div class="pm-nickname-field">
           <input id="pmNicknameInput" class="pm-input pm-input--field" type="text" maxlength="16" placeholder="Your nickname" />
-          <button id="pmNicknameSaveBtn" class="pm-side-btn">Save</button>
+          <button id="pmNicknameSaveBtn" class="pm-side-btn ui-btn ui-btn--primary ui-btn--sm">Save</button>
         </div>
       </div>
       <div class="pm-row pm-display-row">
@@ -259,8 +259,8 @@
         <label class="pm-label" for="pmReferralLink">Your referral link</label>
         <div class="pm-share-row">
           <input id="pmReferralLink" class="pm-input pm-input--field pm-input-referral" type="text" readonly aria-label="Referral link">
-          <button id="pmCopyRefBtn" class="pm-side-btn" aria-label="Copy referral link">COPY</button>
-          <button id="pmShareBtn" class="pm-share-btn is-share" disabled>SHARE RESULT</button>
+          <button id="pmCopyRefBtn" class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" aria-label="Copy referral link">COPY</button>
+          <button id="pmShareBtn" class="pm-share-btn is-share ui-btn ui-btn--secondary ui-btn--sm" disabled>SHARE RESULT</button>
         </div>
       </div>
       <div class="pm-row">
@@ -295,10 +295,10 @@
 
     <!-- Right column: account connections -->
     <aside class="pm-side">
-      <button class="pm-side-btn" id="pmConnectTelegramBtn">Connect Telegram</button>
+      <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
       <div class="pm-side-x pm-x-wrap" id="pmXBlock">
-        <button class="pm-side-btn" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
-        <button class="pm-x-disconnect" id="pmXDisconnectBtn" hidden>Disconnect X</button>
+        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
+        <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
       </div>
     </aside>
   </div>
@@ -309,9 +309,9 @@
 
   <!-- Fixed nav: sfx, music, back -->
   <div class="store-fixed-nav">
-    <button class="store-nav-btn" id="storeSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn" id="storeMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-    <button class="store-nav-btn" id="storeBackBtn" title="Back">←</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeBackBtn" title="Back">←</button>
   </div>
 
   <div class="store-header">
@@ -329,8 +329,8 @@
   </div>
 
   <div class="store-tabs" role="tablist" aria-label="Store sections">
-    <button class="store-tab is-active" id="storeUpgradeTab" type="button" data-store-tab="upgrade" aria-selected="true">Upgrade</button>
-    <button class="store-tab" id="storeDonationTab" type="button" data-store-tab="donation" aria-selected="false">Donation</button>
+    <button class="store-tab is-active ui-btn ui-btn--ghost ui-btn--sm" id="storeUpgradeTab" type="button" data-store-tab="upgrade" aria-selected="true">Upgrade</button>
+    <button class="store-tab ui-btn ui-btn--ghost ui-btn--sm" id="storeDonationTab" type="button" data-store-tab="donation" aria-selected="false">Donation</button>
   </div>
 
   <section class="store-panel store-panel--upgrade is-active" id="storeUpgradePanel" data-store-panel="upgrade">
@@ -410,7 +410,7 @@
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> Rides — pack of rides</span>
         <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
       </div>
-      <button class="store-single-buy" id="store-rides_pack" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <img src="img/icon_gold.png" style="width: 14px; height: 14px; vertical-align: middle;"> 70
+      <button class="store-single-buy ui-btn ui-btn--secondary ui-btn--sm" id="store-rides_pack" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <img src="img/icon_gold.png" style="width: 14px; height: 14px; vertical-align: middle;"> 70
       </button>
     </div>
 
@@ -671,9 +671,9 @@
 <!-- ===== RULES OVERLAY ===== -->
 <div id="rulesScreen">
   <div class="rules-fixed-nav">
-    <button class="store-nav-btn" id="rulesSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn" id="rulesMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-    <button class="store-nav-btn" id="rulesBackBtn" title="Back">←</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesBackBtn" title="Back">←</button>
   </div>
 
   <div class="rules-header">

--- a/js/api.js
+++ b/js/api.js
@@ -8,8 +8,8 @@ import { DOM, getGameplayProgressSnapshot } from './state.js';
 import { WC } from './walletconnect.js';
 import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGameOverLeaderboardNotice, setGameOverPrompt } from './ui.js';
 import { validatePlayerInsights, getRankBucket } from './game/leaderboard-insights.js';
-import { isTelegramAuthMode, hasWalletAuthSession, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot, isTelegramMiniApp } from './auth.js';
-import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './store.js';
+import { isTelegramAuthMode, hasWalletAuthSession, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot, isTelegramMiniApp } from './features/auth/index.js';
+import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './features/store/index.js';
 
 const SAVE_RESULT_STATUS = Object.freeze({
   SAVED: 'saved',

--- a/js/core/runtime.js
+++ b/js/core/runtime.js
@@ -1,0 +1,15 @@
+export {
+  VIEWPORT_SYNC_EVENT,
+  initializeCoreLifecycle,
+  initializeTelegramViewportLifecycle,
+  initializeMetaMaskLifecycle,
+  initializePingLifecycle,
+  subscribeAppVisibilityLifecycle,
+  PERF_SAMPLE_EVENT
+} from '../runtime-lifecycle.js';
+
+export {
+  APP_VISIBILITY_EVENT,
+  SCREEN_CHANGED_EVENT,
+  SMOKE_STEP_COMPLETED_EVENT
+} from '../runtime-events.js';

--- a/js/features/auth/index.js
+++ b/js/features/auth/index.js
@@ -1,0 +1,21 @@
+export {
+  initAuth,
+  isTelegramMiniApp,
+  connectWalletAuth,
+  disconnectAuth,
+  hasWalletAuthSession,
+  isWalletAuthMode,
+  setAuthCallbacks,
+  getAuthStateSnapshot
+} from '../../auth.js';
+
+export {
+  hasAuthenticatedSession,
+  getPrimaryAuthIdentifier,
+  getSigningWalletAddress,
+  getTelegramAuthIdentifier,
+  linkTelegram,
+  linkWallet
+} from '../../auth.js';
+
+export * from '../../auth-service.js';

--- a/js/features/game/bootstrap.js
+++ b/js/features/game/bootstrap.js
@@ -1,0 +1,5 @@
+import { initGameBootstrap } from '../../game-runtime.js';
+
+export function bootstrapGameFeature() {
+  initGameBootstrap();
+}

--- a/js/features/player-menu/index.js
+++ b/js/features/player-menu/index.js
@@ -1,0 +1,6 @@
+export {
+  initPlayerMenu,
+  openPlayerMenu,
+  refreshPlayerMenu,
+  isPlayerMenuOpen
+} from '../../player-menu/index.js';

--- a/js/features/store/index.js
+++ b/js/features/store/index.js
@@ -1,0 +1,20 @@
+export {
+  loadPlayerUpgrades,
+  updateRidesDisplay,
+  resetStoreState,
+  loadUnauthGameConfig,
+  isStoreAvailable,
+  isUnauthRuntimeMode,
+  loadPlayerRides,
+  useRide,
+  showRules,
+  hideRules,
+  hasRideLimit,
+  isEligibleForLeaderboardFlow,
+  canPersistProgress,
+  applyStoreDefaultLockState,
+  updateStoreUI,
+  setActiveStoreTab,
+  closeDonationModal,
+  getStoreStateSnapshot
+} from '../../store.js';

--- a/js/game-runtime.js
+++ b/js/game-runtime.js
@@ -1,7 +1,7 @@
 import { initStoreBootstrap } from './store.js';
 import { initInputHandlers } from './input.js';
 import { initGame } from './game.js';
-import { initializeCoreLifecycle } from './runtime-lifecycle.js';
+import { initializeCoreLifecycle } from './core/runtime.js';
 import { logger } from './logger.js';
 import { setupAnalyticsDelivery } from './analytics-delivery.js';
 import { setupPostHogBridge } from './posthog-bridge.js';

--- a/js/game.js
+++ b/js/game.js
@@ -5,15 +5,15 @@ import { createRenderSnapshot } from './render-snapshot.js';
 import { createGameRenderer, getViewportSize } from './renderers/index.js';
 import { assetManager } from './assets.js';
 import { showStore, hideStore, updateUI } from './ui.js';
-import { loadPlayerRides, useRide, updateRidesDisplay, showRules, hideRules, hasRideLimit, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './store.js';
+import { loadPlayerRides, useRide, updateRidesDisplay, showRules, hideRules, hasRideLimit, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './features/store/index.js';
 import { getPlayerRides } from './store/rides-service.js';
 import { getGameplayUpgradeSnapshot } from './store/upgrades-service.js';
 import { perfMonitor } from './perf.js';
 import { initGameBootstrapFlow } from './game/bootstrap.js';
 import { createGameLoopController } from './game/loop.js';
 import { createGameSessionController } from './game/session.js';
-import { VIEWPORT_SYNC_EVENT } from './runtime-lifecycle.js';
-import { hasWalletAuthSession } from './auth.js';
+import { VIEWPORT_SYNC_EVENT } from './core/runtime.js';
+import { hasWalletAuthSession } from './features/auth/index.js';
 import { logger } from './logger.js';
 
 let activeRenderer = null;

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -3,10 +3,10 @@ import { audioManager, restoreAudioSettings, initAudioToggles } from '../audio.j
 import { DOM, gameState } from '../state.js';
 import { assetManager } from '../assets.js';
 import { updateGameOverLeaderboardNotice, getLeaderboardSnapshot } from '../ui.js';
-import { loadPlayerUpgrades, updateRidesDisplay, resetStoreState, loadUnauthGameConfig, isStoreAvailable, isUnauthRuntimeMode } from '../store.js';
+import { loadPlayerUpgrades, updateRidesDisplay, resetStoreState, loadUnauthGameConfig, isStoreAvailable, isUnauthRuntimeMode } from '../features/store/index.js';
 import { perfMonitor } from '../perf.js';
-import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks, getAuthStateSnapshot } from '../auth.js';
-import { initializePingLifecycle, subscribeAppVisibilityLifecycle } from '../runtime-lifecycle.js';
+import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks, getAuthStateSnapshot } from '../features/auth/index.js';
+import { initializePingLifecycle, subscribeAppVisibilityLifecycle, SCREEN_CHANGED_EVENT } from '../core/runtime.js';
 import { initializeTelegramIntegration } from './integrations/telegram.js';
 import { initializeMetaMaskIntegration } from './integrations/metamask.js';
 import { logger } from '../logger.js';
@@ -14,11 +14,10 @@ import { notifyError, notifySuccess } from '../notifier.js';
 import { trackAnalyticsEvent } from '../analytics.js';
 import { initAiMode } from '../ai-mode.js';
 import { shouldShowFirstRunHint } from './onboarding-hints.js';
-import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } from '../player-menu/index.js';
+import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } from '../features/player-menu/index.js';
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { captureReferralFromUrl, sendReferralAfterAuth } from '../referral/referralCapture.js';
-import { SCREEN_CHANGED_EVENT } from '../runtime-events.js';
-import { identifyPostHogUser, resetPostHogUser } from '../posthog.js';
+import { identifyPostHogUser, resetPostHogUser } from '../integrations/posthog/index.js';
 
 captureReferralFromUrl();
 

--- a/js/game/integrations/metamask.js
+++ b/js/game/integrations/metamask.js
@@ -1,4 +1,4 @@
-import { initializeMetaMaskLifecycle } from '../../runtime-lifecycle.js';
+import { initializeMetaMaskLifecycle } from '../../core/runtime.js';
 import { getInjectedEthereumProvider } from '../../ethereum-provider.js';
 import { logger } from '../../logger.js';
 

--- a/js/game/integrations/telegram.js
+++ b/js/game/integrations/telegram.js
@@ -1,4 +1,4 @@
-import { initializeTelegramViewportLifecycle } from '../../runtime-lifecycle.js';
+import { initializeTelegramViewportLifecycle } from '../../core/runtime.js';
 import { logger } from '../../logger.js';
 
 let cleanupTelegramLifecycle = () => {};

--- a/js/integrations/posthog/index.js
+++ b/js/integrations/posthog/index.js
@@ -1,0 +1,6 @@
+export {
+  initPostHog,
+  capturePostHogEvent,
+  identifyPostHogUser,
+  resetPostHogUser
+} from '../../posthog.js';

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,12 @@
 import { initLogger } from './logger.js';
 import { stabilizeMenuLoad } from './stabilize-menu.js';
+import { bootstrapGameFeature } from './features/game/bootstrap.js';
 import {
   initPostHog,
   capturePostHogEvent,
   identifyPostHogUser,
   resetPostHogUser
-} from './posthog.js';
+} from './integrations/posthog/index.js';
 import '../css/style.css';
 
 if (typeof window !== 'undefined') {
@@ -54,8 +55,7 @@ async function bootstrap() {
     stabilizeMenuLoad();
     initPostHog();
 
-    const { initGameBootstrap } = await import('./game-runtime.js');
-    initGameBootstrap();
+    bootstrapGameFeature();
   } catch (error) {
     console.error('❌ Bootstrap failed:', error);
     renderBootstrapFallback(error);

--- a/js/perf-stabilization.js
+++ b/js/perf-stabilization.js
@@ -5,7 +5,7 @@ import {
   SCREEN_CHANGED_EVENT,
   SMOKE_STEP_COMPLETED_EVENT,
   VIEWPORT_SYNC_EVENT
-} from './runtime-events.js';
+} from './core/runtime.js';
 
 const PERF_SUMMARY_EVENT = 'ursas:perf-summary';
 const MAX_SAMPLES = 180;

--- a/js/perf.js
+++ b/js/perf.js
@@ -2,7 +2,7 @@ import { BACKEND_URL } from './config.js';
 import { request } from './request.js';
 import { gameState } from './state.js';
 import { logger } from './logger.js';
-import { PERF_SAMPLE_EVENT } from './runtime-lifecycle.js';
+import { PERF_SAMPLE_EVENT } from './core/runtime.js';
 
 /**
  * LOW_PERF_MODE – detected once at module load time.

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -1,6 +1,6 @@
 import { DOM } from '../state.js';
 import { fetchMyProfile, fetchCoinHistory, disconnectX, setNickname, setLeaderboardDisplay } from '../api.js';
-import { hasAuthenticatedSession, linkTelegram, linkWallet } from '../auth.js';
+import { hasAuthenticatedSession, linkTelegram, linkWallet } from '../features/auth/index.js';
 import { isTelegramAuthMode } from '../auth-state.js';
 import { showPlayerMenuScreen, hidePlayerMenuScreen } from '../screens.js';
 import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';

--- a/js/posthog-bridge.js
+++ b/js/posthog-bridge.js
@@ -1,5 +1,5 @@
 import { ANALYTICS_TRACK_EVENT } from './analytics.js';
-import { capturePostHogEvent } from './posthog.js';
+import { capturePostHogEvent } from './integrations/posthog/index.js';
 import { logger } from './logger.js';
 
 let bridgeStarted = false;

--- a/js/screens.js
+++ b/js/screens.js
@@ -1,5 +1,5 @@
 import { DOM } from './state.js';
-import { SCREEN_CHANGED_EVENT } from './runtime-events.js';
+import { SCREEN_CHANGED_EVENT } from './core/runtime.js';
 
 function publishScreenChange(screen) {
   window.dispatchEvent(new CustomEvent(SCREEN_CHANGED_EVENT, {

--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -1,6 +1,6 @@
 import { fetchMyProfile, startShare, confirmShare, getXOAuthAuthorizeUrl } from '../api.js';
 import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';
-import { isTelegramMiniApp } from '../auth.js';
+import { isTelegramMiniApp } from '../features/auth/index.js';
 import { logger } from '../logger.js';
 import { analytics } from '../analytics-events.js';
 

--- a/js/store/donation-controller.js
+++ b/js/store/donation-controller.js
@@ -1,6 +1,6 @@
 import { logger } from '../logger.js';
 import { isAuthenticated, getAuthIdentifier } from '../api.js';
-import { isTelegramAuthMode, getPrimaryAuthIdentifier } from '../auth.js';
+import { isTelegramAuthMode, getPrimaryAuthIdentifier } from '../features/auth/index.js';
 import { getDonationProducts, getDonationHistory, getDonationPayment } from '../donation-service.js';
 import { createDonationUiController, createEmptyDonationUiState, createEmptyDonationPaymentState } from './donation-ui.js';
 import {
@@ -18,7 +18,7 @@ import {
 } from './donation-helpers.js';
 import { createDonationFlowActions } from './donation-flow.js';
 import { trackAnalyticsEvent } from '../analytics.js';
-import { capturePostHogEvent } from '../posthog.js';
+import { capturePostHogEvent } from '../integrations/posthog/index.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';

--- a/js/store/donation-flow.js
+++ b/js/store/donation-flow.js
@@ -21,7 +21,7 @@ import {
   invokeDonationWallet
 } from './donation-helpers.js';
 import { trackAnalyticsEvent } from '../analytics.js';
-import { capturePostHogEvent } from '../posthog.js';
+import { capturePostHogEvent } from '../integrations/posthog/index.js';
 
 const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired']);
 const DONATION_PENDING_STATUS = 'pending';

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,8 +1,8 @@
 import { CONFIG } from './config.js';
 import { DOM, gameState, player } from './state.js';
 import { syncAllAudioUI } from './audio.js';
-import { getAuthStateSnapshot, hasWalletAuthSession, hasAuthenticatedSession } from './auth.js';
-import { applyStoreDefaultLockState, loadPlayerUpgrades, updateStoreUI, setActiveStoreTab, closeDonationModal, isStoreAvailable, isUnauthRuntimeMode, getStoreStateSnapshot } from './store.js';
+import { getAuthStateSnapshot, hasWalletAuthSession, hasAuthenticatedSession } from './features/auth/index.js';
+import { applyStoreDefaultLockState, loadPlayerUpgrades, updateStoreUI, setActiveStoreTab, closeDonationModal, isStoreAvailable, isUnauthRuntimeMode, getStoreStateSnapshot } from './features/store/index.js';
 import { createElement, createIconAtlas, clearNode } from './dom-render.js';
 import { showStoreScreen, hideStoreScreen } from './screens.js';
 import { logger } from './logger.js';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "npm run check:conflicts && vite build",
     "preview": "vite preview",
-    "check": "npm run check:syntax && npm run check:static-analysis && npm run check:unused-code && npm run check:no-window-assign && npm run check:asset-paths && npm run check:no-legacy-canvas-runtime && npm run test:e2e-smoke && npm run test:request",
+    "check": "npm run check:syntax && npm run check:static-analysis && npm run check:ui-buttons && npm run check:unused-code && npm run check:no-window-assign && npm run check:asset-paths && npm run check:no-legacy-canvas-runtime && npm run test:e2e-smoke && npm run test:request",
     "check:security": "bash -lc \"unset NPM_CONFIG_HTTP_PROXY npm_config_http_proxy NPM_CONFIG_HTTPS_PROXY npm_config_https_proxy HTTP_PROXY HTTPS_PROXY http_proxy https_proxy; npm audit --omit=dev --audit-level=moderate\"",
     "check:asset-paths": "node scripts/check-public-asset-paths.mjs",
     "check:mobile-perf-gate": "node scripts/check-mobile-perf-gate.mjs",
@@ -28,7 +28,8 @@
     "check:unused-code": "node scripts/check-unused-code.mjs",
     "check:stage-b": "node scripts/check-stage-b.mjs",
     "report:stage-c-audit": "node scripts/build-stage-c-report.mjs",
-    "report:stage-d-burndown": "node scripts/build-stage-d-report.mjs"
+    "report:stage-d-burndown": "node scripts/build-stage-d-report.mjs",
+    "check:ui-buttons": "node scripts/check-ui-buttons.mjs"
   },
   "devDependencies": {
     "vite": "^7.1.0"

--- a/scripts/check-ui-buttons.mjs
+++ b/scripts/check-ui-buttons.mjs
@@ -1,0 +1,43 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const rootDir = new URL('..', import.meta.url).pathname;
+const skipDirs = new Set(['node_modules', '.git', 'dist', 'vendor']);
+
+function collectHtmlFiles(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (skipDirs.has(entry.name)) continue;
+      collectHtmlFiles(join(dir, entry.name), acc);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.html')) acc.push(join(dir, entry.name));
+  }
+  return acc;
+}
+
+const htmlFiles = collectHtmlFiles(rootDir);
+const violations = [];
+let buttonCount = 0;
+
+for (const file of htmlFiles) {
+  const html = readFileSync(file, 'utf8');
+  const buttonTags = [...html.matchAll(/<button\b[^>]*>/g)];
+  buttonCount += buttonTags.length;
+
+  for (const match of buttonTags) {
+    const tag = match[0];
+    const classMatch = tag.match(/class="([^"]*)"/);
+    const classes = (classMatch?.[1] ?? '').split(/\s+/).filter(Boolean);
+    const hasUi = classes.includes('ui-btn');
+    if (!hasUi) violations.push({ file, tag });
+  }
+}
+
+if (violations.length) {
+  console.error('Buttons without .ui-btn found:');
+  violations.forEach(({ file, tag }) => console.error(`- ${file}: ${tag}`));
+  process.exit(1);
+}
+
+console.log(`UI button check passed (${buttonCount} buttons scanned in ${htmlFiles.length} HTML files).`);

--- a/scripts/check-unused-code.mjs
+++ b/scripts/check-unused-code.mjs
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,16 +9,30 @@ const rootDir = path.resolve(__dirname, '..');
 
 const BASELINE_UNUSED_EXPORTS = new Set([
   'js/logger.js:logger',
-  'js/player-menu/controller.js:initPlayerMenu',
-  'js/player-menu/controller.js:openPlayerMenu',
-  'js/player-menu/controller.js:refreshPlayerMenu',
-  'js/player-menu/controller.js:isPlayerMenuOpen',
-  'js/game-runtime.js:initGameBootstrap',
 ]);
 
 function getFiles() {
-  const out = execSync("rg --files js scripts -g '*.js' -g '*.mjs'", { cwd: rootDir, encoding: 'utf8' });
-  return out.trim().split('\n').filter(Boolean);
+  try {
+    const out = execSync("rg --files js scripts -g '*.js' -g '*.mjs'", { cwd: rootDir, encoding: 'utf8' });
+    return out.trim().split('\n').filter(Boolean);
+  } catch {
+    const roots = ['js', 'scripts'];
+    const files = [];
+    const walk = (dir) => {
+      for (const entry of readdirSync(path.join(rootDir, dir), { withFileTypes: true })) {
+        const rel = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(rel);
+          continue;
+        }
+        if (entry.isFile() && (rel.endsWith('.js') || rel.endsWith('.mjs'))) {
+          files.push(rel.replaceAll(path.sep, '/'));
+        }
+      }
+    };
+    for (const dir of roots) walk(dir);
+    return files.sort();
+  }
 }
 
 function resolveImport(fromFile, spec) {
@@ -40,6 +54,7 @@ for (const file of getFiles()) {
 
 const exportDeclRE = /export\s+(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g;
 const exportListRE = /export\s*\{([^}]+)\}/g;
+const exportFromRE = /export\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
 const importNamedRE = /import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
 const importDefaultRE = /import\s+([A-Za-z_$][\w$]*)\s+from\s*['"]([^'"]+)['"]/g;
 
@@ -52,6 +67,9 @@ for (const [file, info] of moduleMap.entries()) {
       const left = n.split(' as ')[0].trim();
       if (left && left !== 'default') info.exports.add(left);
     }
+  }
+  while ((m = exportFromRE.exec(info.content)) !== null) {
+    info.imports.push({ source: m[2], names: m[1].split(',').map((s) => s.trim().split(' as ')[0].trim()) });
   }
 
   while ((m = importNamedRE.exec(info.content)) !== null) {


### PR DESCRIPTION
### Motivation
- Introduce a consistent UI button system and typography scale to reduce duplicated button styles and enable incremental migration. 
- Migrate existing button usages in several screens to the new `ui-btn` convention to improve maintainability and accessibility. 
- Introduce a clear feature/core entrypoint structure to enable gradual modularization of JS domains (auth, store, player-menu, game, integrations). 

### Description
- Added a new UI tokens and `ui-btn` component system in `css/style.css` including typography tokens (`--font-*`), BEM/utility naming docblock and a comprehensive set of modifiers (`--primary`, `--secondary`, `--icon`, sizes, states). 
- Updated many HTML templates in `index.html` to migrate existing buttons to the `ui-btn` classes and replaced several legacy button style blocks, aligning UI markup with the new system. 
- Created feature and core re-export entrypoints under `js/features/*` and `js/core/runtime.js` (auth, store, player-menu, game bootstrap, posthog integration), and updated numerous imports across the codebase to use these new paths. 
- Added `scripts/check-ui-buttons.mjs` and wired it into `package.json` as `check:ui-buttons`, improved `scripts/check-unused-code.mjs` robustness, and added `integrations/posthog/index.js` re-export for consistent integration boundaries. 

### Testing
- Ran the new UI lint check via `node scripts/check-ui-buttons.mjs` which reported no violations and exited successfully. 
- Executed static analysis and syntax checks via `npm run check:static-analysis` and `npm run check:syntax`, both of which completed without errors. 
- Executed unit/request and smoke test suites via `npm run test:request` and `npm run test:e2e-smoke`, and both suites passed in the validation run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38a1244d08320ac64e453ef22c785)