### PR TITLE
Fix Telegram player menu Connect X reposition trigger

### DIFF
--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -196,7 +196,8 @@ function updateWalletBlock(profile) {
 
 
 function applyTelegramPlayerMenuLayout() {
-  if (!document.body.classList.contains('telegram-mini-app')) return;
+  const isTelegramClient = document.body.classList.contains('telegram-mini-app') || document.body.classList.contains('is-telegram');
+  if (!isTelegramClient) return;
 
   const walletBtn = DOM.pmConnectWalletBtn;
   const xBlock = DOM.pmXBlock;


### PR DESCRIPTION
### Motivation
- В Telegram-режиме блок «Connect X» должен быть размещён под кнопкой «Connect Wallet» в меню игрока, но в некоторых сессиях (когда на body ставится класс `is-telegram`) переупорядочивание не срабатывало.

### Description
- Изменил `applyTelegramPlayerMenuLayout` чтобы считать Telegram-клиентом страницу при наличии либо `telegram-mini-app`, либо `is-telegram` на `document.body`, после чего выполняется вставка `#pmXBlock` после `#pmConnectWalletBtn` и добавляется класс `pm-x-wrap--telegram-inline`.

### Testing
- Синтаксическая проверка `node --check js/player-menu/controller.js` прошла успешно.
- Прогон pre-commit/static-analysis зарегистрировал существующие, не связанные с этим изменением, предупреждения (например, превышение порога строк в `js/game/session.js` и неиспользуемые экспорты в `js/renderer-readiness.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d8fdd18c8320a3fd355c2f49d98a)