### PR TITLE
Lower in-game audio toggles for Telegram clients

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3121,10 +3121,13 @@ body.telegram-mini-app #rulesScreen .rules-fixed-nav {
   z-index: 9000;
 }
 
-body.is-web .game-audio-nav,
+body.is-web .game-audio-nav {
+  bottom: max(14px, calc(env(safe-area-inset-bottom, 0px) + 8px));
+}
+
 body.is-telegram .game-audio-nav,
 body.telegram-mini-app .game-audio-nav {
-  bottom: max(14px, calc(env(safe-area-inset-bottom, 0px) + 8px));
+  bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) + 2px));
 }
 body.is-web #walletCorner {
   position: fixed;


### PR DESCRIPTION
### Motivation
- Telegram in-app UI places the audio toggle buttons too close to other controls, so the toggles should be positioned lower only for Telegram clients to match the provided screenshot.

### Description
- Updated `css/style.css` to split `.game-audio-nav` platform rules and set `body.is-telegram`/`body.telegram-mini-app` to `bottom: max(6px, calc(env(safe-area-inset-bottom, 0px) + 2px))` while preserving the original `body.is-web` baseline.

### Testing
- Pre-commit hooks ran and passed `npm run check:syntax` and `npm run check:static-analysis`, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67d09bff883268092d57de3e6c9e1)