### PR TITLE
fix: add static privacy and terms pages to Vite public output

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy — Ursass Tube</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0a0714; color: #f8fafc; line-height: 1.55; }
+    .wrap { max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }
+    h1,h2 { font-family: Orbitron, Inter, sans-serif; margin: 0 0 12px; }
+    h1 { font-size: 30px; }
+    h2 { font-size: 20px; margin-top: 28px; }
+    p, li { color: rgba(248,250,252,.92); }
+    ul { margin: 8px 0 0 20px; }
+    .meta { color: rgba(248,250,252,.7); margin-bottom: 24px; }
+    a { color: #c084fc; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Privacy Policy — Ursass Tube</h1>
+    <p class="meta">Last updated: April 28, 2026</p>
+
+    <p>This Privacy Policy explains how Ursass Tube collects, uses, stores, and protects user information when you use our Telegram Mini App and related bot.</p>
+    <p>Ursass Tube is an arcade runner game available through Telegram. The current version of the product is focused only on the Ursass Tube game experience: gameplay, score tracking, leaderboard, tasks, and related in-game features.</p>
+
+    <h2>1. Information We Collect</h2>
+    <h2>1.1 Telegram account information</h2>
+    <p>When you open Ursass Tube through Telegram, Telegram may provide us with limited account information, such as:</p>
+    <ul><li>Telegram user ID;</li><li>username;</li><li>first name;</li><li>profile photo, if available;</li><li>language code;</li><li>Telegram Mini App launch data.</li></ul>
+    <p>We use this information to identify your game profile, save your progress, and display your result in the leaderboard.</p>
+    <h2>1.2 Game data</h2>
+    <p>We may collect and store game-related data, including:</p>
+    <ul><li>current score;</li><li>best score;</li><li>leaderboard position;</li><li>coins or other in-game progress;</li><li>completed tasks;</li><li>ride/session history;</li><li>referral or invite activity, if used;</li><li>gameplay events needed for analytics and anti-cheat protection.</li></ul>
+    <h2>1.3 Technical data</h2>
+    <p>We may collect technical information needed to operate and improve the game, such as:</p>
+    <ul><li>device type;</li><li>operating system;</li><li>browser or Telegram client information;</li><li>app version;</li><li>error logs;</li><li>session timestamps;</li><li>approximate performance data.</li></ul>
+    <h2>1.4 Analytics data</h2>
+    <p>We may collect basic analytics events, such as:</p>
+    <ul><li>app opened;</li><li>game started;</li><li>game finished;</li><li>score submitted;</li><li>leaderboard opened;</li><li>task completed;</li><li>share button clicked.</li></ul>
+
+    <h2>2. How We Use Information</h2>
+    <p>We use collected information to provide access to the game; create and maintain your game profile; save your progress and scores; display leaderboard results; prevent cheating, abuse, and fake score submissions; improve gameplay, performance, and user experience; fix bugs and technical issues; analyze product usage; and communicate important product updates through the Telegram bot, where permitted.</p>
+
+    <h2>3. Leaderboard and Public Game Data</h2>
+    <p>If you submit a score, some information may be visible to other users in the leaderboard, such as username or display name, score, rank, and best result.</p>
+    <p>Do not use Ursass Tube if you do not want your public game result to appear in the leaderboard.</p>
+
+    <h2>4. Data Sharing</h2>
+    <p>We do not sell your personal data.</p>
+    <p>We may share limited information only when necessary: with infrastructure providers used to host and operate the game; with analytics or error-monitoring tools; if required by law or legal process; to protect the game from fraud, cheating, abuse, or security threats.</p>
+
+    <h2>5. Telegram Platform</h2>
+    <p>Ursass Tube operates as a Telegram Mini App. Your use of Telegram is also governed by Telegram’s own Privacy Policy and Terms of Service.</p>
+    <p>We are responsible only for the data processed by Ursass Tube. We do not control how Telegram processes your data.</p>
+
+    <h2>6. Data Security</h2>
+    <p>We take reasonable technical and organizational measures to protect user data.</p>
+    <p>Telegram Mini App launch data is validated on the server before being used for authentication or score-related features. We do not rely only on unsafe client-side data.</p>
+    <p>However, no system is completely secure, and we cannot guarantee absolute protection against all risks.</p>
+
+    <h2>7. Data Retention</h2>
+    <p>We keep user data only as long as needed to provide the game; maintain leaderboards; prevent abuse; analyze and improve the product; and comply with legal obligations.</p>
+    <p>We may delete inactive accounts, old gameplay sessions, or outdated technical logs at our discretion.</p>
+
+    <h2>8. User Rights</h2>
+    <p>Depending on your location, you may have the right to request access to your data, request correction of inaccurate data, request deletion of your data, object to certain processing, and request limitation of processing.</p>
+    <p>To make a request, contact us using the contact details below.</p>
+
+    <h2>9. Children</h2>
+    <p>Ursass Tube is not intended for children under the age required by applicable law to use online services without parental consent.</p>
+
+    <h2>10. Changes to This Privacy Policy</h2>
+    <p>We may update this Privacy Policy from time to time. If we make significant changes, we may notify users through the Telegram bot, the Mini App, or our website.</p>
+    <p>Your continued use of Ursass Tube after changes means that you accept the updated Privacy Policy.</p>
+
+    <h2>11. Contact</h2>
+    <p>Team: Justconnect-1<br>Project: Ursass Tube<br>Contact: @jamesbrowna<br>Website: <a href="https://ursasstube.fun">https://ursasstube.fun</a></p>
+  </main>
+</body>
+</html>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terms of Use — Ursass Tube</title>
+  <style>
+    body { margin: 0; font-family: Inter, Arial, sans-serif; background: #0a0714; color: #f8fafc; line-height: 1.55; }
+    .wrap { max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }
+    h1,h2 { font-family: Orbitron, Inter, sans-serif; margin: 0 0 12px; }
+    h1 { font-size: 30px; }
+    h2 { font-size: 20px; margin-top: 28px; }
+    p, li { color: rgba(248,250,252,.92); }
+    ul { margin: 8px 0 0 20px; }
+    .meta { color: rgba(248,250,252,.7); margin-bottom: 24px; }
+    a { color: #c084fc; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Terms of Use — Ursass Tube</h1>
+    <p class="meta">Last updated: April 28, 2026</p>
+
+    <p>These Terms of Use govern your access to and use of Ursass Tube, a Telegram Mini App arcade runner game.</p>
+    <p>By using Ursass Tube, you agree to these Terms. If you do not agree, do not use the game.</p>
+
+    <h2>1. About Ursass Tube</h2>
+    <p>Ursass Tube is an arcade runner game where players control a character, collect in-game items, complete tasks, and compete on the leaderboard.</p>
+    <p>The current version of Ursass Tube is focused only on the game experience. Other possible Ursas ecosystem products, tokens, NFTs, marketplace features, or related services are not part of the current Ursass Tube launch unless explicitly announced in official channels.</p>
+
+    <h2>2. Eligibility</h2>
+    <p>You may use Ursass Tube only if:</p>
+    <ul><li>you are allowed to use Telegram in your jurisdiction;</li><li>you comply with these Terms;</li><li>your use of the game does not violate applicable laws or regulations.</li></ul>
+    <p>If you are under the legal age required in your jurisdiction to use online services, you must have permission from a parent or legal guardian.</p>
+
+    <h2>3. Telegram Account</h2>
+    <p>Ursass Tube works through Telegram. To use the game, you may need a Telegram account.</p>
+    <p>You are responsible for keeping your Telegram account secure. We are not responsible for losses caused by unauthorized access to your Telegram account.</p>
+
+    <h2>4. Game Rules</h2>
+    <p>When using Ursass Tube, you agree not to:</p>
+    <ul><li>cheat or manipulate scores;</li><li>use bots, scripts, emulators, automation tools, or modified clients to gain an unfair advantage;</li><li>exploit bugs or vulnerabilities;</li><li>interfere with the game servers or infrastructure;</li><li>attempt to reverse engineer, attack, or disrupt the game;</li><li>impersonate other users;</li><li>use offensive, illegal, or abusive usernames or behavior;</li><li>submit fake, manipulated, or fraudulent gameplay data.</li></ul>
+    <p>We may remove scores, reset progress, restrict access, or ban users who violate these rules.</p>
+
+    <h2>5. Leaderboard</h2>
+    <p>Ursass Tube may include a public leaderboard.</p>
+    <p>By submitting a score, you agree that your Telegram display name, username, rank, and score may be shown to other users.</p>
+    <p>We reserve the right to remove suspicious, fraudulent, offensive, or technically invalid scores from the leaderboard.</p>
+
+    <h2>6. In-Game Items and Progress</h2>
+    <p>Ursass Tube may include in-game coins, tasks, upgrades, ride limits, or other game progress mechanics.</p>
+    <p>Unless explicitly stated otherwise:</p>
+    <ul><li>in-game items have no real-money value;</li><li>in-game progress cannot be exchanged for money;</li><li>in-game balances are part of the game experience only;</li><li>we may adjust game balance, rewards, prices, and mechanics at any time.</li></ul>
+
+    <h2>7. Donations or Payments</h2>
+    <p>Ursass Tube may include optional donation or payment features.</p>
+    <p>Any donation or payment is voluntary unless clearly stated otherwise. Donations do not guarantee leaderboard placement, rewards, prizes, special treatment, or future financial benefit.</p>
+    <p>Payment availability may depend on Telegram, third-party providers, your location, and applicable law.</p>
+
+    <h2>8. No Guarantee of Rewards</h2>
+    <p>Unless we publish separate official campaign rules, Ursass Tube does not guarantee prizes, financial rewards, tokens, NFTs, or other assets.</p>
+    <p>Any future contest, event, season, giveaway, or reward campaign must have separate rules and eligibility requirements.</p>
+    <p>Do not use Ursass Tube with the expectation of earning money or receiving financial rewards.</p>
+
+    <h2>9. Fair Play and Anti-Cheat</h2>
+    <p>We may use technical and behavioral checks to detect cheating, abuse, fake activity, or manipulated scores.</p>
+    <p>We may reject score submissions or remove leaderboard entries if we believe they are invalid, suspicious, or unfair.</p>
+    <p>We are not required to disclose the details of our anti-cheat systems.</p>
+
+    <h2>10. Availability and Updates</h2>
+    <p>We try to keep Ursass Tube available and functional, but we do not guarantee uninterrupted access.</p>
+    <p>The game may be unavailable due to:</p>
+    <ul><li>maintenance;</li><li>technical issues;</li><li>Telegram platform changes;</li><li>hosting or infrastructure problems;</li><li>updates;</li><li>security incidents;</li><li>force majeure events.</li></ul>
+    <p>We may update, modify, suspend, or discontinue parts of the game at any time.</p>
+
+    <h2>11. Intellectual Property</h2>
+    <p>Ursass Tube, including its name, characters, visuals, game design, interface, text, graphics, code, and related materials, belongs to the Ursass Tube project or its respective owners.</p>
+    <p>You may not copy, reproduce, distribute, modify, sell, or use Ursass Tube materials without permission, except as allowed by law.</p>
+
+    <h2>12. User Content</h2>
+    <p>If Ursass Tube allows you to submit usernames, messages, images, or other content, you are responsible for that content.</p>
+    <p>You must not submit content that is illegal, abusive, offensive, misleading, infringing, or harmful.</p>
+    <p>We may remove user content that violates these Terms or creates risk for the project or other users.</p>
+
+    <h2>13. Third-Party Services</h2>
+    <p>Ursass Tube may rely on third-party services, including Telegram, hosting providers, analytics tools, payment providers, or infrastructure services.</p>
+    <p>We are not responsible for the actions, availability, or policies of third-party services.</p>
+
+    <h2>14. Disclaimer</h2>
+    <p>Ursass Tube is provided “as is” and “as available.”</p>
+    <p>We do not guarantee that:</p>
+    <ul><li>the game will always be available;</li><li>the game will be free of bugs or errors;</li><li>scores or progress will never be lost;</li><li>the game will meet your expectations;</li><li>leaderboard positions will remain unchanged.</li></ul>
+    <p>To the maximum extent permitted by law, we disclaim all warranties, express or implied.</p>
+
+    <h2>15. Limitation of Liability</h2>
+    <p>To the maximum extent permitted by law, Ursass Tube and its team are not liable for indirect, incidental, special, consequential, or punitive damages, including loss of data, loss of progress, loss of access, loss of profits, or loss of opportunity.</p>
+
+    <h2>16. Termination</h2>
+    <p>We may suspend or terminate your access to Ursass Tube if:</p>
+    <ul><li>you violate these Terms;</li><li>you cheat or abuse the game;</li><li>your activity creates risk for the game or other users;</li><li>required by law or platform rules;</li><li>the game is discontinued.</li></ul>
+
+    <h2>17. Changes to These Terms</h2>
+    <p>We may update these Terms from time to time.</p>
+    <p>If we make significant changes, we may notify users through the Telegram bot, the Mini App, or the website.</p>
+    <p>Your continued use of Ursass Tube after changes means that you accept the updated Terms.</p>
+
+    <h2>18. Contact</h2>
+    <p>For questions about these Terms, contact us:</p>
+    <p>Team: Justconnect-1<br>Project: Ursass Tube<br>Contact: @jamesbrowna<br>Website: <a href="https://ursasstube.fun">https://ursasstube.fun</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Footer links `/privacy.html` and `/terms.html` returned 404 in production because those files were not present in the built output root.
- The simplest, stable fix is to provide static HTML files in Vite's `public/` folder so they are copied verbatim into the production `dist/` root and served at `/privacy.html` and `/terms.html`.

### Description
- Added `public/privacy.html` containing the Privacy Policy markup and styles so it becomes `dist/privacy.html` after build.
- Added `public/terms.html` containing the Terms of Use markup and styles so it becomes `dist/terms.html` after build.
- Kept existing footer links unchanged in `index.html` (`/privacy.html` and `/terms.html`) so they continue to open in a separate tab via `target="_blank"` and the main game page behavior remains unchanged.

### Testing
- Ran `npm run build` successfully which runs `vite build` and the build validation scripts (`node scripts/check-no-conflict-markers.mjs`).
- Verified presence of the artifacts with `test -f dist/privacy.html` and `test -f dist/terms.html`, both returned OK.
- Pre-commit automated checks including `npm run check:syntax` and the static analysis guard (`npm run check:static-analysis`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51559a7f4832087c5c7d54f0a0769)