### PR TITLE
Unify donation and upgrade card sizing and corner radius

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2320,11 +2320,11 @@ footer a:hover { color: #e0b0ff; }
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
-  min-height: 168px;
-  padding: 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(96,165,250,.18);
-  background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.03));
+  min-height: var(--store-upgrade-item-height, 176px);
+  padding: 14px 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-soft);
+  background: var(--glass);
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: 12px;
@@ -2371,7 +2371,7 @@ footer a:hover { color: #e0b0ff; }
   display: grid;
   gap: 12px;
   padding: 18px;
-  border-radius: 18px;
+  border-radius: var(--radius);
   border: 1px solid rgba(255,255,255,.08);
   background: rgba(255,255,255,.03);
 }


### PR DESCRIPTION
### Motivation
- Align Donation cards with Upgrade lot cards so both tabs share the same sizing and surface styling for a consistent store UI.

### Description
- Modified `css/style.css` to set `.donation-card` `min-height` to `var(--store-upgrade-item-height)`, use `border-radius: var(--radius)`, and swap border/background to shared tokens (`--border-soft`, `--glass`), and set `.donation-history` `border-radius: var(--radius)`.

### Testing
- Ran `npm run build` which completed successfully and pre-commit checks (`check:syntax` and `check:static-analysis`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50b65136883208f9871799257fbd5)