### PR TITLE
Telegram: keep wallet corner pinned and hide on deep scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3161,6 +3161,17 @@ body.is-telegram #walletCorner.is-screen-hidden {
   display: none !important;
 }
 
+body.is-telegram.is-telegram-wallet-corner-hidden-by-scroll #walletCorner {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-10px) !important;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+body.is-telegram #walletCorner {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
 body.is-telegram #playerMenuOverlay .pm-center #pmXBlock {
   width: 100%;
   margin-top: 8px;

--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -1,3 +1,47 @@
+function initTelegramWalletCornerScrollBehavior() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (window.__ursasTelegramWalletCornerScrollBound) return;
+
+  const body = document.body;
+  if (!body || !body.classList.contains('is-telegram')) return;
+
+  const HIDE_SCROLL_THRESHOLD = 180;
+  const SHOW_SCROLL_THRESHOLD = 72;
+  let lastKnownScrollY = 0;
+
+  const getActiveScrollTop = (eventTarget) => {
+    const globalScrollTop = Math.max(
+      window.scrollY || 0,
+      document.documentElement?.scrollTop || 0,
+      document.body?.scrollTop || 0,
+    );
+
+    const targetScrollTop = Number(eventTarget?.scrollTop || 0);
+    return Math.max(globalScrollTop, targetScrollTop);
+  };
+
+  const syncWalletCornerVisibility = (currentScrollTop) => {
+    const isScrollingDown = currentScrollTop > lastKnownScrollY;
+    if (currentScrollTop <= SHOW_SCROLL_THRESHOLD) {
+      body.classList.remove('is-telegram-wallet-corner-hidden-by-scroll');
+    } else if (currentScrollTop >= HIDE_SCROLL_THRESHOLD && isScrollingDown) {
+      body.classList.add('is-telegram-wallet-corner-hidden-by-scroll');
+    } else if (!isScrollingDown) {
+      body.classList.remove('is-telegram-wallet-corner-hidden-by-scroll');
+    }
+    lastKnownScrollY = currentScrollTop;
+  };
+
+  const handleScroll = (event) => {
+    syncWalletCornerVisibility(getActiveScrollTop(event?.target));
+  };
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  document.addEventListener('scroll', handleScroll, { passive: true, capture: true });
+  syncWalletCornerVisibility(getActiveScrollTop());
+  window.__ursasTelegramWalletCornerScrollBound = true;
+}
+
 async function initAuthFlow({
   isTelegramMiniApp,
   waitForTelegramMiniApp,
@@ -17,6 +61,7 @@ async function initAuthFlow({
     document.body.classList.add('telegram-mini-app');
     document.body.classList.add('is-telegram');
     document.body.classList.remove('is-web');
+    initTelegramWalletCornerScrollBehavior();
     authState.telegramUser = getTelegramUserData();
     const telegramInitData = getTelegramInitData();
     const telegramIdentifier = String(


### PR DESCRIPTION
### Motivation
- The Telegram client should keep the wallet block pinned at the top while scrolling and only hide it after a deep downward scroll.  
- When the user scrolls up or returns near the top, the wallet block must reappear.  
- Behavior must be Telegram-only (not affect regular web mode).

### Description
- Added `initTelegramWalletCornerScrollBehavior()` in `js/auth-lifecycle.js` which binds passive scroll listeners once and toggles visibility based on scroll direction and thresholds.  
- The initializer is invoked from `initAuthFlow` immediately after Telegram mode classes are applied so the feature runs only in Telegram clients.  
- Visibility logic uses `HIDE_SCROLL_THRESHOLD = 180` and `SHOW_SCROLL_THRESHOLD = 72` and toggles the body class `is-telegram-wallet-corner-hidden-by-scroll`.  
- Added CSS in `css/style.css` to smoothly hide/show `#walletCorner` when `body.is-telegram.is-telegram-wallet-corner-hidden-by-scroll` is present, disabling pointer events and animating `opacity`/`transform`.

### Testing
- Ran `npm run -s build` and the production build completed successfully and emitted chunks (build passed).  
- Pre-commit checks (syntax checks and static analysis) ran during commit and passed.  
- No automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50e345bc48320a43aec21b77aa282)