### PR TITLE
Перенести кнопку Connect X под Connect Telegram в меню игрока (веб)

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,11 +219,6 @@
     <div class="pm-center">
       <div class="pm-rank">You're <span id="pmRankNumber">#—</span></div>
       <div class="pm-best">Best score: <span id="pmBestScore">0</span></div>
-      <div class="pm-side-x pm-x-wrap" id="pmXBlock">
-        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
-        <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
-      </div>
-
       <div class="pm-row pm-nickname-row">
         <label for="pmNicknameInput" class="pm-label">Nickname</label>
         <div class="pm-nickname-field">
@@ -281,6 +276,10 @@
     <!-- Right column: account connections -->
     <aside class="pm-side">
       <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
+      <div class="pm-side-x pm-x-wrap" id="pmXBlock">
+        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
+        <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
+      </div>
       <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
     </aside>
   </div>


### PR DESCRIPTION
### Motivation
- Упростить расположение аккаунт-кнопок в веб-версии player menu — разместить `Connect X` под `Connect Telegram` для более логичной и компактной правой колонки.

### Description
- Перемещён блок X (`pmXBlock`, `pmConnectXBtn`, `pmXDisconnectBtn`) из центральной колонки в правую колонку аккаунтов в `index.html`, при этом сохранены те же `id` и структура кнопок чтобы существующая логика JS продолжила работать.

### Testing
- Пред-commit хук автоматически запустил `npm run check:syntax` и `npm run check:static-analysis`, и обе проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6679432848326b86709cf725d3766)