### PR TITLE
Fix Store icon regression: keep cart icon and rules-style fill

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -534,6 +534,15 @@ body.ui-stable #gameStart {
 
 #storeBtn {
   top: -20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.store-btn-icon,
+.store-title-icon {
+  color: #c084fc;
 }
 
 #startBtn {
@@ -3173,7 +3182,7 @@ body.is-web #walletCorner .wallet-info {
   overflow-wrap: anywhere;
 }
 
-.store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; }
+.store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; color: #c084fc; }
 .store-icon-atlas { display: none !important; }
 
 .store-panel--donation .donation-card {

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
   <div class="new-title">URSASS TUBE</div>
 
   <div class="new-buttons">
-    <button class="btn-new btn-new-store menu-hidden ui-btn ui-btn--secondary ui-btn--lg" id="storeBtn" data-action="show-store">STORE</button>
+    <button class="btn-new btn-new-store menu-hidden ui-btn ui-btn--secondary ui-btn--lg" id="storeBtn" data-action="show-store"><span class="store-btn-icon" aria-hidden="true">🛒</span> STORE</button>
     <div class="start-btn-wrap">
       <button class="btn-new btn-new-primary ui-btn ui-btn--primary ui-btn--lg" id="startBtn" data-action="start-game"><span class="btn-label">START GAME</span></button>
       <div id="startHook" class="start-hook" hidden aria-hidden="true">


### PR DESCRIPTION
### Motivation
- Restore a deterministic Store icon because it regressed to a random glyph selection and must always show the cart emoji with the same visual fill as the Rules headings.\
- Keep visual parity between the main menu Store button and the Store screen title for all builds and versions.\

### Description
- Hardcoded the cart emoji into the main menu Store button by adding a `<span class="store-btn-icon">🛒</span>` to `index.html`.\
- Ensured the Store screen title keeps the same cart glyph already present in `index.html` and kept both icons consistent.\
- Added layout CSS for `#storeBtn` to use `inline-flex` alignment and a `gap` to stabilize icon/text spacing and added color fill rules `.store-btn-icon, .store-title-icon { color: #c084fc; }` in `css/style.css`.\

### Testing
- Ran `npm run build` and the production build completed successfully.\
- Ran the project's syntax checks (`node scripts/check-syntax.mjs`) which passed for all listed JS files.\
- Ran static analysis (`node scripts/check-static-analysis.mjs`) which reported pre-existing violations (oversized `js/game/session.js` and unused exports in `js/renderer-readiness.js`) unrelated to this UI fix and therefore caused static-analysis to fail for the repo baseline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d7256aac8320b7915c05e6b67872)