### PR TITLE
Lower in-game audio toggles to bottom edge for Web & Telegram

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3091,6 +3091,13 @@ body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
 }
 
 /* --- Platform scoped regression fixes (web + telegram) --- */
+
+
+body.is-web .game-audio-nav,
+body.is-telegram .game-audio-nav,
+body.telegram-mini-app .game-audio-nav {
+  bottom: max(14px, calc(env(safe-area-inset-bottom, 0px) + 8px));
+}
 body.is-web #walletCorner {
   position: fixed;
   top: max(10px, env(safe-area-inset-top));


### PR DESCRIPTION
### Motivation
- Ensure the in-game audio toggles sit at the same vertical level as other bottom HUD elements on Web and Telegram while respecting device safe areas.

### Description
- Inserted a platform-scoped CSS override in `css/style.css` for `body.is-web .game-audio-nav`, `body.is-telegram .game-audio-nav`, and `body.telegram-mini-app .game-audio-nav` that sets `bottom: max(14px, calc(env(safe-area-inset-bottom, 0px) + 8px));`.

### Testing
- Pre-commit automated checks ran during the commit, specifically `npm run check:syntax` and `npm run check:static-analysis`, and both passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66bd8ec788326949241a1a16b59fa)