### PR TITLE
Polish Telegram/mobile UI consistency, legal links, and lightweight game-over confetti

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -86,9 +86,12 @@
 .ui-btn--lg { min-height: 56px; padding: 14px 30px; font-size: var(--font-lg); }
 .ui-btn--icon {
   width: 40px;
+  height: 40px;
+  min-width: 40px;
   min-height: 40px;
   padding: 0;
-  border-radius: 12px;
+  border-radius: 50%;
+  aspect-ratio: 1 / 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -210,8 +213,8 @@ input:checked + .slider:before {
 /* ===== WALLET CORNER ===== */
 #walletCorner {
   position: fixed;
-  top: 10px;
-  right: 30px;
+  top: calc(env(safe-area-inset-top, 0px) + 10px);
+  right: calc(env(safe-area-inset-right, 0px) + 12px);
   z-index: 9000;
   display: flex;
   flex-direction: column;
@@ -3117,4 +3120,28 @@ body.telegram-mini-app .pm-side-x.pm-x-wrap--telegram-inline {
   .pm-rank span {
     font-size: 48px;
   }
+}
+
+/* --- RC polish overrides --- */
+:root { --pm-field-height: 40px; }
+.app-fixed-nav { position: fixed; left: calc(env(safe-area-inset-left, 0px) + 10px); top: calc(env(safe-area-inset-top, 0px) + 8px); z-index: 120; display: flex; flex-direction: column; gap: 8px; }
+.app-nav-btn { width: 40px; height: 40px; min-width: 40px; min-height: 40px; border-radius: 50%; }
+.stars,.stars2 { animation: none !important; }
+body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
+#rulesScreen { padding-top: calc(env(safe-area-inset-top, 0px) + 64px); }
+.rules-content,.rules-section { width: min(92vw, 500px); margin-left: auto; margin-right: auto; }
+.pm-history-title { text-align: center; width: 100%; }
+.pm-history-table th:nth-child(3), .pm-history-table td:nth-child(3) { text-align: center; }
+.pm-input,.pm-input--field,#pmDisplaySelect { min-height: var(--pm-field-height); height: var(--pm-field-height); }
+#pmDisplaySelect { line-height: normal; padding-top: 0; padding-bottom: 0; }
+.donation-card { min-height: 176px; height: 176px; }
+.donation-card__title,.donation-card__description { overflow: hidden; text-overflow: ellipsis; }
+.store-title { display: inline-flex; align-items: center; }
+.store-icon-atlas { width: 20px; height: 20px; background-size: 100px auto; background-position: -20px -20px; margin-right: 8px; }
+.go-confetti-layer { position: fixed; inset: 0; pointer-events: none; z-index: 160; overflow: hidden; }
+.go-confetti { position: absolute; bottom: -10px; width: 6px; height: 12px; border-radius: 2px; animation: goConfettiUp 900ms ease-out forwards; }
+@keyframes goConfettiUp { to { transform: translate3d(var(--dx), calc(-35vh - var(--dy)), 0) rotate(var(--rot)); opacity: 0; } }
+@media (max-width: 768px) {
+  #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 8px); top: calc(env(safe-area-inset-top, 0px) + 8px); }
+  #walletCorner { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); right: calc(env(safe-area-inset-right, 0px) + 10px); }
 }

--- a/index.html
+++ b/index.html
@@ -108,9 +108,9 @@
 <!-- ===== GAME START ===== -->
 <div id="gameStart">
 
-  <div class="start-audio-nav">
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+  <div class="start-audio-nav app-fixed-nav">
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
   </div>
 
   <div class="bear-wrapper" id="bear3d">
@@ -163,9 +163,9 @@
     </div>
     <div class="footer-rules-link" id="rulesLink">📖 Rules</div>
     <div class="footer-legal-links">
-      <a href="/privacy" class="footer-legal-link" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+      <a href="/privacy.html" class="footer-legal-link" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
       <span class="footer-legal-sep">&amp;</span>
-      <a href="/terms" class="footer-legal-link" target="_blank" rel="noopener noreferrer">Terms</a>
+      <a href="/terms.html" class="footer-legal-link" target="_blank" rel="noopener noreferrer">Terms</a>
     </div>
     Team<br>
     &copy; 2026 Ursass Tube &mdash; Powered by Justconnect
@@ -177,10 +177,11 @@
   <div class="go-backdrop"></div>
 
   <!-- Game Over audio toggles (same style as Store) -->
-  <div class="go-audio-nav">
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="goSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="goMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+  <div class="go-audio-nav app-fixed-nav">
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="goSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="goMusicBtn" data-action="toggle-music" title="Music">🎵</button>
   </div>
+  <div id="goConfettiLayer" class="go-confetti-layer" aria-hidden="true"></div>
 
   <div class="go-title" id="goTitle">GAME OVER</div>
 
@@ -230,7 +231,7 @@
 
 <!-- ===== PLAYER MENU OVERLAY ===== -->
 <div id="playerMenuOverlay" class="player-menu-overlay" hidden>
-  <button class="pm-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="pmBackBtn" aria-label="Back">←</button>
+  <button class="pm-back-btn app-nav-btn app-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="pmBackBtn" aria-label="Back">←</button>
 
   <div class="pm-content">
     <!-- Center column -->
@@ -295,11 +296,11 @@
 
     <!-- Right column: account connections -->
     <aside class="pm-side">
-      <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
       <div class="pm-side-x pm-x-wrap" id="pmXBlock">
         <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
         <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
       </div>
+      <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
     </aside>
   </div>
 </div>
@@ -308,14 +309,14 @@
 <div id="storeScreen">
 
   <!-- Fixed nav: sfx, music, back -->
-  <div class="store-fixed-nav">
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeBackBtn" title="Back">←</button>
+  <div class="store-fixed-nav app-fixed-nav">
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn app-nav-btn app-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeBackBtn" title="Back">←</button>
   </div>
 
   <div class="store-header">
-    <div class="store-title">🛒 STORE</div>
+    <div class="store-title"><span class="icon-atlas store-icon-atlas" aria-hidden="true"></span> STORE</div>
     <div class="store-coins">
       <div class="store-coin-display">
         <img src="img/icon_gold.png">
@@ -670,10 +671,10 @@
 
 <!-- ===== RULES OVERLAY ===== -->
 <div id="rulesScreen">
-  <div class="rules-fixed-nav">
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-    <button class="store-nav-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesBackBtn" title="Back">←</button>
+  <div class="rules-fixed-nav app-fixed-nav">
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn app-nav-btn app-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesBackBtn" title="Back">←</button>
   </div>
 
   <div class="rules-header">

--- a/js/game/game-over-confetti.js
+++ b/js/game/game-over-confetti.js
@@ -1,0 +1,45 @@
+const milestoneStorageKeys = { 3: 'ursas_seen_top_3', 10: 'ursas_seen_top_10', 100: 'ursas_seen_top_100', 1000: 'ursas_seen_top_1000' };
+
+function getLocalStorageSafe() {
+  if (typeof window === 'undefined') return null;
+  try { return window.localStorage || null; } catch (_e) { return null; }
+}
+
+function shouldCelebrateMilestone({ score, bestScoreBeforeRun, playerPosition }) {
+  if (score > bestScoreBeforeRun) return true;
+  if (playerPosition === 1) return true;
+  const storage = getLocalStorageSafe();
+  for (const top of [3, 10, 100, 1000]) {
+    if (playerPosition > 0 && playerPosition <= top) {
+      const key = milestoneStorageKeys[top];
+      if (storage?.getItem(key) !== '1') {
+        storage?.setItem?.(key, '1');
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function spawnGameOverConfetti(layer) {
+  if (!layer) return;
+  layer.innerHTML = '';
+  const colors = ['#22d3ee', '#a855f7', '#fbbf24', '#34d399', '#f472b6'];
+  for (let i = 0; i < 28; i += 1) {
+    const p = document.createElement('span');
+    p.className = 'go-confetti';
+    p.style.left = `${5 + Math.random() * 90}%`;
+    p.style.background = colors[i % colors.length];
+    p.style.setProperty('--dx', `${Math.round((Math.random() - 0.5) * 180)}px`);
+    p.style.setProperty('--dy', `${Math.round(Math.random() * 140)}px`);
+    p.style.setProperty('--rot', `${Math.round((Math.random() - 0.5) * 720)}deg`);
+    layer.appendChild(p);
+  }
+  setTimeout(() => { layer.innerHTML = ''; }, 1200);
+}
+
+export function maybeCelebrateMilestone({ dom, score, bestScoreBeforeRun, playerPosition }) {
+  if (!shouldCelebrateMilestone({ score, bestScoreBeforeRun, playerPosition })) return;
+  const layer = dom?.goConfettiLayer || document.getElementById('goConfettiLayer');
+  spawnGameOverConfetti(layer);
+}

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -14,6 +14,7 @@ import { buildCollisionReactionMetrics } from './collision-reaction-metrics.js';
 import { buildInputFeedbackMetrics } from './input-feedback-metrics.js';
 import { getDifficultySegment, normalizeRunIndex } from './difficulty-segmentation.js';
 import { buildGameOverSummary } from './game-over-copy.js';
+import { maybeCelebrateMilestone } from './game-over-confetti.js';
 import { beginAiRun, finishAiRun } from '../ai-mode.js';
 const CRASH_FLYER_SRC = 'img/bear_pixel_transparent.webp'; const CRASH_FLYER_FALLBACK_SRC = 'img/bear.png';
 const CRASH_FLY_DEFAULT_DURATION_MS = 6000;
@@ -73,14 +74,12 @@ function createGameSessionController({
     }
     return next;
   }
-
   function resetUiAfterRideFailure() {
     audioManager.stopSFX('gameover_screen');
     showMainMenuScreen();
     if (DOM.darkScreen) DOM.darkScreen.style.display = 'none';
     updateRidesDisplay();
   }
-
   function updateGameOverDynamicCopy({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun }) {
     const { entries, playerPosition, playerInsights, gameOverPrompt } = getLeaderboardSnapshot();
     const summary = buildGameOverSummary({ score, runIndex, bestScoreBeforeRun, bestScoreAfterRun, entries, playerPosition, playerInsights, gameOverPrompt, isAuthenticated: isAuthenticated() });
@@ -505,6 +504,7 @@ function createGameSessionController({
       }
       destroyRenderer?.();
       showGameOverScreen();
+      maybeCelebrateMilestone({ dom: DOM, score: gameState.score, bestScoreBeforeRun, playerPosition: Number(getLeaderboardSnapshot()?.playerPosition || 0) });
       syncAllAudioUI();
       audioManager.playSFX('gameover_screen');
       endGameInProgress = false;

--- a/js/state.js
+++ b/js/state.js
@@ -134,6 +134,7 @@ const DOM_IDS = {
   goBoost: 'goBoost',
   goComparison: 'goComparison',
   goNextTarget: 'goNextTarget',
+  goConfettiLayer: 'goConfettiLayer',
   goDistance: 'goDistance',
   goScore: 'goScore',
   goGold: 'goGold',


### PR DESCRIPTION
### Motivation

- Reduce mobile/Telegram overheating and visual drift by unifying fixed nav/button patterns and disabling heavy idle animations.
- Make audio/back/nav buttons consistent and circular across Start, Store, Rules, Game Over and Player Menu to prevent visual drift.
- Fix broken legal footer links that returned 404 on static hosting and ensure store icon parity between Telegram and web.
- Provide a lightweight celebratory UX on Game Over for milestone achievements while keeping the implementation cheap on CPU/GPU.

### Description

- Unified top nav/button classes by adding `app-fixed-nav`, `app-nav-btn`, `app-back-btn`, `app-audio-btn` and applied them to Start/Store/Rules/Game Over and Player Menu in `index.html` to enforce consistent safe-area fixed positioning.
- Enforced circular icon geometry globally by updating `.ui-btn--icon` to fixed width/height, `border-radius: 50%`, `aspect-ratio: 1/1` and related safe-area offsets for `#walletCorner` in `css/style.css`.
- Disabled the moving star animations by forcing `.stars, .stars2 { animation: none !important; }` and hid the wallet corner during initial preloader via `body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }` to avoid wallet flashing during Telegram preloader.
- Replaced emoji store label with the shared icon-atlas element and added a small CSS atlas helper so Store shows the same icon across Telegram/web.
- Tightened Rules layout (top padding and max width) and player-menu fixes (moved `Connect X` ordering in markup, normalized `#pmDisplaySelect` height and field height token) and centered history title/silver column via CSS overrides.
- Normalized donation lot sizes with a fixed min-height for donation cards to avoid per-user height drift.
- Added a lightweight confetti layer and implementation: `goConfettiLayer` DOM slot + new `js/game/game-over-confetti.js` that tracks milestone flags in `localStorage` (top 3/10/100/1000, new record, #1) and spawns a short burst of DOM confetti; wired it into end-game flow via `maybeCelebrateMilestone(...)` in `js/game/session.js` and registered the new DOM id in `js/state.js`.
- Fixed footer legal links to point to the static files `/privacy.html` and `/terms.html` to eliminate 404s on static hosting.

### Testing

- Ran syntax/static checks with `npm run check:syntax` and static-analysis pre-commit checks, which passed after changes.
- Ran UI button validation with `npm run check:ui-buttons`, and the UI button script passed (checked scanned buttons).
- Pre-commit hooks (which execute the syntax and static-analysis checks) completed successfully during commits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ca6c20ec8320ae70dbab3d456e35)