### PR TITLE
Hide start-screen particles in Telegram mini app

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -339,6 +339,11 @@ body.telegram-mini-app #gameStart .eyes {
   animation: none;
 }
 
+body.is-telegram #gameStart .particle,
+body.telegram-mini-app #gameStart .particle {
+  display: none;
+}
+
 .particle {
   position: absolute;
   width: 4px; height: 4px;


### PR DESCRIPTION
### Motivation
- Remove decorative upward-floating particles on the main start screen for Telegram Mini App clients to provide a cleaner, lighter UI in that environment.

### Description
- Added Telegram-scoped CSS to `css/style.css` that hides `#gameStart .particle` when `body` contains `is-telegram` or `telegram-mini-app` (two lines inserted to disable the particles only for Telegram clients).

### Testing
- Pre-commit automated checks ran during the commit, including `npm run check:syntax` and `npm run check:static-analysis`, and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68005844883269b9642e52b00c236)