### PR TITLE
Add start-screen audio toggles for web and Telegram

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,11 @@
 <!-- ===== GAME START ===== -->
 <div id="gameStart">
 
+  <div class="start-audio-nav app-fixed-nav">
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+  </div>
+
   <div class="bear-wrapper" id="bear3d">
     <img src="img/glow.png" class="layer glow" width="1000" height="1000" decoding="async">
     <img src="img/bear.png" class="layer bear" width="1000" height="1000" decoding="async">


### PR DESCRIPTION
### Motivation
- Expose immediate audio controls on the main/home screen so users (web + Telegram mini-app) can mute/unmute without opening the store or game over screens.
- Keep behaviour consistent with existing audio toggles used elsewhere in the UI to avoid duplicating logic.

### Description
- Inserted a `start-audio-nav` block in `index.html` inside `#gameStart` with two buttons `startSfxBtn` and `startMusicBtn` to toggle SFX and music respectively.
- Buttons reuse `data-action="toggle-sfx"` and `data-action="toggle-music"` and existing shared classes (`app-audio-btn`, `app-fixed-nav`, etc.), so existing audio management code handles them.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- Pre-commit validation executed on commit and `npm run check:static-analysis` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50aeef49483208f4c0597992b2364)