### PR TITLE
Fix web wallet corner viewport overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3069,18 +3069,28 @@ body.is-web #walletCorner {
   position: fixed;
   top: max(10px, env(safe-area-inset-top));
   right: max(12px, env(safe-area-inset-right));
-  max-width: calc(100vw - 24px);
+  left: auto;
+  max-width: calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)));
   box-sizing: border-box;
+  overflow: visible;
 }
 
 body.is-web #walletCorner .wallet-corner-row {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  row-gap: 6px;
   max-width: 100%;
 }
 
 body.is-web #walletCorner .wallet-btn-corner,
 body.is-web #walletCorner .wallet-info {
-  max-width: min(280px, calc(100vw - 24px));
+  max-width: min(280px, calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right))));
   box-sizing: border-box;
+}
+
+body.is-web #walletCorner .tg-account-badge {
+  max-width: min(42vw, calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)) - 56px));
 }
 
 body.is-web #walletCorner .wallet-btn-corner {
@@ -3092,6 +3102,7 @@ body.is-web #walletCorner .wallet-btn-corner {
 body.is-web #walletCorner .wallet-info {
   width: 100%;
   overflow-wrap: anywhere;
+  align-self: flex-end;
 }
 
 .store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; color: #c084fc; }


### PR DESCRIPTION
### Motivation
- The wallet corner UI (Connect Wallet button, Telegram badge, and wallet info) could overflow or shift outside the visible viewport on web browsers, causing horizontal scroll and clipped controls. 
- The goal is to fix positioning/overflow only, keep existing wallet UI and auth logic unchanged, and preserve Telegram Mini App layout rules. 
- Changes must respect safe-area insets and work across desktop, narrow, and mobile web widths. 

### Description
- Constrained `#walletCorner` width on Web to use a dynamic viewport-safe expression (`100dvw` minus safe-area insets) and set `left: auto` to avoid left-side drift, while allowing visible overflow where needed. 
- Made the top wallet row right-aligned and wrapable by forcing `display:flex`, `justify-content:flex-end`, `flex-wrap:wrap`, and `row-gap` so the `Connect Wallet` button and badges never push out of the viewport. 
- Restricted max widths for `.wallet-btn-corner`, `.wallet-info`, and `.tg-account-badge` in Web mode to prevent horizontal overflow and kept the wallet info panel anchored to the right with `align-self:flex-end`. 
- Changes are CSS-only and contained to `css/style.css` without touching any JavaScript authentication or UI logic. 

### Testing
- Pre-commit checks were executed which include `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed. 
- The updated `css/style.css` was inspected to verify the applied rules and ensure the wallet corner uses viewport-safe constraints and wrapping behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e43d1b7c8320ac2a6bb3fe3c7646)