### PR TITLE
Увеличить ширину блоков правил в Telegram-лейауте

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3211,8 +3211,8 @@ body.is-telegram #rulesScreen {
 
 body.is-telegram #rulesScreen .rules-content,
 body.is-telegram #rulesScreen .rules-section {
-  width: min(82vw, 380px);
-  max-width: calc(100vw - 116px);
+  width: min(90vw, 420px);
+  max-width: calc(100vw - 84px);
   margin-left: auto;
   margin-right: auto;
   touch-action: pan-y;


### PR DESCRIPTION
### Motivation
- В Telegram-версии страницы `rules` блоки описания были излишне узкими и часто разбивали текст на короткие строки. 
- Нужно увеличить доступное горизонтальное пространство для улучшения читаемости в Telegram-клиентах.

### Description
- Обновлён файл `css/style.css`, в Telegram-override для `body.is-telegram #rulesScreen .rules-content, .rules-section` изменено `width: min(82vw, 380px)` на `width: min(90vw, 420px)`.
- Также изменено `max-width: calc(100vw - 116px)` на `max-width: calc(100vw - 84px)` для тех же селекторов.

### Testing
- Прогоны пред-коммита включающие `check:syntax` были выполнены и прошли успешно.
- Прогоны `check:static-analysis` были выполнены и прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6817e80408326b68c275e6e6856c8)