### PR TITLE
Move `Connect Wallet` button under `Connect Telegram` in web player menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,6 @@
     <div class="pm-center">
       <div class="pm-rank">You're <span id="pmRankNumber">#—</span></div>
       <div class="pm-best">Best score: <span id="pmBestScore">0</span></div>
-      <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
       <div class="pm-side-x pm-x-wrap" id="pmXBlock">
         <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
         <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
@@ -272,6 +271,7 @@
     <!-- Right column: account connections -->
     <aside class="pm-side">
       <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
+      <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
     </aside>
   </div>
 </div>

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -205,7 +205,9 @@ function applyTelegramPlayerMenuLayout() {
   if (!walletBtn || !xBlock || !centerColumn) return;
 
   const walletParent = walletBtn.parentElement;
-  if (walletParent !== centerColumn) return;
+  if (walletParent && walletParent !== centerColumn) {
+    centerColumn.insertBefore(walletBtn, xBlock);
+  }
 
   if (xBlock.previousElementSibling !== walletBtn) {
     centerColumn.insertBefore(xBlock, walletBtn.nextSibling);


### PR DESCRIPTION
### Motivation
- Adjust player menu layout so the `Connect Wallet` control appears in the right account connections column for the web layout while preserving the Telegram in-app layout. 

### Description
- Moved the `Connect Wallet` button from the center column to the right sidebar in `index.html` so it is positioned directly under `Connect Telegram` in web builds. 
- Updated `applyTelegramPlayerMenuLayout()` in `js/player-menu/controller.js` to reinsert the wallet button into the center column next to the X block when the Telegram client layout is active. 
- Kept existing visibility logic in `updateWalletBlock()` so the button remains hidden/shown according to auth state. 

### Testing
- Ran the repository pre-commit checks which executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed. 
- Verified that `js` syntax checks included `js/player-menu/controller.js` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50a87fafc83208ccebf0882bc8668)