### PR TITLE
Disable start screen eye/glow pulse animations in Telegram

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -332,6 +332,13 @@ body.ui-stable #gameStart {
   animation: eyeFlicker 4s ease-in-out infinite alternate;
 }
 
+body.is-telegram #gameStart .glow,
+body.telegram-mini-app #gameStart .glow,
+body.is-telegram #gameStart .eyes,
+body.telegram-mini-app #gameStart .eyes {
+  animation: none;
+}
+
 .particle {
   position: absolute;
   width: 4px; height: 4px;


### PR DESCRIPTION
### Motivation
- Убрать эффект пульсации у глаз и `glow` на главной странице для Telegram-версии (Mini App / `is-telegram`), чтобы снизить визуальную интенсивность в мобильном Telegram-клиенте.

### Description
- Добавлено правило в `css/style.css`: селекторы `body.is-telegram` и `body.telegram-mini-app` для `#gameStart .glow` и `#gameStart .eyes` устанавливают `animation: none;`, при этом поведение в веб/десктопе не изменилось.

### Testing
- Автоматические проверки прошли: pre-commit hooks сработали и `npm run check:syntax` и `node scripts/check-static-analysis.mjs` вернули успех.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f513e97dac8320b64f217a47693a1c)