### PR TITLE
Fix Web & Telegram UI regressions: audio toggles, wallet overflow, store icon, donation sizing, rules & player menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3145,3 +3145,91 @@ body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
   #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 8px); top: calc(env(safe-area-inset-top, 0px) + 8px); }
   #walletCorner { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); right: calc(env(safe-area-inset-right, 0px) + 10px); }
 }
+
+/* --- Platform scoped regression fixes (web + telegram) --- */
+body.is-web #audioTogglesGlobal {
+  display: none !important;
+}
+
+body.is-web #walletCorner {
+  position: fixed;
+  top: max(10px, env(safe-area-inset-top));
+  right: max(12px, env(safe-area-inset-right));
+  max-width: calc(100vw - 24px);
+  box-sizing: border-box;
+}
+
+body.is-web #walletCorner .wallet-corner-row {
+  max-width: 100%;
+}
+
+body.is-web #walletCorner .wallet-btn-corner,
+body.is-web #walletCorner .wallet-info {
+  max-width: min(280px, calc(100vw - 24px));
+  box-sizing: border-box;
+}
+
+body.is-web #walletCorner .wallet-info {
+  overflow-wrap: anywhere;
+}
+
+.store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; }
+.store-icon-atlas { display: none !important; }
+
+.store-panel--donation .donation-card {
+  min-height: var(--store-upgrade-item-height, 176px);
+  height: var(--store-upgrade-item-height, 176px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.store-panel--donation .donation-card__header,
+.store-panel--donation .donation-card__description {
+  min-height: 0;
+}
+
+.store-panel--donation .donation-card__description {
+  flex: 1;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+}
+
+body.is-telegram #gameStart .start-audio-nav {
+  display: flex;
+  position: fixed;
+  top: max(8px, env(safe-area-inset-top));
+  left: 12px;
+  z-index: 9000;
+}
+
+body.is-telegram #rulesScreen {
+  padding-top: calc(env(safe-area-inset-top) + 64px);
+}
+
+body.is-telegram #rulesScreen .rules-content,
+body.is-telegram #rulesScreen .rules-section {
+  width: min(88vw, 420px);
+  max-width: calc(100vw - 64px);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+body.is-telegram #walletCorner {
+  position: fixed;
+  top: max(8px, env(safe-area-inset-top));
+  right: max(12px, env(safe-area-inset-right));
+  z-index: 8000;
+  transform: none !important;
+}
+
+body.is-telegram #walletCorner.is-screen-hidden {
+  display: none !important;
+}
+
+body.is-telegram #playerMenuOverlay .pm-center #pmXBlock {
+  width: 100%;
+  margin-top: 8px;
+}

--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
   </div>
 
   <div class="store-header">
-    <div class="store-title"><span class="icon-atlas store-icon-atlas" aria-hidden="true"></span> STORE</div>
+    <div class="store-title"><span class="store-title-icon" aria-hidden="true">🛒</span> STORE</div>
     <div class="store-coins">
       <div class="store-coin-display">
         <img src="img/icon_gold.png">

--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -15,6 +15,8 @@ async function initAuthFlow({
   const isTelegramReady = isTelegramMiniApp() || await waitForTelegramMiniApp();
   if (isTelegramReady) {
     document.body.classList.add('telegram-mini-app');
+    document.body.classList.add('is-telegram');
+    document.body.classList.remove('is-web');
     authState.telegramUser = getTelegramUserData();
     const telegramInitData = getTelegramInitData();
     const telegramIdentifier = String(
@@ -55,6 +57,8 @@ async function initAuthFlow({
   }
 
   document.body.classList.remove('telegram-mini-app');
+  document.body.classList.remove('is-telegram');
+  document.body.classList.add('is-web');
   clearAuthSessionState();
   logger.info('🌐 Browser mode — wallet auth');
   updateAuthUI();

--- a/js/screens.js
+++ b/js/screens.js
@@ -17,8 +17,10 @@ function setVisibilityClass(node, className, isVisible) {
 }
 
 function setMenuUiVisible(isVisible) {
-  setDisplay(DOM.audioTogglesGlobal, isVisible ? 'flex' : 'none');
+  const isTelegram = document.body.classList.contains('is-telegram') || document.body.classList.contains('telegram-mini-app');
+  setDisplay(DOM.audioTogglesGlobal, isVisible && isTelegram ? 'flex' : 'none');
   setDisplay(DOM.walletCorner, isVisible ? 'flex' : 'none');
+  if (DOM.walletCorner) DOM.walletCorner.classList.toggle('is-screen-hidden', !isVisible);
 }
 
 function setEyesVisibility(isVisible) {


### PR DESCRIPTION
### Motivation
- Address multiple UI regressions introduced earlier that showed duplicate audio controls, caused wallet/connect UI to overflow viewport, changed the Store icon incorrectly, and produced inconsistent donation card heights across wallet states. 
- Ensure fixes are platform-scoped so Web visuals remain unchanged while Telegram Mini App gets its own layout adjustments. 
- Keep changes narrowly focused on layout/visibility rules and do not alter gameplay, analytics, or wallet authentication logic. 

### Description
- Add explicit platform body classes at auth startup (`is-telegram` / `is-web`) so CSS/visibility is scoped reliably and avoids viewport-only heuristics (`js/auth-lifecycle.js`).
- Make menu visibility Telegram-scoped so legacy labeled global audio toggles are hidden on Web while Telegram keeps its top toggles (`js/screens.js`, `css/style.css`).
- Constrain wallet corner and wallet-info to safe-area-aware fixed positioning and viewport max-widths to prevent overflow and horizontal scroll on Web (`css/style.css`).
- Restore stable Store icon in markup and disable atlas fallback so Store icon is deterministic (`index.html`, `css/style.css`).
- Stabilize donation lot sizing by enforcing consistent min/height and clamping description text to prevent card-height jumps across wallet states (`css/style.css`).
- Apply Telegram-only fixes: pin start-page audio nav to top safe area, narrow Rules content and add safe top padding, ensure wallet/player corner is fixed and can be hidden per-screen, and ensure Player Menu X block can display inline beneath Connect Wallet via Telegram-specific styling (`css/style.css`).

### Testing
- Ran `npm run check:syntax`, which completed successfully for all JS files touched. 
- Ran `npm run test:request`, which mostly passed but reported a single existing unrelated failure in `scripts/game-loop-controller.test.mjs` (one assertion); this failure is pre-existing and not caused by these UI-only changes. 
- Manual sanity checks: verified Web main page no longer shows duplicate labeled audio toggles and Connect Wallet/wallet menu are constrained to the viewport; Telegram-scoped rules and audio nav styles were added and scoped to `body.is-telegram`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d417ef7883209249733b65db8206)