### PR TITLE
Adjust web walletCorner spacing and add .wallet-info-row to fix overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3068,9 +3068,9 @@ body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
 body.is-web #walletCorner {
   position: fixed;
   top: max(10px, env(safe-area-inset-top));
-  right: max(12px, env(safe-area-inset-right));
+  right: max(16px, env(safe-area-inset-right));
   left: auto;
-  max-width: calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)));
+  max-width: calc(100dvw - max(12px, env(safe-area-inset-left)) - max(16px, env(safe-area-inset-right)) - 6px);
   box-sizing: border-box;
   overflow: visible;
 }
@@ -3103,6 +3103,12 @@ body.is-web #walletCorner .wallet-info {
   width: 100%;
   overflow-wrap: anywhere;
   align-self: flex-end;
+}
+
+body.is-web #walletCorner .wallet-info-row {
+  max-width: 100%;
+  min-width: 0;
+  justify-content: flex-end;
 }
 
 .store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; color: #c084fc; }


### PR DESCRIPTION
### Motivation
- Fix layout and overflow issues for the web `#walletCorner` area so the wallet controls and text do not overlap safe-area insets and align correctly.

### Description
- Update `body.is-web #walletCorner` to use `right: max(16px, env(safe-area-inset-right))` and adjust the `max-width` calculation to subtract the larger inset plus 6px, and add a new `.wallet-info-row` rule to cap width and enable `justify-content: flex-end`.

### Testing
- Ran stylesheet lint and project build (`npm run lint:css`, `npm run build`), both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f509991d5c8320be876ae4a199a3f8)