### PR TITLE
Сместить окантовку трубы на 3px вверх только для Telegram-версии

### DIFF
--- a/js/phaser/tunnel/TunnelRenderer.js
+++ b/js/phaser/tunnel/TunnelRenderer.js
@@ -437,7 +437,12 @@ class TunnelRenderer {
     const borderScale = clamp(CONFIG.TUBE_RADIUS / 278, 0.75, 1.1);
     const rimLift = Math.max(0, (278 - CONFIG.TUBE_RADIUS) * 0.25);
     const mobileTubeDropPx = CONFIG.TUBE_RADIUS <= 230 ? 6 : 0;
-    const ringCenterY = centerY - rimLift - mobileTubeDropPx;
+    const isTelegramClient = Boolean(
+      document?.body?.classList?.contains('is-telegram')
+      || document?.body?.classList?.contains('telegram-mini-app')
+    );
+    const telegramRingLiftPx = isTelegramClient ? 3 : 0;
+    const ringCenterY = centerY - rimLift - mobileTubeDropPx - telegramRingLiftPx;
     const centerShift = Math.hypot(tube.centerOffsetX || 0, tube.centerOffsetY || 0);
     const shiftBoost = clamp(centerShift / 120, 0, 0.22);
 


### PR DESCRIPTION
### Motivation
- Устранить визуальное смещение окантовки (rim) трубы в Telegram-мини-приложении, переместив её на 3px вверх только для Telegram-клиента.

### Description
- Добавлена детекция Telegram-клиента через `document?.body?.classList?.contains('is-telegram')` или `document?.body?.classList?.contains('telegram-mini-app')` в `drawMouthRing`.
- При Telegram-клиенте вводится `telegramRingLiftPx = 3` и `ringCenterY` смещается на это значение в `js/phaser/tunnel/TunnelRenderer.js`.
- Поведение для веб-версии не изменилось.

### Testing
- Pre-commit запустил `npm run check:syntax` и `npm run check:static-analysis`, оба прогона успешно прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66fa3bb4c8326813b759bd5eceb93)