### PR TITLE
Pin Telegram main-screen top controls (audio/menu) on scroll

### DIFF
--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -5,40 +5,9 @@ function initTelegramWalletCornerScrollBehavior() {
   const body = document.body;
   if (!body || !body.classList.contains('is-telegram')) return;
 
-  const HIDE_SCROLL_THRESHOLD = 180;
-  const SHOW_SCROLL_THRESHOLD = 72;
-  let lastKnownScrollY = 0;
-
-  const getActiveScrollTop = (eventTarget) => {
-    const globalScrollTop = Math.max(
-      window.scrollY || 0,
-      document.documentElement?.scrollTop || 0,
-      document.body?.scrollTop || 0,
-    );
-
-    const targetScrollTop = Number(eventTarget?.scrollTop || 0);
-    return Math.max(globalScrollTop, targetScrollTop);
-  };
-
-  const syncWalletCornerVisibility = (currentScrollTop) => {
-    const isScrollingDown = currentScrollTop > lastKnownScrollY;
-    if (currentScrollTop <= SHOW_SCROLL_THRESHOLD) {
-      body.classList.remove('is-telegram-wallet-corner-hidden-by-scroll');
-    } else if (currentScrollTop >= HIDE_SCROLL_THRESHOLD && isScrollingDown) {
-      body.classList.add('is-telegram-wallet-corner-hidden-by-scroll');
-    } else if (!isScrollingDown) {
-      body.classList.remove('is-telegram-wallet-corner-hidden-by-scroll');
-    }
-    lastKnownScrollY = currentScrollTop;
-  };
-
-  const handleScroll = (event) => {
-    syncWalletCornerVisibility(getActiveScrollTop(event?.target));
-  };
-
-  window.addEventListener('scroll', handleScroll, { passive: true });
-  document.addEventListener('scroll', handleScroll, { passive: true, capture: true });
-  syncWalletCornerVisibility(getActiveScrollTop());
+  // Telegram main screen UX: keep wallet/player menu controls pinned at top-right.
+  // No scroll-reactive hiding in mini app mode.
+  body.classList.remove('is-telegram-wallet-corner-hidden-by-scroll');
   window.__ursasTelegramWalletCornerScrollBound = true;
 }
 


### PR DESCRIPTION
### Motivation
- The Telegram Mini App main screen should keep audio toggles and the player-menu/wallet corner fixed at the top and not hide/move when the user scrolls. 
- Current scroll-reactive hiding caused controls to drift or disappear on the main page in Telegram mode, breaking expected UX.

### Description
- Removed the scroll-reactive hide/show logic and event listeners from `initTelegramWalletCornerScrollBehavior` in `js/auth-lifecycle.js` so controls are no longer toggled by scroll thresholds. 
- Explicitly clear the `is-telegram-wallet-corner-hidden-by-scroll` class on init to ensure top-right controls remain visible and pinned. 
- Change applies only in Telegram mode (`body.is-telegram`) and does not affect web behavior. 
- One file modified: `js/auth-lifecycle.js` (removed thresholds/handlers and replaced with a pinned behavior comment and class removal).

### Testing
- Pre-commit automated checks ran during the commit, including `npm run check:syntax`, and all syntax checks passed. 
- Static analysis guardrails executed via `npm run check:static-analysis` and passed. 
- Changes were committed after the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67286c52c8326b5c43245ce59af48)