### PR TITLE
Fix web wallet corner horizontal spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3139,7 +3139,7 @@ body.is-web #walletCorner {
   top: max(10px, env(safe-area-inset-top));
   right: max(12px, env(safe-area-inset-right));
   left: auto;
-  max-width: calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)) - 6px);
+  max-width: calc(100% - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)));
   box-sizing: border-box;
   overflow: visible;
 }
@@ -3154,12 +3154,12 @@ body.is-web #walletCorner .wallet-corner-row {
 
 body.is-web #walletCorner .wallet-btn-corner,
 body.is-web #walletCorner .wallet-info {
-  max-width: min(280px, calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right))));
+  max-width: min(280px, calc(100% - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right))));
   box-sizing: border-box;
 }
 
 body.is-web #walletCorner .tg-account-badge {
-  max-width: min(42vw, calc(100dvw - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)) - 56px));
+  max-width: min(42vw, calc(100% - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)) - 56px));
 }
 
 body.is-web #walletCorner .wallet-btn-corner {


### PR DESCRIPTION
### Motivation
- Исправить съехавшую вправо кнопку `Connect Wallet` в веб-версии, где использование `100dvw` могло учитывать ширину скроллбара и давать меньше пространства справа.

### Description
- Обновлён `css/style.css`: заменены `100dvw` на `100%` в правилах `body.is-web #walletCorner`, в ограничениях `max-width` для `.wallet-btn-corner`/`.wallet-info` и для `.tg-account-badge`, чтобы слева и справа были одинаковые визуальные отступы.

### Testing
- Пред-коммитные проверки (включая синтакс-проверку `npm run check:syntax` и статический анализ `check-static-analysis`) были запущены и прошли успешно; изменения закоммичены.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f68688c2688326a9195adc0228dec5)