### PR TITLE
Restore in-game audio toggles on gameplay HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,11 @@
         <div>FPS: <span id="fpsVal">60</span></div>
       </div>
 
+      <div class="game-audio-nav" aria-label="In-game audio controls">
+        <button class="game-audio-btn" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
+        <button class="game-audio-btn" id="gameMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+      </div>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Restore the missing in-game audio controls that were accidentally removed from the game HUD, which caused audio toggle buttons to disappear in both web and Telegram Mini App modes while the JS logic in `js/audio.js` still expected those DOM nodes.

### Description
- Inserted a `.game-audio-nav` block into `index.html` containing `#gameSfxBtn` and `#gameMusicBtn` with `data-action="toggle-sfx"` and `data-action="toggle-music"` so the existing audio handlers and styles are reconnected to the gameplay UI.

### Testing
- Ran pre-commit automated checks including `npm run check:syntax` and `npm run check:static-analysis` (static analysis guardrails) and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519352f888320b31b108a21a0e7c7)