### PR TITLE
Unify store and donation card styles across Web and Telegram

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1419,18 +1419,24 @@ body.start-launching #walletCorner {
   padding-left: 0;
 }
 
-.store-item {
-  background: var(--glass);
+.store-item,
+.donation-card {
+  background: linear-gradient(180deg, rgba(18, 18, 36, 0.92), rgba(14, 14, 30, 0.94));
   backdrop-filter: blur(10px);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(139, 92, 246, 0.3);
   border-radius: var(--radius);
-  padding: 14px 16px;
-  transition: .3s;
+  box-shadow: 0 10px 30px rgba(3, 7, 28, 0.42), inset 0 0 0 1px rgba(147, 197, 253, 0.08);
+  transition: border-color .28s ease, box-shadow .28s ease, background .28s ease, transform .28s ease;
 }
 
-.store-item:hover {
-  border-color: var(--border-accent);
-  box-shadow: 0 0 12px rgba(140, 80, 255, .1);
+.store-item {
+  padding: 14px 16px;
+}
+
+.store-item:hover,
+.donation-card:hover {
+  border-color: rgba(96, 165, 250, 0.56);
+  box-shadow: 0 14px 36px rgba(30, 64, 175, 0.28), inset 0 0 0 1px rgba(125, 211, 252, 0.22);
 }
 
 .store-item-header {
@@ -2348,9 +2354,6 @@ footer a:hover { color: #e0b0ff; }
   box-sizing: border-box;
   min-height: var(--store-upgrade-item-height, 176px);
   padding: 14px 16px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border-soft);
-  background: var(--glass);
   display: grid;
   grid-template-rows: auto 1fr auto;
   gap: 12px;


### PR DESCRIPTION
### Motivation
- Ensure identical visual treatment for upgrade cards and donation cards across web and Telegram clients by unifying background, border, shadow and hover feedback.
- Reduce duplicated CSS for card base styles to simplify maintenance and avoid platform drift.

### Description
- Merged common base styles into a shared selector so `.store-item` and `.donation-card` now share the same background, border, radius, shadow and transitions in `css/style.css`.
- Introduced a shared hover state for `.store-item:hover` and `.donation-card:hover` to provide consistent interactive feedback (accented border + enhanced shadow).
- Removed duplicated border/background definitions from the `.donation-card` block while keeping its layout, sizing and padding intact.
- Change is CSS-only and confined to `css/style.css`.

### Testing
- Ran `npm run -s check:syntax` and it completed successfully.
- Pre-commit validation executed `npm run check:syntax` and `npm run check:static-analysis`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67a4f21cc8326bc26f4d57d989fa5)