### PR TITLE
Fix wallet corner: prevent label wrap and keep 20px right gap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3137,9 +3137,9 @@ body.telegram-mini-app .game-audio-nav {
 body.is-web #walletCorner {
   position: fixed;
   top: max(10px, env(safe-area-inset-top));
-  right: max(12px, env(safe-area-inset-right));
+  right: calc(env(safe-area-inset-right, 0px) + 20px);
   left: auto;
-  max-width: calc(100% - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)));
+  max-width: calc(100% - max(12px, env(safe-area-inset-left)) - calc(env(safe-area-inset-right, 0px) + 20px));
   box-sizing: border-box;
   overflow: visible;
 }
@@ -3154,18 +3154,20 @@ body.is-web #walletCorner .wallet-corner-row {
 
 body.is-web #walletCorner .wallet-btn-corner,
 body.is-web #walletCorner .wallet-info {
-  max-width: min(280px, calc(100% - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right))));
+  max-width: min(280px, calc(100% - max(12px, env(safe-area-inset-left)) - calc(env(safe-area-inset-right, 0px) + 20px)));
   box-sizing: border-box;
 }
 
 body.is-web #walletCorner .tg-account-badge {
-  max-width: min(42vw, calc(100% - max(12px, env(safe-area-inset-left)) - max(12px, env(safe-area-inset-right)) - 56px));
+  max-width: min(42vw, calc(100% - max(12px, env(safe-area-inset-left)) - calc(env(safe-area-inset-right, 0px) + 20px) - 56px));
 }
 
 body.is-web #walletCorner .wallet-btn-corner {
-  white-space: normal;
-  text-align: right;
-  word-break: break-word;
+  width: 156px;
+  min-width: 156px;
+  white-space: nowrap;
+  text-align: center;
+  word-break: normal;
 }
 
 body.is-web #walletCorner .wallet-info {
@@ -3248,7 +3250,7 @@ body.is-telegram #rulesScreen {
 body.is-telegram #walletCorner {
   position: fixed;
   top: max(8px, env(safe-area-inset-top));
-  right: max(12px, env(safe-area-inset-right));
+  right: calc(env(safe-area-inset-right, 0px) + 20px);
   z-index: 8000;
   transform: none !important;
 }


### PR DESCRIPTION
### Motivation
- Prevent the `Connect Wallet` label from breaking onto two lines in web builds so the button remains visually stable.
- Ensure the wallet button and its dropdown/menu never touch or overflow the browser right edge by keeping a 20px gap (with safe-area support).
- Avoid layout/overflow issues for the wallet badge and info block on narrow viewports in web mode.

### Description
- Updated `body.is-web #walletCorner` to use `right: calc(env(safe-area-inset-right, 0px) + 20px)` and adjusted `max-width` calculations to subtract the extra 20px spacing.
- Adjusted `body.is-web #walletCorner .wallet-btn-corner` to be fixed-width (`width: 156px; min-width: 156px`), use `white-space: nowrap`, center the text, and disable word-breaking to keep the label on one line.
- Updated `max-width` for `.wallet-info`/`.wallet-btn-corner`/`.tg-account-badge` calculations to account for the new right inset so menus do not overflow the viewport.
- Applied the same 20px safe-area right offset for `body.is-telegram #walletCorner` to keep consistent spacing across environments.

### Testing
- Ran the repository pre-commit checks which executed `scripts/check-syntax.mjs` and `scripts/check-static-analysis.mjs`, and both completed successfully.
- Static analysis and syntax guards passed with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a1c95ca08326b2da3dd3207b9fce)