### PR TITLE
Remove duplicate in-game audio toggle buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,12 +77,6 @@
         <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
-      <!-- In-game audio toggles -->
-      <div class="game-audio-nav">
-        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-      </div>
-
     </div>
   </div>
 </div>
@@ -94,6 +88,7 @@
     <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
     <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
   </div>
+
 
   <div class="bear-wrapper" id="bear3d">
     <img src="img/glow.png" class="layer glow" width="1000" height="1000" decoding="async">


### PR DESCRIPTION
### Motivation
- Remove duplicated in-game audio toggles from the gameplay HUD to avoid UI duplication and centralize audio controls in the start/app nav.

### Description
- Deleted the `.game-audio-nav` block containing `#gameSfxBtn` and `#gameMusicBtn` from `index.html`.

### Testing
- Ran the site build (`npm run build`) and the test suite (`npm test`), and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4dff4d5c48320bc00b2dd77b0462c)