### PR TITLE
Use X API for Share result and add telemetry

### DIFF
--- a/js/analytics-events.js
+++ b/js/analytics-events.js
@@ -136,6 +136,19 @@ export const analytics = {
     });
   },
 
+
+  shareResultApiSuccess(payload = {}) {
+    trackAnalyticsEvent('share_result_api_success', payload);
+  },
+
+  shareResultApiError(payload = {}) {
+    trackAnalyticsEvent('share_result_api_error', payload);
+  },
+
+  shareIntentOpened(payload = {}) {
+    trackAnalyticsEvent('share_intent_opened', payload);
+  },
+
   // Deprecated typo aliases. Do not use in new code.
   donationSuccsses(payload = {}) {
     this.donationSuccess(payload);

--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -81,40 +81,60 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
   const {
     shareId,
     intentUrl,
+    shareResultApiUrl,
     shareResultEndpoint,
+    preferredShareFlow,
     secondsUntilReward = 30,
     eligibleForReward
   } = startResp;
 
-  let mediaPostedToX = false;
+  const shareResultUrl = shareResultApiUrl || shareResultEndpoint;
 
-  if (shareResultEndpoint) {
-    try {
-      const mediaResult = await postShareResultMedia(shareResultEndpoint, {
-        shareId,
-        context
+  if (preferredShareFlow === 'x_api') {
+    if (!shareResultUrl) {
+      notifyError('⚠️ Share API endpoint missing. Please try again.');
+      analytics.shareResultApiError({
+        context,
+        code: 'x_api_missing_endpoint'
       });
-      if (mediaResult.ok) {
-        mediaPostedToX = true;
+      return { success: false };
+    }
+
+    try {
+      const mediaResult = await postShareResultMedia(shareResultUrl, { shareId, context });
+      if (mediaResult.ok && mediaResult.data?.posted) {
         const tweetUrl = mediaResult.data?.tweetUrl || mediaResult.data?.url || mediaResult.data?.postUrl;
-        notifySuccess(tweetUrl ? `✅ Posted to X: ${tweetUrl}` : '✅ Posted to X');
-      } else {
-        logger.warn('⚠️ share media attach request failed:', mediaResult.status, mediaResult.data);
-        if (intentUrl) {
-          notifyWarn('ℹ️ Откроется окно шаринга без авто-прикрепления картинки.');
-          openUrl(intentUrl);
+        notifySuccess('✅ Shared to X');
+        if (tweetUrl) {
+          openUrl(tweetUrl);
         }
+        analytics.shareResultApiSuccess({ context, tweet_url_present: Boolean(tweetUrl) });
+      } else {
+        const errorCode = mediaResult.data?.code || mediaResult.data?.error || `http_${mediaResult.status}`;
+        notifyError(`⚠️ Could not attach image (${errorCode})`);
+        analytics.shareResultApiError({ context, code: errorCode, status: mediaResult.status });
+        if (intentUrl) {
+          notifyWarn('ℹ️ Share text instead');
+        }
+        return { success: false, errorCode, fallbackIntentUrl: intentUrl || null };
       }
     } catch (e) {
       logger.warn('⚠️ share media attach request error:', e);
+      notifyError('⚠️ Could not attach image (network_error)');
+      analytics.shareResultApiError({ context, code: 'network_error' });
       if (intentUrl) {
-        notifyWarn('ℹ️ Откроется окно шаринга без авто-прикрепления картинки.');
-        openUrl(intentUrl);
+        notifyWarn('ℹ️ Share text instead');
       }
+      return { success: false, errorCode: 'network_error', fallbackIntentUrl: intentUrl || null };
+    }
+  } else if (preferredShareFlow === 'intent') {
+    if (intentUrl) {
+      openUrl(intentUrl);
+      analytics.shareIntentOpened({ context, reason: 'preferred_share_flow_intent' });
     }
   } else if (intentUrl) {
-    notifyWarn('ℹ️ Откроется окно шаринга без авто-прикрепления картинки.');
     openUrl(intentUrl);
+    analytics.shareIntentOpened({ context, reason: 'fallback_unknown_preferred_flow' });
   }
 
 


### PR DESCRIPTION
### Motivation
- Ensure the "Share result" button posts with an attached image when X is connected by preferring the API flow instead of the intent/composer flow.
- Avoid opening the `intentUrl` after a successful API post so users do not get a text-only share that lacks the image.

### Description
- Update `performShare` in `js/share/shareFlow.js` to respect `preferredShareFlow` from `/api/share/start` and prefer `x_api` when present.
- For `x_api` use `shareResultApiUrl`/`shareResultEndpoint` to POST and on success show a success toast, open returned `tweetUrl` (if any), and do NOT open `intentUrl`.
- Surface backend error codes on API failures, provide a text-share fallback hint (but do not auto-open intent on success), and return a structured failure with `errorCode`/`fallbackIntentUrl` when appropriate.
- Preserve intent flow behavior for `preferredShareFlow === 'intent'` and for other fallbacks, while adding telemetry calls for intent openings.
- Add analytics helpers in `js/analytics-events.js` for `share_result_api_success`, `share_result_api_error`, and `share_intent_opened` and emit these events from the share flow.

### Testing
- Ran `npm run check:syntax` which completed successfully with no syntax errors.
- Ran unit/request checks via `node --test scripts/analytics.test.mjs scripts/request.test.mjs` which passed.
- Pre-commit hooks (including `check:static-analysis`) ran during commit and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89049a3a883269e12fff09289ae29)