### PR TITLE
Remove in-game and start-screen audio toggle buttons from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,23 +77,12 @@
         <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
-      <!-- In-game audio toggles -->
-      <div class="game-audio-nav">
-        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-      </div>
-
     </div>
   </div>
 </div>
 
 <!-- ===== GAME START ===== -->
 <div id="gameStart">
-
-  <div class="start-audio-nav app-fixed-nav">
-    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
-  </div>
 
   <div class="bear-wrapper" id="bear3d">
     <img src="img/glow.png" class="layer glow" width="1000" height="1000" decoding="async">


### PR DESCRIPTION
### Motivation
- Simplify the UI by removing redundant audio toggle buttons from both the in-game HUD and the start screen, presumably to consolidate audio controls or rely on a single control surface.

### Description
- Removed the in-page HTML markup for the in-game audio buttons (`#gameSfxBtn`, `#gameMusicBtn`) and the start-screen audio buttons (`#startSfxBtn`, `#startMusicBtn`) in `index.html`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4dff4d5c48320bc00b2dd77b0462c)