### PR TITLE
Fix X result sharing UX by gating intent fallback

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -35,7 +35,15 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
     headers,
     body: JSON.stringify(payload || {})
   });
-  return { ok: response.ok, status: response.status };
+
+  let data = null;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+
+  return { ok: response.ok, status: response.status, data };
 }
 
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
@@ -78,23 +86,37 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
     eligibleForReward
   } = startResp;
 
+  let mediaPostedToX = false;
+
   if (shareResultEndpoint) {
     try {
       const mediaResult = await postShareResultMedia(shareResultEndpoint, {
         shareId,
         context
       });
-      if (!mediaResult.ok) {
+      if (mediaResult.ok) {
+        mediaPostedToX = true;
+        const tweetUrl = mediaResult.data?.tweetUrl || mediaResult.data?.url || mediaResult.data?.postUrl;
+        notifySuccess(tweetUrl ? `✅ Posted to X: ${tweetUrl}` : '✅ Posted to X');
+      } else {
         logger.warn('⚠️ share media attach request failed:', mediaResult.status, mediaResult.data);
+        if (intentUrl) {
+          notifyWarn('ℹ️ Откроется окно шаринга без авто-прикрепления картинки.');
+          openUrl(intentUrl);
+        }
       }
     } catch (e) {
       logger.warn('⚠️ share media attach request error:', e);
+      if (intentUrl) {
+        notifyWarn('ℹ️ Откроется окно шаринга без авто-прикрепления картинки.');
+        openUrl(intentUrl);
+      }
     }
-  }
-
-  if (intentUrl) {
+  } else if (intentUrl) {
+    notifyWarn('ℹ️ Откроется окно шаринга без авто-прикрепления картинки.');
     openUrl(intentUrl);
   }
+
 
   if (!shareId) {
     return { success: true };


### PR DESCRIPTION
### Motivation
- Prevent the `intentUrl` window from opening when the backend has already posted media to X so users don't see the intent flow as a failure.
- Provide clear UI feedback when media attach fails and the app falls back to the manual sharing intent so users understand the image won't be auto-attached.

### Description
- Updated `js/share/shareFlow.js` so `postShareResultMedia(...)` parses the backend JSON response and returns `{ ok, status, data }` to surface returned post URLs.
- Changed `performShare(...)` to set a `mediaPostedToX` flag and, on successful media post, show `✅ Posted to X` with the backend `tweetUrl` (if present) and avoid opening `intentUrl`.
- On media-post failure or error the code now shows `Откроется окно шаринга без авто-прикрепления картинки.` via `notifyWarn` and then opens `intentUrl` as a fallback; when no `shareResultEndpoint` is provided the same explicit warning is shown before opening the intent.
- All edits are contained in `js/share/shareFlow.js` and keep the confirm/reward flow unchanged.

### Testing
- Pre-commit checks including `npm run check:syntax` completed successfully and reported the modified files pass syntax checks.
- Static analysis (`node scripts/check-static-analysis.mjs`) ran as part of the pre-commit hooks and passed without errors.
- The updated `js/share/shareFlow.js` file was inspected to verify the new branches and notification messages behave as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f875d95034832693921c987f14d42c)