### PR TITLE
Move Connect X under Connect Wallet in Player Menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,10 @@
       <div class="pm-rank">You're <span id="pmRankNumber">#—</span></div>
       <div class="pm-best">Best score: <span id="pmBestScore">0</span></div>
       <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
+      <div class="pm-side-x pm-x-wrap" id="pmXBlock">
+        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
+        <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
+      </div>
 
       <div class="pm-row pm-nickname-row">
         <label for="pmNicknameInput" class="pm-label">Nickname</label>
@@ -267,10 +271,6 @@
 
     <!-- Right column: account connections -->
     <aside class="pm-side">
-      <div class="pm-side-x pm-x-wrap" id="pmXBlock">
-        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
-        <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
-      </div>
       <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
     </aside>
   </div>


### PR DESCRIPTION
### Motivation
- The Telegram Mini App Player Menu required the `Connect X` button to appear directly under `Connect Wallet` for correct ordering in that environment. 
- This is a layout/markup-only fix that must not affect any auth logic or create duplicate buttons.

### Description
- Moved the existing `#pmXBlock` markup (containing `#pmConnectXBtn` and `#pmXDisconnectBtn`) into the Player Menu center column directly under the `#pmConnectWalletBtn` element in `index.html`.
- Removed the old `#pmXBlock` from the right-side account connections `aside` to avoid duplicates while preserving all IDs and classes so wiring remains unchanged.
- Change scope is limited to `index.html` and does not modify any JavaScript auth logic or styles.

### Testing
- Pre-commit syntax checks (`npm run check:syntax`) ran as part of the commit hooks and passed.
- Static analysis guard (`npm run check:static-analysis`) ran as part of the commit hooks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e865589c8320a2cf054fed539d08)