### PR TITLE
Telegram: place Connect X and Connect Wallet under Best score in player menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3034,6 +3034,18 @@ body.telegram-mini-app .pm-side-x.pm-x-wrap--telegram-inline {
   margin-top: 6px;
 }
 
+body.telegram-mini-app .pm-telegram-connect-row,
+body.is-telegram .pm-telegram-connect-row {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+body.telegram-mini-app .pm-telegram-connect-row .pm-side-btn,
+body.is-telegram .pm-telegram-connect-row .pm-side-btn {
+  width: 100%;
+}
+
 /* Game Over share button variants */
 .go-btn-share.is-connect-x {
   background: linear-gradient(135deg, rgba(0,0,0,.6), rgba(30,30,30,.75));

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -202,16 +202,18 @@ function applyTelegramPlayerMenuLayout() {
   const walletBtn = DOM.pmConnectWalletBtn;
   const xBlock = DOM.pmXBlock;
   const centerColumn = document.querySelector('.pm-center');
-  if (!walletBtn || !xBlock || !centerColumn) return;
+  const bestScore = centerColumn?.querySelector('.pm-best');
+  if (!walletBtn || !xBlock || !centerColumn || !bestScore) return;
 
-  const walletParent = walletBtn.parentElement;
-  if (walletParent && walletParent !== centerColumn) {
-    centerColumn.insertBefore(walletBtn, xBlock);
+  let connectRow = centerColumn.querySelector('.pm-telegram-connect-row');
+  if (!connectRow) {
+    connectRow = document.createElement('div');
+    connectRow.className = 'pm-telegram-connect-row';
+    bestScore.insertAdjacentElement('afterend', connectRow);
   }
 
-  if (xBlock.previousElementSibling !== walletBtn) {
-    centerColumn.insertBefore(xBlock, walletBtn.nextSibling);
-  }
+  connectRow.appendChild(xBlock);
+  connectRow.appendChild(walletBtn);
   xBlock.classList.add('pm-x-wrap--telegram-inline');
 }
 


### PR DESCRIPTION
### Motivation
- On Telegram clients the player menu should surface account/connect actions directly under the player "Best score" to improve discoverability and match the mobile layout requirements. 

### Description
- Updated `applyTelegramPlayerMenuLayout` in `js/player-menu/controller.js` to create a `.pm-telegram-connect-row` and move the `pmXBlock` (Connect X) and `pmConnectWalletBtn` (Connect Wallet) into it immediately after the `.pm-best` element when body contains `telegram-mini-app` or `is-telegram`.
- The buttons are appended in the order `Connect X` then `Connect Wallet` to match the requested placement.
- Added Telegram-scoped styles in `css/style.css` for `.pm-telegram-connect-row` to use a vertical grid, gap spacing and full-width `.pm-side-btn` so the change affects only Telegram clients.

### Testing
- Ran project pre-commit checks which executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks completed successfully.
- Confirmed the modified files are `js/player-menu/controller.js` and `css/style.css` and that the commit was created without failing hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66da98ad08326b5be0c9f30a10b49)