### PR TITLE
Fix game loop default render behavior

### DIFF
--- a/js/game/loop.js
+++ b/js/game/loop.js
@@ -72,7 +72,8 @@ function createGameLoopController({
     }
 
     const shouldUpdateSimulation = Boolean(gameState.simulationRunning || gameState.running);
-    const shouldRenderLiveGameplay = Boolean(gameState.heavyRenderEnabled && shouldUpdateSimulation);
+    const heavyRenderEnabled = gameState.heavyRenderEnabled !== false;
+    const shouldRenderLiveGameplay = Boolean(heavyRenderEnabled && shouldUpdateSimulation);
     const shouldRenderPreparingFrame = Boolean(gameState.preparingGameplay && !gameState.firstGameplayFrameReady);
 
     if (shouldRenderLiveGameplay || shouldRenderPreparingFrame) {


### PR DESCRIPTION
### Motivation
- A lifecycle test (`stopMainLoop prevents further RAF scheduling after current frame`) failed because gameplay rendering was skipped when `gameState.heavyRenderEnabled` was `undefined`, causing no render to occur before stopping the loop.
- The intent is to keep gameplay rendering enabled by default and only disable it when `heavyRenderEnabled` is explicitly set to `false` to preserve backward-compatible behavior.

### Description
- Change `createGameLoopController` in `js/game/loop.js` to compute `heavyRenderEnabled` as `gameState.heavyRenderEnabled !== false` and use that in the `shouldRenderLiveGameplay` gate. 
- This preserves existing simulation and preparing-frame conditions while restoring the expected default render semantics so frames are rendered unless explicitly opted out.

### Testing
- Ran the relevant test suite via `npm test -- --test scripts/game-loop-controller.test.mjs`, which includes `scripts/game-loop-controller.test.mjs`, and the failing test now passes along with the full suite. 
- Pre-commit checks (`scripts/check-syntax.mjs` and `scripts/check-static-analysis.mjs`) executed as part of the commit flow and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ee1913d88320a2cf80434d09302a)