### PR TITLE
Fix filled Store icon rendering in Telegram mini app

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -457,6 +457,25 @@ body.ui-stable #gameStart {
 .store-btn-icon,
 .store-title-icon {
   color: #c084fc;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-size: 0;
+  line-height: 1;
+}
+
+.store-btn-icon::before,
+.store-title-icon::before {
+  content: '';
+  width: 100%;
+  height: 100%;
+  display: block;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23c084fc' d='M7 18c-1.1 0-1.99.9-1.99 2S5.9 22 7 22s2-.9 2-2-.9-2-2-2Zm10 0c-1.1 0-1.99.9-1.99 2S15.9 22 17 22s2-.9 2-2-.9-2-2-2ZM7.17 14h9.98c.75 0 1.41-.41 1.75-1.03l3.58-6.49a1 1 0 0 0-.88-1.48H6.21l-.94-2H2v2h2l3.6 7.59-1.35 2.45A1.99 1.99 0 0 0 8 18h12v-2H8l1.1-2Z'/%3E%3C/svg%3E");
 }
 
 #startBtn {


### PR DESCRIPTION
### Motivation
- Telegram clients render emoji differently (often as outlined glyphs), causing the Store icon to look inconsistent vs web. 
- The goal is visual parity: make the Store icon a consistent filled icon across Web and Telegram mini app views.

### Description
- Added CSS rules in `css/style.css` to replace emoji rendering with a fixed inline-SVG background using a `::before` pseudo-element for `.store-btn-icon` and `.store-title-icon`. 
- Set explicit icon container sizing and alignment (`inline-flex`, `18x18`, `font-size: 0`, centered) to avoid layout shifts across clients. 
- No JavaScript changes; only visual treatment via CSS data-URI SVG to ensure a filled appearance.

### Testing
- Ran `npm run check:syntax` which executes `scripts/check-syntax.mjs` and it completed successfully. 
- Pre-commit checks ran and `scripts/check-static-analysis.mjs` passed successfully during the commit hook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50cf9de948320a200c1295e3802cb)