### PR TITLE
Remove legacy global audio toggles UI and references

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -124,92 +124,6 @@ body {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
-/* ===== GLOBAL AUDIO TOGGLES ===== */
-#audioTogglesGlobal {
-  position: fixed;
-  top: 10px;
-  left: 12px;
-  z-index: 9000;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.toggle-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 14px;
-  background: var(--glass);
-  backdrop-filter: blur(12px);
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  transition: border-color .3s, box-shadow .3s, transform .15s;
-}
-
-.toggle-row:active { transform: scale(0.97); }
-
-.toggle-row.active {
-  border-color: rgba(140, 80, 255, .35);
-  box-shadow: 0 0 10px rgba(140, 80, 255, .15);
-}
-
-.toggle-label {
-  font-family: 'Orbitron', sans-serif;
-  font-size: 11px;
-  opacity: .9;
-  width: 72px;
-  pointer-events: none;
-}
-
-/* Toggle switch */
-.switch {
-  position: relative;
-  width: 40px;
-  height: 22px;
-  flex-shrink: 0;
-}
-
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(255, 255, 255, .08);
-  border-radius: 22px;
-  transition: background .35s ease, box-shadow .35s ease;
-}
-
-.slider:before {
-  content: "";
-  position: absolute;
-  height: 16px;
-  width: 16px;
-  left: 3px;
-  bottom: 3px;
-  background: rgba(255, 255, 255, .35);
-  border-radius: 50%;
-  transition: transform .35s cubic-bezier(.4, .0, .2, 1), background .35s ease, box-shadow .35s ease;
-}
-
-input:checked + .slider {
-  background: linear-gradient(135deg, #8b5cf6, #6366f1);
-  box-shadow: 0 0 12px rgba(139, 92, 246, .4);
-}
-
-input:checked + .slider:before {
-  transform: translateX(18px);
-  background: linear-gradient(135deg, #c084fc, #e879f9);
-  box-shadow: 0 0 6px rgba(192, 132, 252, .5);
-}
-
 /* ===== WALLET CORNER ===== */
 #walletCorner {
   position: fixed;
@@ -820,7 +734,6 @@ body.ui-stable #gameStart {
   line-height: 1.6;
 }
 
-#audioTogglesGlobal,
 #walletCorner,
 #bear3d,
 #gameStart .new-title,
@@ -828,11 +741,6 @@ body.ui-stable #gameStart {
 #startLeaderboardWrap,
 #gameStart footer {
   transition: transform 0.9s cubic-bezier(.22, .8, .2, 1), opacity 0.7s ease, margin 0.9s cubic-bezier(.22, .8, .2, 1);
-}
-
-body.start-launching #audioTogglesGlobal {
-  transform: translateX(-180%);
-  opacity: 0;
 }
 
 body.start-launching #walletCorner {
@@ -1985,10 +1893,6 @@ footer a:hover { color: #e0b0ff; }
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 768px) {
-  #audioTogglesGlobal {
-    display: none !important;
-  }
-
   #storeScreen:not(.visible) .store-fixed-nav,
   #gameOver:not(.visible) .go-audio-nav {
     display: none;
@@ -3147,10 +3051,6 @@ body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
 }
 
 /* --- Platform scoped regression fixes (web + telegram) --- */
-body.is-web #audioTogglesGlobal {
-  display: none !important;
-}
-
 body.is-web #walletCorner {
   position: fixed;
   top: max(10px, env(safe-area-inset-top));

--- a/index.html
+++ b/index.html
@@ -19,24 +19,6 @@
 
 <body class="loading-ui">
   
-<!-- ===== Global toggle sound ===== -->
-<div id="audioTogglesGlobal">
-  <div class="toggle-row" id="sfxToggleRow">
-    <span class="toggle-label">🔊 Effects</span>
-    <label class="switch">
-      <input type="checkbox" id="sfxToggle" checked>
-      <span class="slider"></span>
-    </label>
-  </div>
-  <div class="toggle-row" id="musicToggleRow">
-    <span class="toggle-label">🎵 Music</span>
-    <label class="switch">
-      <input type="checkbox" id="musicToggle" checked>
-      <span class="slider"></span>
-    </label>
-  </div>
-</div>
-
 <!-- ===== WALLET + INFO ===== -->
 <div id="walletCorner">
   <div class="wallet-corner-row">

--- a/js/audio.js
+++ b/js/audio.js
@@ -171,16 +171,6 @@ function toggleSfxMute() { setSfxEnabled(!audioSettings.sfxEnabled); }
 function toggleMusicMute() { setMusicEnabled(!audioSettings.musicEnabled); }
 
 function syncAllAudioUI() {
-  const sfxCb = document.getElementById('sfxToggle');
-  const musicCb = document.getElementById('musicToggle');
-  const sfxRow = document.getElementById('sfxToggleRow');
-  const musicRow = document.getElementById('musicToggleRow');
-
-  if (sfxCb) sfxCb.checked = audioSettings.sfxEnabled;
-  if (musicCb) musicCb.checked = audioSettings.musicEnabled;
-  if (sfxRow) sfxRow.classList.toggle('active', audioSettings.sfxEnabled);
-  if (musicRow) musicRow.classList.toggle('active', audioSettings.musicEnabled);
-
   AUDIO_TOGGLE_BUTTONS.forEach(({ id, setting, enabledIcon, disabledIcon }) => {
     const button = document.getElementById(id);
     if (!button) return;
@@ -192,11 +182,6 @@ function syncAllAudioUI() {
 }
 
 function initAudioToggles() {
-  const sfxCb = document.getElementById('sfxToggle');
-  const musicCb = document.getElementById('musicToggle');
-  if (sfxCb) sfxCb.addEventListener('change', () => { setSfxEnabled(sfxCb.checked); });
-  if (musicCb) musicCb.addEventListener('change', () => { setMusicEnabled(musicCb.checked); });
-
   // Add explicit touchend listeners for all audio toggle buttons (mobile/Telegram fix)
   AUDIO_TOGGLE_BUTTONS.forEach(({ id, toggle }) => {
     const btn = document.getElementById(id);

--- a/js/input.js
+++ b/js/input.js
@@ -11,7 +11,7 @@ function isInteractiveElement(el) {
   if (!el) return false;
   const tag = el.tagName;
   if (tag === 'BUTTON' || tag === 'INPUT' || tag === 'LABEL' || tag === 'A' || tag === 'SELECT' || tag === 'TEXTAREA') return true;
-  if (el.closest('button, a, input, label, .toggle-row, .game-audio-nav, .store-nav-btn, .go-audio-nav, .go-btn, .btn-new, .wallet-btn-corner, .link-btn, #audioTogglesGlobal')) return true;
+  if (el.closest('button, a, input, label, .game-audio-nav, .store-nav-btn, .go-audio-nav, .go-btn, .btn-new, .wallet-btn-corner, .link-btn')) return true;
   return false;
 }
 

--- a/js/screens.js
+++ b/js/screens.js
@@ -17,8 +17,6 @@ function setVisibilityClass(node, className, isVisible) {
 }
 
 function setMenuUiVisible(isVisible) {
-  const isTelegram = document.body.classList.contains('is-telegram') || document.body.classList.contains('telegram-mini-app');
-  setDisplay(DOM.audioTogglesGlobal, isVisible && isTelegram ? 'flex' : 'none');
   setDisplay(DOM.walletCorner, isVisible ? 'flex' : 'none');
   if (DOM.walletCorner) DOM.walletCorner.classList.toggle('is-screen-hidden', !isVisible);
 }

--- a/js/state.js
+++ b/js/state.js
@@ -94,7 +94,6 @@ const DOM_IDS = {
   storeScreen: 'storeScreen',
   rulesScreen: 'rulesScreen',
   darkScreen: 'darkScreen',
-  audioTogglesGlobal: 'audioTogglesGlobal',
   walletCorner: 'walletCorner',
   ridesInfo: 'ridesInfo',
   ridesText: 'ridesText',


### PR DESCRIPTION
### Motivation
- Remove an older floating global audio toggles panel that conflicted with platform-specific audio controls and responsive layouts.
- Consolidate audio control behavior to the in-game audio buttons (`AUDIO_TOGGLE_BUTTONS`) and eliminate duplicate/unused DOM references.
- Reduce CSS/HTML/JS surface area and avoid touch/interaction conflicts on mobile/Telegram builds.

### Description
- Deleted the global audio toggles HTML block from `index.html` and removed related CSS rules from `css/style.css` to drop the floating switch panel and its styles.
- Removed `audioTogglesGlobal` from `DOM_IDS` in `js/state.js` and removed references to the global checkbox UI in `js/audio.js`, `js/input.js`, and `js/screens.js`, consolidating UI updates to `AUDIO_TOGGLE_BUTTONS` only.
- Updated `syncAllAudioUI()` and `initAudioToggles()` in `js/audio.js` to stop querying and wiring legacy checkbox inputs and rely solely on the existing button-based toggles.
- Adjusted `isInteractiveElement()` in `js/input.js` and screen visibility logic in `js/screens.js` to no longer treat the removed global toggles as interactive elements.

### Testing
- Ran project lint and build commands (`npm run lint`, `npm run build`) which completed successfully.
- Exercised the audio toggles in the app manually to verify the remaining `AUDIO_TOGGLE_BUTTONS` continue to toggle sound and update UI state correctly.
- No automated unit tests for the removed UI were modified during this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d65ee1488320ab383a94e44a3a9d)