### PR TITLE
Adjust Telegram spacing between nav controls and Rules/Store content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3206,10 +3206,28 @@ body.is-telegram #rulesScreen {
 body.is-telegram #rulesScreen .rules-content,
 body.is-telegram #rulesScreen .rules-section {
   width: min(82vw, 380px);
-  max-width: calc(100vw - 104px);
+  max-width: calc(100vw - 116px);
   margin-left: auto;
   margin-right: auto;
   touch-action: pan-y;
+}
+
+body.is-telegram #storeScreen,
+body.telegram-mini-app #storeScreen {
+  padding-left: 78px;
+}
+
+body.is-telegram #storeScreen .store-header,
+body.telegram-mini-app #storeScreen .store-header,
+body.is-telegram #storeScreen .store-tabs,
+body.telegram-mini-app #storeScreen .store-tabs,
+body.is-telegram #storeScreen .store-list,
+body.telegram-mini-app #storeScreen .store-list,
+body.is-telegram #storeScreen .store-donation-shell,
+body.telegram-mini-app #storeScreen .store-donation-shell,
+body.is-telegram #storeScreen .store-donation-grid,
+body.telegram-mini-app #storeScreen .store-donation-grid {
+  max-width: calc(100vw - 116px);
 }
 
 body.is-telegram #rulesScreen {


### PR DESCRIPTION
### Motivation
- Ensure a consistent horizontal gap on Telegram clients between the fixed left nav (sound toggles / back button) and page content for Rules and Store screens.
- Cover both Telegram web wrapper and mini-app variants so layouts remain consistent across embed modes.

### Description
- Modified `css/style.css` to increase the Rules content width reservation by changing `body.is-telegram #rulesScreen .rules-content` / `.rules-section` `max-width` to `calc(100vw - 116px)` so cards sit further from the left fixed nav.
- Added Telegram-only left padding for the Store screen via `body.is-telegram #storeScreen, body.telegram-mini-app #storeScreen { padding-left: 78px; }` to shift the whole store content away from the left controls.
- Constrained Store inner blocks by setting `max-width: calc(100vw - 116px)` for `.store-header`, `.store-tabs`, `.store-list`, `.store-donation-shell`, and `.store-donation-grid` under both `body.is-telegram` and `body.telegram-mini-app` scopes.
- Changes are implemented in a single stylesheet file: `css/style.css`.

### Testing
- Pre-commit quality checks ran during the change and passed, including the `check:syntax` script and the `check:static-analysis` guardrails.
- No automated UI tests were modified; visual spacing change validated via static checks only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f679729358832694dcc8945eb0dff9)