### PR TITLE
Defer Phaser lifecycle to gameplay, add renderer warmup/placeholder, and gate main loop

### DIFF
--- a/docs/start-screen-overheating-patch-plan-2026-04-30-ru.md
+++ b/docs/start-screen-overheating-patch-plan-2026-04-30-ru.md
@@ -1,0 +1,92 @@
+# Ursass Tube — Patch Plan: перегрев на стартовом экране (Telegram Mini App)
+
+**Дата:** 30 апреля 2026  
+**Контекст:** предрелизный критический perf-issue на мобильных устройствах
+
+## Проблема
+
+На стартовом экране до нажатия `Start Game` запускался тяжёлый runtime/рендер-path, что приводило к повышенной CPU/GPU нагрузке и нагреву устройства.
+
+## Подтверждённые причины
+
+1. Инициализация Phaser renderer происходила на bootstrap (до старта ранa).
+2. Main loop запускался слишком рано.
+3. Стартовое меню было UI-оверлеем, но игровой runtime уже существовал.
+
+## Цель патча
+
+- Поднимать Phaser только после нажатия `Start Game`.
+- Держать меню лёгким (без фонового тяжёлого рендера).
+- После выхода в меню — опускать нагрузку обратно.
+- Сохранить игровой feel: target FPS **не снижать**.
+
+## Технический план (по файлам)
+
+### 1) `js/game.js`
+
+- Ввести ленивый lifecycle renderer:
+  - `ensureRendererReady()`
+  - `destroyRenderer()`
+  - сериализация через `rendererInitPromise`.
+- Убрать eager renderer init из `initGame()`.
+- Передать lifecycle-функции в session controller.
+
+### 2) `js/game/session.js`
+
+- В `startGame` перед `actualStartGame` вызывать `ensureRendererReady()`.
+- После инициализации делать `syncViewport()` и только потом запуск run.
+- На `goToMainMenu()` вызывать `destroyRenderer()` для полного teardown.
+- Запуск loop только при первом gameplay (`gameplayLoopStarted`).
+
+### 3) `js/game/bootstrap.js`
+
+- Убрать автоматический вызов `startMainLoop()` на bootstrap.
+- Оставить deferred-подход: loop стартует в gameplay-пути.
+
+## Риски и контроль
+
+- **Риск:** первый старт ранa может занять немного больше времени.
+  - **Митигировать:** использовать transition/preload слой и fallback на ошибку init.
+- **Риск:** race-condition при повторных нажатиях `Start`.
+  - **Митигировать:** единый `rendererInitPromise`.
+
+## Acceptance criteria
+
+1. На меню до `Start Game` Phaser runtime не выполняет тяжёлую отрисовку.
+2. После `Start Game` runtime и сцена поднимаются в рамках transition/preload.
+3. После `Game Over -> Menu` нагрузка снова падает.
+4. FPS gameplay остаётся 60-target.
+
+## Preload black-screen mitigation (новый блок)
+
+### Варианты решения
+
+1. **Warm-up кадр до снятия preloading overlay**  
+   После `ensureRendererReady()` принудительно отрисовать первый snapshot и дождаться минимум 1–2 RAF перед скрытием transition.
+
+2. **Fail-safe таймаут готовности рендера**  
+   Если warm-up подтверждение задерживается, не блокировать старт бесконечно: снимать preload по timeout (например 700–900ms), чтобы избежать зависаний.
+
+3. **Scene-level ready event из Phaser**  
+   Эмитить explicit событие из Phaser-сцены после первого стабильного `applySnapshot`/draw и стартовать геймплей только после него.
+
+4. **Placeholder-first strategy**  
+   Показать лёгкий placeholder (градиент/статичное изображение туннеля) до первого реального кадра Phaser, затем кроссфейд.
+
+### План следующей итерации
+
+- [x] Пункт 1: warm-up кадр перед снятием preload.
+- [x] Пункт 2: fail-safe timeout готовности.
+- [x] Пункт 3: scene-level ready event.
+- [x] Пункт 4: placeholder-first strategy.
+
+## Smoke-checklist
+
+1. Open app -> 60s idle on menu (без заметного нагрева).
+2. Start Game -> корректный preload -> старт ранa.
+3. Game Over -> Menu -> повторный idle (нагрузка ниже gameplay).
+4. Повторить цикл 3–5 раз (без деградации/утечек).
+
+## Статус
+
+План оформлен в репозитории как отдельный документ для трекинга и ревью.

--- a/docs/start-screen-overheating-qa-report-template-2026-05-01.md
+++ b/docs/start-screen-overheating-qa-report-template-2026-05-01.md
@@ -1,0 +1,69 @@
+# QA Report Template — Start-screen overheating mitigation (Telegram Mini App)
+
+**Build hash / tag:**  
+**Environment (prod/stage):**  
+**Date (UTC):**  
+**Tester:**  
+
+---
+
+## 1) Device matrix
+
+| # | Device | OS | Telegram version | SoC / RAM | Result |
+|---|--------|----|------------------|-----------|--------|
+| 1 | iPhone 12/13+ | iOS | | | |
+| 2 | Android mid-tier | Android 12+ | | | |
+| 3 | Android low-tier | Android (4GB RAM) | | | |
+
+---
+
+## 2) Test protocol (required)
+
+1. Cold open Mini App → stay on **Start Menu** for 60s.
+2. Press **Start Game** → wait transition/preload → play 15–30s.
+3. Trigger **Game Over** → stay on screen 60s.
+4. Return to **Menu** → stay 60s.
+5. Repeat steps 2–4 **three times**.
+
+---
+
+## 3) Observations per device
+
+### Device: __________________
+
+- Start Menu 60s (thermal): cool / warm / hot
+- Start Menu smoothness: OK / minor jank / major jank
+- Start transition visual handoff: clean / occasional black frame / frequent black frame
+- Game Over 60s (thermal): cool / warm / hot
+- Menu-after-GO 60s (thermal): cool / warm / hot
+- 3-loop stability: pass / fail
+- Crashes / WebView restarts: none / present
+- Notes:
+
+---
+
+## 4) Pass/fail gates
+
+Mark each gate:
+
+- [ ] No sustained heating on Start Menu idle windows
+- [ ] No sustained heating on Game Over / post-GO Menu windows
+- [ ] Start transition has no visible black-screen regressions
+- [ ] 3 repeated loops complete without degradation or restart
+- [ ] Gameplay responsiveness remains acceptable (subjective 60 FPS feel)
+
+---
+
+## 5) Final decision
+
+- **Release status:** APPROVED / BLOCKED
+- **Blocking issues (if any):**
+- **Recommended follow-ups:**
+
+---
+
+## 6) Attachments
+
+- Screenshots/video:
+- Console logs:
+- Perf traces (if available):

--- a/docs/start-screen-overheating-real-device-checklist-2026-05-01.md
+++ b/docs/start-screen-overheating-real-device-checklist-2026-05-01.md
@@ -1,0 +1,48 @@
+# Start-screen overheating — Real-device Telegram checklist (2026-05-01)
+
+## Goal
+Confirm that menu/game-over screens stay lightweight on real mobile devices inside Telegram Mini App after deferred Phaser lifecycle changes.
+
+## Devices (minimum matrix)
+
+- iOS: iPhone 12/13+ (latest Telegram + latest iOS)
+- Android: mid-tier Snapdragon (Android 12+) and one low-tier device (Android Go / 4GB RAM)
+
+## Build and runtime
+
+- Production build (`npm run build`) served over HTTPS
+- Telegram Mini App context only (not standalone browser)
+
+## Test script
+
+1. Cold open Mini App -> stay on Start Menu for 60s
+2. Press `Start Game` -> wait for transition/preload -> play 15–30s
+3. Trigger Game Over -> stay on Game Over for 60s
+4. Return to Menu -> stay 60s
+5. Repeat steps 2–4 three times
+
+## Measurements to capture
+
+- Device temperature trend (qualitative: cool / warm / hot)
+- FPS overlay/telemetry if available
+- Jank / stutter events on menu and game-over
+- Battery drain estimate (5-min session)
+- Any watchdog/background throttling signs
+
+## Pass criteria
+
+- No sustained heating on Start Menu / Game Over / Menu idle windows
+- Gameplay enters at normal responsiveness after Start
+- No progressive degradation across 3 loops
+- No crashes / WebView restarts
+
+## Report template
+
+- Device:
+- OS / Telegram version:
+- Build hash:
+- Menu 60s result:
+- Game Over 60s result:
+- Menu-after-GO 60s result:
+- Loop stability (x3):
+- Notes / screenshots / logs:

--- a/docs/start-screen-overheating-release-note-2026-05-01.md
+++ b/docs/start-screen-overheating-release-note-2026-05-01.md
@@ -1,0 +1,25 @@
+# Release note — Start-screen overheating mitigation (2026-05-01)
+
+## What changed
+
+- Phaser runtime init is deferred until gameplay start (`Start Game`).
+- Main loop startup is deferred from bootstrap to first gameplay run.
+- Rendering is gated by active screen (`gameplay` only).
+- Renderer teardown is executed on game-over/menu flows.
+
+## Expected user impact
+
+- Lower idle CPU/GPU load on Start Menu.
+- Reduced risk of mobile overheating before gameplay starts.
+- Preserved gameplay feel (60 FPS target remains unchanged).
+
+## Validation status
+
+- Synthetic checks: PASS (`npm test`, `npm run lint`, `npm run build`, `npm run test:e2e-smoke`).
+- Real-device Telegram validation: pending execution per checklist.
+
+## Linked artifacts
+
+- Patch plan: `docs/start-screen-overheating-patch-plan-2026-04-30-ru.md`
+- Validation log: `docs/start-screen-overheating-validation-2026-05-01.md`
+- Real-device checklist: `docs/start-screen-overheating-real-device-checklist-2026-05-01.md`

--- a/docs/start-screen-overheating-validation-2026-05-01.md
+++ b/docs/start-screen-overheating-validation-2026-05-01.md
@@ -1,0 +1,42 @@
+# Start-screen overheating — validation run (2026-05-01)
+
+## Scope
+Validation of deferred Phaser init / deferred loop / render gating changes for menu-load reduction.
+
+## Commands executed
+
+1. `npm test`
+2. `npm run lint`
+3. `npm run build`
+4. `npm run test:e2e-smoke`
+
+## Results
+
+- `npm test`: **PASS** (84/84 tests passed).
+- `npm run lint`: **PASS** (`check:syntax` + `check:static-analysis`).
+- `npm run build`: **PASS** (Vite build successful; non-blocking chunk-size warning present).
+- `npm run test:e2e-smoke`: **PASS**.
+
+### MIG-08 synthetic smoke snapshot
+
+- capturedAt: `2026-05-01T10:54:20.267Z`
+- sampleCount: `120`
+- fpsP50 / fpsP95: `60 / 62`
+- frameMsP50 / frameMsP95: `16.67 / 17.24`
+- pingMsP50 / pingMsP95: `73 / 76`
+- smoke checklist: `6 / 6` complete
+
+## Notes
+
+- This smoke run is synthetic (scripted lifecycle/perf flow), useful as a regression gate.
+- Real-device Telegram Mini App thermal/perf verification is still recommended before release.
+
+## Re-run (2026-05-01, latest)
+
+- command: `npm run test:e2e-smoke`
+- capturedAt: `2026-05-01T10:57:12.369Z`
+- sampleCount: `120`
+- fpsP50 / fpsP95: `60 / 62`
+- frameMsP50 / frameMsP95: `16.67 / 17.24`
+- pingMsP50 / pingMsP95: `73 / 76`
+- smoke checklist: `6 / 6` complete

--- a/js/game.js
+++ b/js/game.js
@@ -13,12 +13,17 @@ import { initGameBootstrapFlow } from './game/bootstrap.js';
 import { createGameLoopController } from './game/loop.js';
 import { createGameSessionController } from './game/session.js';
 import { VIEWPORT_SYNC_EVENT } from './runtime-lifecycle.js';
+import { SCREEN_CHANGED_EVENT, PHASER_SCENE_READY_EVENT } from './runtime-events.js';
 import { hasWalletAuthSession } from './auth.js';
 import { logger } from './logger.js';
 
 let activeRenderer = null;
 let viewportSyncBound = false;
+let rendererInitPromise = null;
+let gameplayRenderEnabled = false;
+let screenRenderGateBound = false;
 const PHASER_LOADING_OVERLAY_ID = 'phaserLoadingOverlay';
+const RENDERER_PLACEHOLDER_ID = 'phaserRendererPlaceholder';
 let loadingOverlayElements = null;
 
 function createSnapshotForRenderer(width, height) {
@@ -46,8 +51,100 @@ function bindViewportSyncLifecycle() {
   viewportSyncBound = true;
 }
 
+function bindScreenRenderGate() {
+  if (screenRenderGateBound) return;
+  window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
+    const screen = event?.detail?.screen || 'menu';
+    gameplayRenderEnabled = screen === 'gameplay';
+  });
+  screenRenderGateBound = true;
+}
+
+async function ensureRendererReady({ forceRecreate = false } = {}) {
+  if (forceRecreate && activeRenderer) {
+    activeRenderer.destroy();
+    activeRenderer = null;
+  }
+
+  if (activeRenderer) {
+    return activeRenderer;
+  }
+
+  if (!rendererInitPromise) {
+    rendererInitPromise = (async () => {
+      const { width, height } = getViewportDimensions();
+      const initialSnapshot = createSnapshotForRenderer(width, height);
+      const renderer = await createGameRenderer(initialSnapshot);
+      activeRenderer = renderer;
+      bindViewportSyncLifecycle();
+      bindScreenRenderGate();
+      syncRendererViewport();
+      return renderer;
+    })();
+  }
+
+  try {
+    return await rendererInitPromise;
+  } finally {
+    rendererInitPromise = null;
+  }
+}
+
+function destroyRenderer() {
+  rendererInitPromise = null;
+  activeRenderer?.destroy?.();
+  activeRenderer = null;
+  gameplayRenderEnabled = false;
+}
+
 function requestViewportSync() {
   window.dispatchEvent(new CustomEvent(VIEWPORT_SYNC_EVENT));
+}
+
+async function warmupRendererFrame({ maxWaitMs = 900 } = {}) {
+  if (!activeRenderer) return;
+  const { width, height } = getViewportDimensions();
+  activeRenderer.render(createSnapshotForRenderer(width, height));
+
+  const rafReady = new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
+  const sceneReady = new Promise((resolve) => {
+    const onReady = () => {
+      window.removeEventListener(PHASER_SCENE_READY_EVENT, onReady);
+      resolve();
+    };
+    window.addEventListener(PHASER_SCENE_READY_EVENT, onReady, { once: true });
+  });
+  const timeoutReady = new Promise((resolve) => {
+    setTimeout(resolve, Math.max(120, Number(maxWaitMs) || 900));
+  });
+  await Promise.race([Promise.all([rafReady, sceneReady]), timeoutReady]);
+}
+
+function showRendererPlaceholder() {
+  if (document.getElementById(RENDERER_PLACEHOLDER_ID)) return;
+  const host = DOM.gameContent || DOM.gameWrapper || DOM.gameContainer;
+  if (!host) return;
+  const node = document.createElement('div');
+  node.id = RENDERER_PLACEHOLDER_ID;
+  Object.assign(node.style, {
+    position: 'absolute',
+    inset: '0',
+    zIndex: '3',
+    pointerEvents: 'none',
+    background: 'radial-gradient(circle at 50% 45%, rgba(120, 55, 255, 0.22) 0%, rgba(15, 14, 30, 0.96) 62%, rgba(5, 8, 22, 1) 100%)',
+    opacity: '1',
+    transition: 'opacity 220ms ease'
+  });
+  host.appendChild(node);
+}
+
+function hideRendererPlaceholder() {
+  const node = document.getElementById(RENDERER_PLACEHOLDER_ID);
+  if (!node) return;
+  node.style.opacity = '0';
+  setTimeout(() => node.remove(), 240);
 }
 
 function ensureLoadingOverlay() {
@@ -148,6 +245,7 @@ const loopController = createGameLoopController({
     renderLoadingOverlay(progress);
   },
   renderFrame: () => {
+    if (!gameplayRenderEnabled) return;
     const { width, height } = getViewportDimensions();
     activeRenderer?.render(createSnapshotForRenderer(width, height));
   },
@@ -186,23 +284,21 @@ const sessionController = createGameSessionController({
   getBestScore,
   setBestDistance,
   getBestDistance,
+  ensureRendererReady,
+  showRendererPlaceholder,
+  hideRendererPlaceholder,
+  warmupRendererFrame,
+  destroyRenderer,
   initializeGameplayRun,
   applyGameplayUpgradeState,
   clearGameplayCollections
 });
 
 async function initGame() {
-  const { width, height } = getViewportDimensions();
-  const initialSnapshot = createSnapshotForRenderer(width, height);
-  activeRenderer = await createGameRenderer(initialSnapshot);
-  bindViewportSyncLifecycle();
-  syncRendererViewport();
-
   await initGameBootstrapFlow({
     startGame: sessionController.startGame,
     restartFromGameOver: sessionController.restartFromGameOver,
     goToMainMenu: sessionController.goToMainMenu,
-    startMainLoop: loopController.startMainLoop,
     showStore,
     hideStore,
     showRules,

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -365,7 +365,7 @@ function bindVisibilityAudioLifecycle() {
   visibilityAudioLifecycleBound = true;
 }
 
-async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainMenu, startMainLoop, showStore, hideStore, showRules, hideRules, toggleSfxMute, toggleMusicMute, prepareViewport }) {
+async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainMenu, showStore, hideStore, showRules, hideRules, toggleSfxMute, toggleMusicMute, prepareViewport }) {
   logger.info('🎮 Initializing game...');
 
   bindUiEventHandlers({
@@ -512,8 +512,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     prepareViewport();
   }
 
-  logger.info('▶️ Starting main loop...');
-  startMainLoop();
+  logger.info('⏸ Main loop deferred until first gameplay start');
 
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
     const screen = event.detail?.screen;

--- a/js/game/loop.js
+++ b/js/game/loop.js
@@ -10,6 +10,8 @@ function createGameLoopController({
   onUpdateError,
   logger
 }) {
+  let loopActive = false;
+
   function runAfterLayoutStabilizes(callback) {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
@@ -27,10 +29,17 @@ function createGameLoopController({
   }
 
   function startMainLoop() {
+    if (loopActive) return;
+    loopActive = true;
     requestAnimationFrame(gameLoop);
   }
 
+  function stopMainLoop() {
+    loopActive = false;
+  }
+
   function gameLoop(time) {
+    if (!loopActive) return;
     const frameStart = performance.now();
     const debugStats = gameState.debugStats;
     debugStats.drawMs = 0;
@@ -40,7 +49,7 @@ function createGameLoopController({
 
     if (!assetManager.isReady()) {
       renderLoadingFrame();
-      requestAnimationFrame(gameLoop);
+      if (loopActive) requestAnimationFrame(gameLoop);
       return;
     }
 
@@ -58,7 +67,7 @@ function createGameLoopController({
     perfMonitor.updateFPS();
 
     if (gameState.visibilitySuspended) {
-      requestAnimationFrame(gameLoop);
+      if (loopActive) requestAnimationFrame(gameLoop);
       return;
     }
 
@@ -79,7 +88,7 @@ function createGameLoopController({
         logger.error("❌ Update error:", error);
         onUpdateError(error);
         debugStats.frameMs = performance.now() - frameStart;
-        requestAnimationFrame(gameLoop);
+        if (loopActive) requestAnimationFrame(gameLoop);
         return;
       }
     }
@@ -93,14 +102,15 @@ function createGameLoopController({
     }
 
     debugStats.frameMs = performance.now() - frameStart;
-    requestAnimationFrame(gameLoop);
+    if (loopActive) requestAnimationFrame(gameLoop);
   }
 
   return {
     gameLoop,
     runAfterLayoutStabilizes,
     scheduleResizeStabilization,
-    startMainLoop
+    startMainLoop,
+    stopMainLoop
   };
 }
 

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -15,14 +15,11 @@ import { buildInputFeedbackMetrics } from './input-feedback-metrics.js';
 import { getDifficultySegment, normalizeRunIndex } from './difficulty-segmentation.js';
 import { buildGameOverSummary } from './game-over-copy.js';
 import { beginAiRun, finishAiRun } from '../ai-mode.js';
-
-const CRASH_FLYER_SRC = 'img/bear_pixel_transparent.webp';
-const CRASH_FLYER_FALLBACK_SRC = 'img/bear.png';
+const CRASH_FLYER_SRC = 'img/bear_pixel_transparent.webp'; const CRASH_FLYER_FALLBACK_SRC = 'img/bear.png';
 const CRASH_FLY_DEFAULT_DURATION_MS = 6000;
 const START_TRANSITION_STATIC_EYES_SRC = 'img/eyes.png';
 const MENU_EYES_STATIC_SRC = 'img/eyes.png';
 const RUN_INDEX_STORAGE_KEY = 'ursas_run_index';
-
 function createGameSessionController({
   DOM,
   gameState,
@@ -45,6 +42,11 @@ function createGameSessionController({
   getBestScore,
   setBestDistance,
   getBestDistance,
+  ensureRendererReady,
+  showRendererPlaceholder,
+  hideRendererPlaceholder,
+  warmupRendererFrame,
+  destroyRenderer,
   initializeGameplayRun,
   applyGameplayUpgradeState,
   clearGameplayCollections
@@ -52,9 +54,8 @@ function createGameSessionController({
   let endGameInProgress = false;
   let runStartedAt = null;
   let currentRunIndex = 1;
-  let latestGameOverSummary = null;
-  let gameOverRunToken = 0;
-
+  let latestGameOverSummary = null; let gameOverRunToken = 0;
+  let startTransitionInProgress = false;
   function getLocalStorageSafe() {
     if (typeof window === 'undefined') return null;
     try {
@@ -63,7 +64,6 @@ function createGameSessionController({
       return null;
     }
   }
-
   function bumpRunIndex() {
     const storage = getLocalStorageSafe();
     const previous = normalizeRunIndex(storage?.getItem(RUN_INDEX_STORAGE_KEY) || 0);
@@ -250,26 +250,21 @@ function createGameSessionController({
   function actualStartGame() {
     if (gameState.running) return;
     endGameInProgress = false;
-
+    loopController.startMainLoop();
     stopMenuLaunchAnimation();
     showGameplayScreen();
-
     loopController.runAfterLayoutStabilizes(() => {
       syncViewport();
-
       resetGameSessionState();
       showGameplayScreen();
-
       initializeGameplayRun({
         now: performance.now(),
         speed: CONFIG.SPEED_START,
         nextCurveDirection: Math.random() * Math.PI * 2,
         nextCurveStrength: 0.5 + Math.random() * 0.5
       });
-
       clearGameplayCollections();
       clearParticles();
-
       applyPlayerUpgrades();
       beginAiRun();
       runStartedAt = Date.now();
@@ -308,7 +303,6 @@ function createGameSessionController({
         runIndex: currentRunIndex,
         difficultySegment: getDifficultySegment(currentRunIndex),
       });
-
       audioManager.playRandomGameMusic();
       loopController.scheduleResizeStabilization();
       logger.info('✅ Game started!');
@@ -316,22 +310,20 @@ function createGameSessionController({
   }
 
   async function startGame() {
+    if (startTransitionInProgress) return;
     if (!areAllAssetsReady()) {
       showBonusText('⏳ Loading sprites...');
       setTimeout(startGame, 500);
       return;
     }
-
     if (isAuthenticated() || hasRideLimit()) {
       await loadPlayerRides();
       const playerRides = getPlayerRides();
-
       if (hasRideLimit() && (playerRides.totalRides || 0) <= 0) {
         resetUiAfterRideFailure();
         notifyWarn(`🎟 No rides! ⏰ Resets in ${playerRides.resetInFormatted}. 💰 Buy a ride pack in the Store!`, { durationMs: 7000 });
         return;
       }
-
       const canPlay = await useRide();
       if (hasRideLimit() && !canPlay) {
         const currentRides = getPlayerRides();
@@ -340,33 +332,46 @@ function createGameSessionController({
         return;
       }
     }
-
     logger.info('▶️ Starting game...');
+    startTransitionInProgress = true;
     audioManager.stopAll();
-
     showMainMenuScreen();
     playStartTransitionAnimation();
     playMenuLaunchAnimation();
+    showRendererPlaceholder?.();
     audioManager.playSFX('gamestart');
-
-    const onEnd = () => {
-      audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
-      stopStartTransitionAnimation();
-      stopMenuLaunchAnimation();
-      actualStartGame();
-    };
-    audioManager.sfx.gamestart.addEventListener('ended', onEnd);
-
-    setTimeout(() => {
-      if (!gameState.running) {
-        audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
+    const startAfterTransition = async (phase) => {
+      if (!startTransitionInProgress) return;
+      startTransitionInProgress = false;
+      try {
+        await ensureRendererReady();
+        syncViewport();
+        await warmupRendererFrame({ maxWaitMs: 900 });
+        hideRendererPlaceholder?.();
         stopStartTransitionAnimation();
         stopMenuLaunchAnimation();
         actualStartGame();
+      } catch (error) {
+        logger.error(`❌ Phaser init failed on ${phase}:`, error);
+        hideRendererPlaceholder?.();
+        stopStartTransitionAnimation();
+        stopMenuLaunchAnimation();
+        showMainMenuScreen();
+        showBonusText('⚠️ Loading failed. Please try again.');
+      }
+    };
+    const onEnd = () => {
+      audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
+      startAfterTransition('start');
+    };
+    audioManager.sfx.gamestart.addEventListener('ended', onEnd);
+    setTimeout(() => {
+      if (startTransitionInProgress && !gameState.running) {
+        audioManager.sfx.gamestart.removeEventListener('ended', onEnd);
+        startAfterTransition('start fallback');
       }
     }, 5000);
   }
-
   function restartFromGameOver() {
     endGameInProgress = false;
     audioManager.stopSFX('gameover_screen');
@@ -374,15 +379,14 @@ function createGameSessionController({
     if (DOM.darkScreen) DOM.darkScreen.style.display = 'none';
     startGame();
   }
-
   function endGame(reason = 'Unknown') {
     if (endGameInProgress) return;
     endGameInProgress = true;
     finishAiRun();
-
     const { width: viewportW, height: viewportH } = getViewportDimensions();
     resetGameSessionState();
     gameState.running = false;
+    loopController.stopMainLoop();
     audioManager.stopMusic();
 
     spawnParticles(viewportW / 2, viewportH / 2, 'rgba(255, 0, 0, 1)', 30, 12);
@@ -499,7 +503,7 @@ function createGameSessionController({
       if (!initialSnapshot.playerInsights && initialSnapshot.insightsReason === 'no_wallet') {
         trackAnalyticsEvent('game_over_insights_unavailable', { reason: 'no_wallet' });
       }
-
+      destroyRenderer?.();
       showGameOverScreen();
       syncAllAudioUI();
       audioManager.playSFX('gameover_screen');
@@ -549,14 +553,15 @@ function createGameSessionController({
   }
 
   function goToMainMenu() {
+    startTransitionInProgress = false;
+    hideRendererPlaceholder?.();
     endGameInProgress = false;
     logger.info('🏠 Return to main menu');
     audioManager.stopAll();
     stopMenuLaunchAnimation();
-
     showMainMenuScreen();
     gameState.running = false;
-
+    loopController.stopMainLoop();
     clearGameplayCollections();
     clearParticles();
 
@@ -570,24 +575,20 @@ function createGameSessionController({
     gameState.spinActive = false;
     gameState.spinProgress = 0;
     gameState.spinCooldown = 0;
-
     resetGameSessionState();
+    destroyRenderer?.();
     audioManager.playMusic('menu');
-
     if (runStartedAt) {
       trackAnalyticsEvent('session_length', {
         seconds: Number(((Date.now() - runStartedAt) / 1000).toFixed(2))
       });
       runStartedAt = null;
     }
-
     if (hasWalletAuthSession() || isUnauthRuntimeMode()) {
       loadPlayerRides().then(() => updateRidesDisplay());
     }
-
     logger.info('✅ State reset');
   }
-
   return {
     endGame,
     goToMainMenu,
@@ -595,5 +596,4 @@ function createGameSessionController({
     startGame
   };
 }
-
 export { createGameSessionController };

--- a/js/phaser/scenes/MainScene.js
+++ b/js/phaser/scenes/MainScene.js
@@ -2,6 +2,7 @@ import { EntityRenderer } from '../entities/EntityRenderer.js';
 import { TunnelRenderer } from '../tunnel/TunnelRenderer.js';
 import { TunnelOuterRing } from '../tunnel/TunnelOuterRing.js';
 import { CONFIG } from '../../config.js';
+import { PHASER_SCENE_READY_EVENT } from '../../runtime-events.js';
 
 const MAIN_SCENE_KEY = 'MainScene';
 
@@ -43,6 +44,16 @@ class MainSceneController {
     this.tunnelOuterRing?.applySnapshot(this.snapshot);
     this.scene.scale.on('resize', this.handleResize);
     this.scene.events.on('update', this.handleUpdate);
+    this.scene.events.once('postupdate', () => {
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent(PHASER_SCENE_READY_EVENT, {
+          detail: {
+            scene: MAIN_SCENE_KEY,
+            timestamp: Date.now()
+          }
+        }));
+      }
+    });
   }
 
   handleResize(gameSize) {

--- a/js/runtime-events.js
+++ b/js/runtime-events.js
@@ -2,4 +2,5 @@ export const VIEWPORT_SYNC_EVENT = 'ursas:viewport-sync-requested';
 export const PERF_SAMPLE_EVENT = 'ursas:perf-sample';
 export const APP_VISIBILITY_EVENT = 'ursas:app-visibility-changed';
 export const SCREEN_CHANGED_EVENT = 'ursas:ui-screen-changed';
+export const PHASER_SCENE_READY_EVENT = 'ursas:phaser-scene-ready';
 export const SMOKE_STEP_COMPLETED_EVENT = 'ursas:smoke-step-completed';

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "npm run test:request",
+    "lint": "npm run check:syntax && npm run check:static-analysis",
     "build": "npm run check:conflicts && vite build",
     "preview": "vite preview",
     "check": "npm run check:syntax && npm run check:static-analysis && npm run check:no-window-assign && npm run check:asset-paths && npm run check:no-legacy-canvas-runtime && npm run test:e2e-smoke && npm run test:request",
@@ -20,7 +22,7 @@
     "check:no-legacy-canvas-runtime": "node scripts/check-no-legacy-canvas-runtime.mjs",
     "check:mig08-smoke": "node scripts/run-mig08-smoke.mjs",
     "test:e2e-smoke": "npm run check:mig08-smoke",
-    "test:request": "node --test scripts/request.test.mjs scripts/auth-service.test.mjs scripts/donation-service.test.mjs scripts/upgrades-math.test.mjs scripts/runtime-lifecycle.test.mjs scripts/phaser-runtime-controller.test.mjs scripts/analytics.test.mjs scripts/store-analytics.test.mjs scripts/analytics-delivery.test.mjs scripts/analytics-metrics.test.mjs scripts/entity-render-passes.test.mjs scripts/onboarding-hints.test.mjs scripts/tunnel-math-utils.test.mjs scripts/mobile-perf-gate.test.mjs scripts/observability-gate.test.mjs scripts/rollback-gate.test.mjs scripts/collision-reaction-metrics.test.mjs scripts/input-feedback-metrics.test.mjs scripts/difficulty-segmentation.test.mjs scripts/security-gate-report.test.mjs scripts/release-gates.test.mjs scripts/game-over-copy.test.mjs scripts/leaderboard-insights.test.mjs",
+    "test:request": "node --test scripts/request.test.mjs scripts/auth-service.test.mjs scripts/donation-service.test.mjs scripts/upgrades-math.test.mjs scripts/runtime-lifecycle.test.mjs scripts/phaser-runtime-controller.test.mjs scripts/game-loop-controller.test.mjs scripts/analytics.test.mjs scripts/store-analytics.test.mjs scripts/analytics-delivery.test.mjs scripts/analytics-metrics.test.mjs scripts/entity-render-passes.test.mjs scripts/onboarding-hints.test.mjs scripts/tunnel-math-utils.test.mjs scripts/mobile-perf-gate.test.mjs scripts/observability-gate.test.mjs scripts/rollback-gate.test.mjs scripts/collision-reaction-metrics.test.mjs scripts/input-feedback-metrics.test.mjs scripts/difficulty-segmentation.test.mjs scripts/security-gate-report.test.mjs scripts/release-gates.test.mjs scripts/game-over-copy.test.mjs scripts/leaderboard-insights.test.mjs",
     "report:metrics": "node scripts/build-product-metrics-report.mjs",
     "check:syntax": "node scripts/check-syntax.mjs",
     "prepare": "node scripts/setup-hooks.mjs",

--- a/scripts/game-loop-controller.test.mjs
+++ b/scripts/game-loop-controller.test.mjs
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createGameLoopController } from '../js/game/loop.js';
+
+function createHarness() {
+  const originalRAF = globalThis.requestAnimationFrame;
+  const callbacks = [];
+  globalThis.requestAnimationFrame = (cb) => {
+    callbacks.push(cb);
+    return callbacks.length;
+  };
+
+  const calls = {
+    render: 0,
+    update: 0,
+    ui: 0,
+    loading: 0
+  };
+
+  const gameState = {
+    debugStats: { drawMs: 0, updateMs: 0, uiMs: 0, frameMs: 0 },
+    visibilitySuspended: false,
+    running: true,
+    lastTime: 0
+  };
+
+  const controller = createGameLoopController({
+    gameState,
+    assetManager: { isReady: () => true },
+    perfMonitor: { updateFPS: () => {} },
+    syncViewport: () => {},
+    renderLoadingFrame: () => { calls.loading += 1; },
+    renderFrame: () => { calls.render += 1; },
+    updateFrame: () => { calls.update += 1; },
+    renderUiFrame: () => { calls.ui += 1; },
+    onUpdateError: () => {},
+    logger: { error: () => {} }
+  });
+
+  function tick(ts = 16.67) {
+    const cb = callbacks.shift();
+    assert.ok(cb, 'expected queued animation frame callback');
+    cb(ts);
+  }
+
+  function cleanup() {
+    globalThis.requestAnimationFrame = originalRAF;
+  }
+
+  return { controller, calls, tick, cleanup, callbacks };
+}
+
+test('loop does not duplicate RAF scheduling when startMainLoop is called repeatedly', () => {
+  const h = createHarness();
+  h.controller.startMainLoop();
+  h.controller.startMainLoop();
+  assert.equal(h.callbacks.length, 1, 'only one RAF callback should be queued');
+  h.cleanup();
+});
+
+test('stopMainLoop prevents further RAF scheduling after current frame', () => {
+  const h = createHarness();
+  h.controller.startMainLoop();
+  h.tick(16.67);
+  assert.equal(h.calls.render, 1);
+  assert.equal(h.callbacks.length, 1, 'next frame should be queued while active');
+
+  h.controller.stopMainLoop();
+  h.tick(33.34);
+
+  assert.equal(h.calls.render, 1, 'render should not run after stop');
+  assert.equal(h.callbacks.length, 0, 'no further frames should be scheduled after stop');
+  h.cleanup();
+});


### PR DESCRIPTION
### Motivation

- Reduce CPU/GPU load and mobile overheating on the Start Menu by preventing heavy Phaser runtime work before the user presses `Start Game`.
- Avoid black/blank frames during preload handoff and race conditions on repeated `Start` presses while preserving gameplay feel (target 60 FPS).
- Make main loop lifecycle controllable so rendering only runs during actual gameplay and can be fully torn down on Game Over / Menu.

### Description

- Implemented lazy renderer lifecycle in `js/game.js` with `ensureRendererReady()`, `destroyRenderer()`, a `rendererInitPromise` to serialize init, `warmupRendererFrame()` to wait for RAF + scene-ready, and `showRendererPlaceholder()`/`hideRendererPlaceholder()` to avoid black screens.
- Added `PHASER_SCENE_READY_EVENT` to `js/runtime-events.js` and emit it from `js/phaser/scenes/MainScene.js` after the first `postupdate` to signal scene readiness.
- Gated rendering by screen via `SCREEN_CHANGED_EVENT` and a `gameplayRenderEnabled` flag so `renderFrame` in the loop no-ops outside gameplay, and deferred renderer init until session `startGame` path.
- Adjusted session lifecycle in `js/game/session.js` to: guard repeated starts with `startTransitionInProgress`, show placeholder during transition, call `ensureRendererReady()` + `warmupRendererFrame()` before `actualStartGame()`, start main loop in `actualStartGame()`, and call `loopController.stopMainLoop()` + `destroyRenderer()` on `endGame` / `goToMainMenu` flows.
- Deferred main loop startup in `js/game/bootstrap.js` (removed automatic `startMainLoop()` on bootstrap) to prevent eager rendering while on the menu.
- Enhanced loop controller in `js/game/loop.js` with `startMainLoop()` idempotency, a new `stopMainLoop()` to halt RAF scheduling, and conditional RAF scheduling to avoid duplicate frames.
- Added `js/runtime-events.js` export and updated `package.json` scripts; added `scripts/game-loop-controller.test.mjs` unit tests; and included new docs: patch plan, QA template, real-device checklist, release note, and validation report.

### Testing

- Ran `npm test` which reported **PASS** (`84/84` tests passed) as recorded in the validation log.
- Ran `npm run lint` which reported **PASS** for syntax and static analysis checks.
- Ran `npm run build` which completed successfully (Vite build PASS; non-blocking chunk-size warning noted).
- Ran `npm run test:e2e-smoke` (synthetic smoke) which reported **PASS** and produced stable FPS metrics (`fpsP50/fpsP95: 60/62`) as captured in the validation snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37ddf30c48320888ca3e3205a153d)