### PR TITLE
Fix Telegram store title icon to match filled web style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3138,6 +3138,12 @@ body.is-web #walletCorner .wallet-info-row {
 }
 
 .store-title-icon { font-size: 18px; line-height: 1; margin-right: 8px; color: #c084fc; }
+body.is-telegram .store-title-icon,
+body.telegram-mini-app .store-title-icon {
+  width: 18px;
+  height: 18px;
+  font-size: 0;
+}
 .store-icon-atlas { display: none !important; }
 
 .store-panel--donation .donation-card {


### PR DESCRIPTION
### Motivation
- Telegram displays the store title as an emoji text glyph which differs from the filled icon used on web, so we need to force the filled glyph for Telegram contexts.

### Description
- Added a Telegram-scoped CSS override in `css/style.css` for `.store-title-icon` (scoped to `body.is-telegram` and `body.telegram-mini-app`) that sets `width: 18px`, `height: 18px` and `font-size: 0` so the existing filled pseudo-element icon is shown instead of emoji text.

### Testing
- Pre-commit hooks were executed and passed, including `node scripts/check-syntax.mjs` and `node scripts/check-static-analysis.mjs`."}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f669b30f048326938b0e071fc88c68)