### PR TITLE
Fix start screen audio toggles vertical position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -754,7 +754,7 @@ body.telegram-mini-app #gameStart .eyes {
 
 #gameStart.hidden { display: none; }
 
-#gameStart > :not(.bear-wrapper) {
+#gameStart > :not(.bear-wrapper):not(.start-audio-nav) {
   transform: translateY(var(--start-ui-offset-y));
 }
 


### PR DESCRIPTION
### Motivation
- The start-screen vertical offset (`--start-ui-offset-y`) was moving the sound/music toggle block on the main screen, causing the audio buttons to not stay pinned to the top in Web and Telegram views.

### Description
- Update in `css/style.css`: changed the selector from `#gameStart > :not(.bear-wrapper)` to `#gameStart > :not(.bear-wrapper):not(.start-audio-nav)` so the `.start-audio-nav` container is excluded from the global start-screen translate.

### Testing
- Automated pre-commit checks were executed including `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f666a07ec4832694394fe8d75eedf4)