### PR TITLE
Fix web wallet controls overflowing viewport

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3169,8 +3169,33 @@ body.is-web #walletCorner .wallet-info {
   box-sizing: border-box;
 }
 
+body.is-web #walletCorner .wallet-btn-corner {
+  white-space: normal;
+  text-align: right;
+  word-break: break-word;
+}
+
 body.is-web #walletCorner .wallet-info {
+  width: 100%;
   overflow-wrap: anywhere;
+}
+
+body.is-web #walletCorner .wallet-info-row {
+  max-width: 100%;
+  justify-content: flex-end;
+  text-align: right;
+}
+
+body.is-web .pm-connect-wallet-top {
+  max-width: 100%;
+  width: 100%;
+}
+
+body.is-web .pm-connect-wallet-top .pm-side-btn {
+  width: auto;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; }


### PR DESCRIPTION
### Motivation
- Wallet connect UI on web could overflow the viewport when labels are long, causing `Connect Wallet` and the connected wallet panel to be clipped or shift off-screen.

### Description
- Updated web-scoped wallet corner styles in `css/style.css` to allow wrapping for the wallet button and prevent horizontal overflow by enabling `white-space: normal`, `word-break: break-word`, and right-aligning content.
- Made the wallet info area width-safe by setting `width: 100%` and ensuring `.wallet-info-row` uses right-aligned layout to keep values inside the viewport.
- Constrained the Player Menu top wallet connect area in web mode by setting `.pm-connect-wallet-top` and its `.pm-side-btn` to support wrapping and max-width so long labels remain within layout bounds.
- Changes are limited to `css/style.css` and do not modify JS behavior.

### Testing
- Ran `npm run -s build` and the production build completed successfully.
- Pre-commit static analysis reported unrelated baseline issues in the codebase (`js/game/session.js` size and unused exports in `js/renderer-readiness.js`) which prevented the pre-commit check from passing for this repo-wide policy.
- Verified the change is limited to `css/style.css` and the updated styles render without build-time errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d6c0e9c88320830b201b6a562dcf)