### PR TITLE
Prevent horizontal dragging on Telegram rules screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3147,6 +3147,11 @@ body.is-telegram #rulesScreen .rules-section {
   max-width: calc(100vw - 104px);
   margin-left: auto;
   margin-right: auto;
+  touch-action: pan-y;
+}
+
+body.is-telegram #rulesScreen {
+  overflow-x: hidden;
 }
 
 body.is-telegram #walletCorner {


### PR DESCRIPTION
### Motivation
- In Telegram WebView the rules description blocks could be dragged horizontally by touch which produced unwanted layout shift, so horizontal movement needs to be eliminated to keep cards visually fixed.

### Description
- Add `touch-action: pan-y` to `body.is-telegram #rulesScreen .rules-content, body.is-telegram #rulesScreen .rules-section` and add `overflow-x: hidden` to `body.is-telegram #rulesScreen` in `css/style.css` to force vertical-only scrolling.

### Testing
- Pre-commit hooks ran the project checks which executed `npm run check:syntax` and `npm run check:static-analysis`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50d5502608320954b6b253e5d3fbd)