### PR TITLE
Defer Phaser renderer and main loop to prevent start-screen overheating

### DIFF
--- a/docs/start-screen-overheating-patch-plan-2026-04-30-ru.md
+++ b/docs/start-screen-overheating-patch-plan-2026-04-30-ru.md
@@ -1,0 +1,69 @@
+# Ursass Tube — Patch Plan: перегрев на стартовом экране (Telegram Mini App)
+
+**Дата:** 30 апреля 2026  
+**Контекст:** предрелизный критический perf-issue на мобильных устройствах
+
+## Проблема
+
+На стартовом экране до нажатия `Start Game` запускался тяжёлый runtime/рендер-path, что приводило к повышенной CPU/GPU нагрузке и нагреву устройства.
+
+## Подтверждённые причины
+
+1. Инициализация Phaser renderer происходила на bootstrap (до старта ранa).
+2. Main loop запускался слишком рано.
+3. Стартовое меню было UI-оверлеем, но игровой runtime уже существовал.
+
+## Цель патча
+
+- Поднимать Phaser только после нажатия `Start Game`.
+- Держать меню лёгким (без фонового тяжёлого рендера).
+- После выхода в меню — опускать нагрузку обратно.
+- Сохранить игровой feel: target FPS **не снижать**.
+
+## Технический план (по файлам)
+
+### 1) `js/game.js`
+
+- Ввести ленивый lifecycle renderer:
+  - `ensureRendererReady()`
+  - `destroyRenderer()`
+  - сериализация через `rendererInitPromise`.
+- Убрать eager renderer init из `initGame()`.
+- Передать lifecycle-функции в session controller.
+
+### 2) `js/game/session.js`
+
+- В `startGame` перед `actualStartGame` вызывать `ensureRendererReady()`.
+- После инициализации делать `syncViewport()` и только потом запуск run.
+- На `goToMainMenu()` вызывать `destroyRenderer()` для полного teardown.
+- Запуск loop только при первом gameplay (`gameplayLoopStarted`).
+
+### 3) `js/game/bootstrap.js`
+
+- Убрать автоматический вызов `startMainLoop()` на bootstrap.
+- Оставить deferred-подход: loop стартует в gameplay-пути.
+
+## Риски и контроль
+
+- **Риск:** первый старт ранa может занять немного больше времени.
+  - **Митигировать:** использовать transition/preload слой и fallback на ошибку init.
+- **Риск:** race-condition при повторных нажатиях `Start`.
+  - **Митигировать:** единый `rendererInitPromise`.
+
+## Acceptance criteria
+
+1. На меню до `Start Game` Phaser runtime не выполняет тяжёлую отрисовку.
+2. После `Start Game` runtime и сцена поднимаются в рамках transition/preload.
+3. После `Game Over -> Menu` нагрузка снова падает.
+4. FPS gameplay остаётся 60-target.
+
+## Smoke-checklist
+
+1. Open app -> 60s idle on menu (без заметного нагрева).
+2. Start Game -> корректный preload -> старт ранa.
+3. Game Over -> Menu -> повторный idle (нагрузка ниже gameplay).
+4. Повторить цикл 3–5 раз (без деградации/утечек).
+
+## Статус
+
+План оформлен в репозитории как отдельный документ для трекинга и ревью.

--- a/docs/start-screen-overheating-validation-2026-05-01.md
+++ b/docs/start-screen-overheating-validation-2026-05-01.md
@@ -1,0 +1,32 @@
+# Start-screen overheating — validation run (2026-05-01)
+
+## Scope
+Validation of deferred Phaser init / deferred loop / render gating changes for menu-load reduction.
+
+## Commands executed
+
+1. `npm test`
+2. `npm run lint`
+3. `npm run build`
+4. `npm run test:e2e-smoke`
+
+## Results
+
+- `npm test`: **PASS** (82/82 tests passed).
+- `npm run lint`: **PASS** (`check:syntax` + `check:static-analysis`).
+- `npm run build`: **PASS** (Vite build successful; non-blocking chunk-size warning present).
+- `npm run test:e2e-smoke`: **PASS**.
+
+### MIG-08 synthetic smoke snapshot
+
+- capturedAt: `2026-05-01T10:54:20.267Z`
+- sampleCount: `120`
+- fpsP50 / fpsP95: `60 / 62`
+- frameMsP50 / frameMsP95: `16.67 / 17.24`
+- pingMsP50 / pingMsP95: `73 / 76`
+- smoke checklist: `6 / 6` complete
+
+## Notes
+
+- This smoke run is synthetic (scripted lifecycle/perf flow), useful as a regression gate.
+- Real-device Telegram Mini App thermal/perf verification is still recommended before release.

--- a/js/game.js
+++ b/js/game.js
@@ -13,11 +13,15 @@ import { initGameBootstrapFlow } from './game/bootstrap.js';
 import { createGameLoopController } from './game/loop.js';
 import { createGameSessionController } from './game/session.js';
 import { VIEWPORT_SYNC_EVENT } from './runtime-lifecycle.js';
+import { SCREEN_CHANGED_EVENT } from './runtime-events.js';
 import { hasWalletAuthSession } from './auth.js';
 import { logger } from './logger.js';
 
 let activeRenderer = null;
 let viewportSyncBound = false;
+let rendererInitPromise = null;
+let gameplayRenderEnabled = false;
+let screenRenderGateBound = false;
 const PHASER_LOADING_OVERLAY_ID = 'phaserLoadingOverlay';
 let loadingOverlayElements = null;
 
@@ -44,6 +48,55 @@ function bindViewportSyncLifecycle() {
   if (viewportSyncBound) return;
   window.addEventListener(VIEWPORT_SYNC_EVENT, syncRendererViewport);
   viewportSyncBound = true;
+}
+
+function bindScreenRenderGate() {
+  if (screenRenderGateBound) return;
+  window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
+    const screen = event?.detail?.screen || 'menu';
+    gameplayRenderEnabled = screen === 'gameplay';
+  });
+  screenRenderGateBound = true;
+}
+
+function isRendererReady() {
+  return Boolean(activeRenderer);
+}
+
+async function ensureRendererReady({ forceRecreate = false } = {}) {
+  if (forceRecreate && activeRenderer) {
+    activeRenderer.destroy();
+    activeRenderer = null;
+  }
+
+  if (activeRenderer) {
+    return activeRenderer;
+  }
+
+  if (!rendererInitPromise) {
+    rendererInitPromise = (async () => {
+      const { width, height } = getViewportDimensions();
+      const initialSnapshot = createSnapshotForRenderer(width, height);
+      const renderer = await createGameRenderer(initialSnapshot);
+      activeRenderer = renderer;
+      bindViewportSyncLifecycle();
+      bindScreenRenderGate();
+      syncRendererViewport();
+      return renderer;
+    })();
+  }
+
+  try {
+    return await rendererInitPromise;
+  } finally {
+    rendererInitPromise = null;
+  }
+}
+
+function destroyRenderer() {
+  rendererInitPromise = null;
+  activeRenderer?.destroy?.();
+  activeRenderer = null;
 }
 
 function requestViewportSync() {
@@ -148,6 +201,7 @@ const loopController = createGameLoopController({
     renderLoadingOverlay(progress);
   },
   renderFrame: () => {
+    if (!gameplayRenderEnabled) return;
     const { width, height } = getViewportDimensions();
     activeRenderer?.render(createSnapshotForRenderer(width, height));
   },
@@ -186,23 +240,18 @@ const sessionController = createGameSessionController({
   getBestScore,
   setBestDistance,
   getBestDistance,
+  ensureRendererReady,
+  destroyRenderer,
   initializeGameplayRun,
   applyGameplayUpgradeState,
   clearGameplayCollections
 });
 
 async function initGame() {
-  const { width, height } = getViewportDimensions();
-  const initialSnapshot = createSnapshotForRenderer(width, height);
-  activeRenderer = await createGameRenderer(initialSnapshot);
-  bindViewportSyncLifecycle();
-  syncRendererViewport();
-
   await initGameBootstrapFlow({
     startGame: sessionController.startGame,
     restartFromGameOver: sessionController.restartFromGameOver,
     goToMainMenu: sessionController.goToMainMenu,
-    startMainLoop: loopController.startMainLoop,
     showStore,
     hideStore,
     showRules,

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -365,7 +365,7 @@ function bindVisibilityAudioLifecycle() {
   visibilityAudioLifecycleBound = true;
 }
 
-async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainMenu, startMainLoop, showStore, hideStore, showRules, hideRules, toggleSfxMute, toggleMusicMute, prepareViewport }) {
+async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainMenu, showStore, hideStore, showRules, hideRules, toggleSfxMute, toggleMusicMute, prepareViewport }) {
   logger.info('🎮 Initializing game...');
 
   bindUiEventHandlers({
@@ -512,8 +512,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     prepareViewport();
   }
 
-  logger.info('▶️ Starting main loop...');
-  startMainLoop();
+  logger.info('⏸ Main loop deferred until first gameplay start');
 
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
     const screen = event.detail?.screen;

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -22,7 +22,6 @@ const CRASH_FLY_DEFAULT_DURATION_MS = 6000;
 const START_TRANSITION_STATIC_EYES_SRC = 'img/eyes.png';
 const MENU_EYES_STATIC_SRC = 'img/eyes.png';
 const RUN_INDEX_STORAGE_KEY = 'ursas_run_index';
-
 function createGameSessionController({
   DOM,
   gameState,
@@ -45,6 +44,8 @@ function createGameSessionController({
   getBestScore,
   setBestDistance,
   getBestDistance,
+  ensureRendererReady,
+  destroyRenderer,
   initializeGameplayRun,
   applyGameplayUpgradeState,
   clearGameplayCollections
@@ -52,9 +53,9 @@ function createGameSessionController({
   let endGameInProgress = false;
   let runStartedAt = null;
   let currentRunIndex = 1;
-  let latestGameOverSummary = null;
-  let gameOverRunToken = 0;
-
+  let latestGameOverSummary = null; let gameOverRunToken = 0;
+  let gameplayLoopStarted = false;
+  let startTransitionInProgress = false;
   function getLocalStorageSafe() {
     if (typeof window === 'undefined') return null;
     try {
@@ -63,7 +64,6 @@ function createGameSessionController({
       return null;
     }
   }
-
   function bumpRunIndex() {
     const storage = getLocalStorageSafe();
     const previous = normalizeRunIndex(storage?.getItem(RUN_INDEX_STORAGE_KEY) || 0);
@@ -250,26 +250,24 @@ function createGameSessionController({
   function actualStartGame() {
     if (gameState.running) return;
     endGameInProgress = false;
-
+    if (!gameplayLoopStarted) {
+      loopController.startMainLoop();
+      gameplayLoopStarted = true;
+    }
     stopMenuLaunchAnimation();
     showGameplayScreen();
-
     loopController.runAfterLayoutStabilizes(() => {
       syncViewport();
-
       resetGameSessionState();
       showGameplayScreen();
-
       initializeGameplayRun({
         now: performance.now(),
         speed: CONFIG.SPEED_START,
         nextCurveDirection: Math.random() * Math.PI * 2,
         nextCurveStrength: 0.5 + Math.random() * 0.5
       });
-
       clearGameplayCollections();
       clearParticles();
-
       applyPlayerUpgrades();
       beginAiRun();
       runStartedAt = Date.now();
@@ -308,7 +306,6 @@ function createGameSessionController({
         runIndex: currentRunIndex,
         difficultySegment: getDifficultySegment(currentRunIndex),
       });
-
       audioManager.playRandomGameMusic();
       loopController.scheduleResizeStabilization();
       logger.info('✅ Game started!');
@@ -316,22 +313,20 @@ function createGameSessionController({
   }
 
   async function startGame() {
+    if (startTransitionInProgress) return;
     if (!areAllAssetsReady()) {
       showBonusText('⏳ Loading sprites...');
       setTimeout(startGame, 500);
       return;
     }
-
     if (isAuthenticated() || hasRideLimit()) {
       await loadPlayerRides();
       const playerRides = getPlayerRides();
-
       if (hasRideLimit() && (playerRides.totalRides || 0) <= 0) {
         resetUiAfterRideFailure();
         notifyWarn(`🎟 No rides! ⏰ Resets in ${playerRides.resetInFormatted}. 💰 Buy a ride pack in the Store!`, { durationMs: 7000 });
         return;
       }
-
       const canPlay = await useRide();
       if (hasRideLimit() && !canPlay) {
         const currentRides = getPlayerRides();
@@ -340,29 +335,39 @@ function createGameSessionController({
         return;
       }
     }
-
     logger.info('▶️ Starting game...');
+    startTransitionInProgress = true;
     audioManager.stopAll();
-
     showMainMenuScreen();
     playStartTransitionAnimation();
     playMenuLaunchAnimation();
     audioManager.playSFX('gamestart');
-
-    const onEnd = () => {
-      audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
-      stopStartTransitionAnimation();
-      stopMenuLaunchAnimation();
-      actualStartGame();
-    };
-    audioManager.sfx.gamestart.addEventListener('ended', onEnd);
-
-    setTimeout(() => {
-      if (!gameState.running) {
-        audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
+    const startAfterTransition = async (phase) => {
+      if (!startTransitionInProgress) return;
+      startTransitionInProgress = false;
+      try {
+        await ensureRendererReady();
+        syncViewport();
         stopStartTransitionAnimation();
         stopMenuLaunchAnimation();
         actualStartGame();
+      } catch (error) {
+        logger.error(`❌ Phaser init failed on ${phase}:`, error);
+        stopStartTransitionAnimation();
+        stopMenuLaunchAnimation();
+        showMainMenuScreen();
+        showBonusText('⚠️ Loading failed. Please try again.');
+      }
+    };
+    const onEnd = () => {
+      audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
+      startAfterTransition('start');
+    };
+    audioManager.sfx.gamestart.addEventListener('ended', onEnd);
+    setTimeout(() => {
+      if (startTransitionInProgress && !gameState.running) {
+        audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
+        startAfterTransition('start fallback');
       }
     }, 5000);
   }
@@ -374,12 +379,10 @@ function createGameSessionController({
     if (DOM.darkScreen) DOM.darkScreen.style.display = 'none';
     startGame();
   }
-
   function endGame(reason = 'Unknown') {
     if (endGameInProgress) return;
     endGameInProgress = true;
     finishAiRun();
-
     const { width: viewportW, height: viewportH } = getViewportDimensions();
     resetGameSessionState();
     gameState.running = false;
@@ -499,7 +502,7 @@ function createGameSessionController({
       if (!initialSnapshot.playerInsights && initialSnapshot.insightsReason === 'no_wallet') {
         trackAnalyticsEvent('game_over_insights_unavailable', { reason: 'no_wallet' });
       }
-
+      destroyRenderer?.();
       showGameOverScreen();
       syncAllAudioUI();
       audioManager.playSFX('gameover_screen');
@@ -549,14 +552,13 @@ function createGameSessionController({
   }
 
   function goToMainMenu() {
+    startTransitionInProgress = false;
     endGameInProgress = false;
     logger.info('🏠 Return to main menu');
     audioManager.stopAll();
     stopMenuLaunchAnimation();
-
     showMainMenuScreen();
     gameState.running = false;
-
     clearGameplayCollections();
     clearParticles();
 
@@ -572,6 +574,7 @@ function createGameSessionController({
     gameState.spinCooldown = 0;
 
     resetGameSessionState();
+    destroyRenderer?.();
     audioManager.playMusic('menu');
 
     if (runStartedAt) {
@@ -584,10 +587,8 @@ function createGameSessionController({
     if (hasWalletAuthSession() || isUnauthRuntimeMode()) {
       loadPlayerRides().then(() => updateRidesDisplay());
     }
-
     logger.info('✅ State reset');
   }
-
   return {
     endGame,
     goToMainMenu,
@@ -595,5 +596,4 @@ function createGameSessionController({
     startGame
   };
 }
-
 export { createGameSessionController };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "npm run test:request",
+    "lint": "npm run check:syntax && npm run check:static-analysis",
     "build": "npm run check:conflicts && vite build",
     "preview": "vite preview",
     "check": "npm run check:syntax && npm run check:static-analysis && npm run check:no-window-assign && npm run check:asset-paths && npm run check:no-legacy-canvas-runtime && npm run test:e2e-smoke && npm run test:request",


### PR DESCRIPTION
### Motivation

- Reduce CPU/GPU load and device heating on the main menu by preventing the heavy Phaser runtime from running before gameplay starts.
- Ensure the main loop and renderer are raised only when the player presses `Start Game` while preserving gameplay target FPS.
- Provide deterministic teardown when returning to menu or on game-over to avoid sustained background rendering.

### Description

- Introduce a lazy renderer lifecycle in `js/game.js` by adding `ensureRendererReady()`, `destroyRenderer()`, a `rendererInitPromise`, and a `gameplayRenderEnabled` gate tied to `SCREEN_CHANGED_EVENT`, and modify `loopController.renderFrame` to skip rendering unless gameplay is active.
- Remove eager renderer initialization from `initGame()` and pass `ensureRendererReady`/`destroyRenderer` into the session controller so renderer lifecycle is driven from gameplay flow.
- Defer starting the main loop in `js/game/bootstrap.js` (remove automatic `startMainLoop`), making the loop start from gameplay path instead of bootstrap.
- Update `js/game/session.js` to call `ensureRendererReady()` during `startGame`, start the main loop on first actual gameplay run via `loopController.startMainLoop()`, add start-transition gating (`startTransitionInProgress`), and perform renderer teardown on `goToMainMenu()` and after game-over.
- Update `package.json` scripts to surface `test` and `lint` commands and adjust CI/dev script wiring.
- Add documentation files `docs/start-screen-overheating-patch-plan-2026-04-30-ru.md` and `docs/start-screen-overheating-validation-2026-05-01.md` describing the patch plan and validation run.

### Testing

- Ran `npm test` which passed all unit tests (`82/82` tests passed).
- Ran `npm run lint` which passed static checks (`check:syntax` and `check:static-analysis` both passed).
- Ran `npm run build` which completed successfully (Vite build OK with a non-blocking chunk-size warning).
- Ran `npm run test:e2e-smoke` (MIG-08 synthetic smoke) which passed and produced target perf metrics (fpsP50 60, frameMsP50 ~16.67) and completed the smoke checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37ddf30c48320888ca3e3205a153d)