### PR TITLE
Wire share flow to POST media endpoint before X intent

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -1,8 +1,9 @@
 import { fetchMyProfile, startShare, confirmShare, getXOAuthAuthorizeUrl } from '../api.js';
 import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';
-import { isTelegramMiniApp } from '../features/auth/index.js';
+import { isTelegramMiniApp, getPrimaryAuthIdentifier, getSigningWalletAddress } from '../features/auth/index.js';
 import { logger } from '../logger.js';
 import { analytics } from '../analytics-events.js';
+import { BACKEND_URL } from '../config.js';
 
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
@@ -13,6 +14,28 @@ function openUrl(url) {
   } else {
     window.open(url, '_blank', 'noopener,noreferrer');
   }
+}
+
+async function postShareResultMedia(shareResultEndpoint, payload = {}) {
+  const endpoint = String(shareResultEndpoint || '').trim();
+  if (!endpoint) return { ok: false, status: 400 };
+  const primaryId = getPrimaryAuthIdentifier();
+  const wallet = getSigningWalletAddress();
+  const headers = { 'Content-Type': 'application/json' };
+  if (primaryId) {
+    headers['X-Primary-Id'] = String(primaryId);
+    headers['X-Wallet'] = String(wallet || primaryId);
+  }
+  if (isTelegramMiniApp() && window.Telegram?.WebApp?.initData) {
+    headers['X-Telegram-Init-Data'] = window.Telegram.WebApp.initData;
+  }
+  const url = endpoint.startsWith('http') ? endpoint : `${BACKEND_URL}${endpoint}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload || {})
+  });
+  return { ok: response.ok, status: response.status };
 }
 
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
@@ -47,7 +70,27 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
     return { success: false };
   }
 
-  const { shareId, intentUrl, secondsUntilReward = 30, eligibleForReward } = startResp;
+  const {
+    shareId,
+    intentUrl,
+    shareResultEndpoint,
+    secondsUntilReward = 30,
+    eligibleForReward
+  } = startResp;
+
+  if (shareResultEndpoint) {
+    try {
+      const mediaResult = await postShareResultMedia(shareResultEndpoint, {
+        shareId,
+        context
+      });
+      if (!mediaResult.ok) {
+        logger.warn('⚠️ share media attach request failed:', mediaResult.status, mediaResult.data);
+      }
+    } catch (e) {
+      logger.warn('⚠️ share media attach request error:', e);
+    }
+  }
 
   if (intentUrl) {
     openUrl(intentUrl);


### PR DESCRIPTION
### Motivation
- Backend now returns an explicit media attach endpoint from `/api/share/start`, and the frontend must call it to ensure the shared image is attached as media (not only opening the intent URL). 
- The attach request must be associated with the active authenticated session and support Telegram Mini App init data so backend can link the media to the user.

### Description
- Read `shareResultEndpoint` from the `startShare()` response and `POST` a JSON payload (`{ shareId, context }`) to it before opening the `intentUrl` in `performShare`.
- Added a local `postShareResultMedia` helper inside `js/share/shareFlow.js` that builds auth-aware headers (`X-Primary-Id`, `X-Wallet`, and `X-Telegram-Init-Data`) and resolves relative endpoints using `BACKEND_URL`.
- Preserved the existing share confirmation flow (retry on `425`, reward notifications and profile update callbacks) unchanged.
- Imported `getPrimaryAuthIdentifier`, `getSigningWalletAddress`, and `BACKEND_URL` into `shareFlow.js` to support the new media attach step.

### Testing
- Ran `npm run check:syntax` and it succeeded.
- Ran `npm run check:static-analysis` and it succeeded.
- Pre-commit checks (syntax + static-analysis) ran during the commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e575c714832682a48d6224671182)