### PR TITLE
Align wallet corner right inset with left controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3094,9 +3094,9 @@ body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
 body.is-web #walletCorner {
   position: fixed;
   top: max(10px, env(safe-area-inset-top));
-  right: max(16px, env(safe-area-inset-right));
+  right: max(12px, env(safe-area-inset-right));
   left: auto;
-  max-width: calc(100dvw - max(12px, env(safe-area-inset-left)) - max(16px, env(safe-area-inset-right)) - 6px);
+  max-width: calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)) - 6px);
   box-sizing: border-box;
   overflow: visible;
 }


### PR DESCRIPTION
### Motivation
- В web-режиме `#walletCorner` в правом верхнем углу находился слишком близко к правому краю, нужно сделать правый зазор симметричным левому (как у переключателей звука) для визуального баланса.

### Description
- В `css/style.css` изменён `right` у `body.is-web #walletCorner` с `max(16px, env(safe-area-inset-right))` на `max(12px, env(safe-area-inset-right))` и скорректирован связанный `max-width`, чтобы использовать тот же `max(12px, env(safe-area-inset-right))` в расчёте ширины.

### Testing
- Автоматические проверки, запущенные в pre-commit (`npm run check:syntax` и `npm run check:static-analysis`), успешно прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66563102c8326b9a6e7eab7648369)