### PR TITLE
Improve share-result UX for backend error contract fallbacks

### DIFF
--- a/js/notifier.js
+++ b/js/notifier.js
@@ -40,6 +40,8 @@ function notify(message, options = {}) {
     sticky = false,
     sub = null,
     toastKey = '',
+    actionLabel = '',
+    onAction = null,
   } = options;
 
   const normalizedToastKey = String(toastKey || '').trim();
@@ -59,6 +61,23 @@ function notify(message, options = {}) {
     subEl.textContent = String(sub);
     subEl.style.cssText = 'margin-top:4px;opacity:0.7;font-size:10px;';
     toast.appendChild(subEl);
+  }
+
+  const normalizedActionLabel = String(actionLabel || '').trim();
+  if (normalizedActionLabel && typeof onAction === 'function') {
+    const actionBtn = document.createElement('button');
+    actionBtn.type = 'button';
+    actionBtn.className = 'payment-secondary-btn toast-action-btn';
+    actionBtn.textContent = normalizedActionLabel;
+    actionBtn.style.cssText = 'margin-top:8px;margin-right:8px;';
+    actionBtn.addEventListener('click', () => {
+      try {
+        onAction();
+      } finally {
+        dismissToast(toast);
+      }
+    });
+    toast.appendChild(actionBtn);
   }
 
   const closeBtn = document.createElement('button');

--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -16,6 +16,47 @@ function openUrl(url) {
   }
 }
 
+function openTextShareIntent(intentUrl, context, reason) {
+  if (!intentUrl) return;
+  openUrl(intentUrl);
+  analytics.shareIntentOpened({ context, reason });
+}
+
+function handleShareContractError({ errorCode, contractFallback, mediaResult, intentUrl, context }) {
+  if (contractFallback === 'text_intent') {
+    notifyWarn('Не удалось опубликовать изображение. Можно поделиться текстом.', {
+      sticky: true,
+      actionLabel: 'Поделиться текстом',
+      onAction: () => openTextShareIntent(intentUrl, context, 'contract_fallback_text_intent')
+    });
+    return { success: false, errorCode, fallbackIntentUrl: intentUrl || null };
+  }
+
+  if (errorCode === 'x_auth_expired') {
+    notifyWarn('Сессия X истекла. Подключите X снова.', {
+      sticky: true,
+      actionLabel: 'Подключить X снова',
+      onAction: () => {
+        startXConnectFlow().catch((e) => logger.warn('⚠️ X reconnect failed:', e));
+      }
+    });
+    return { success: false, errorCode };
+  }
+
+  if (errorCode === 'x_rate_limited') {
+    notifyWarn('X временно ограничил публикации. Попробуйте чуть позже.');
+    return { success: false, errorCode };
+  }
+
+  if (mediaResult.status >= 500) {
+    notifyError('Не удалось поделиться, попробуйте позже.');
+    return { success: false, errorCode };
+  }
+
+  notifyError('Не удалось поделиться, попробуйте позже.');
+  return { success: false, errorCode };
+}
+
 async function postShareResultMedia(shareResultEndpoint, payload = {}) {
   const endpoint = String(shareResultEndpoint || '').trim();
   if (!endpoint) return { ok: false, status: 400 };
@@ -111,30 +152,22 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
         analytics.shareResultApiSuccess({ context, tweet_url_present: Boolean(tweetUrl) });
       } else {
         const errorCode = mediaResult.data?.code || mediaResult.data?.error || `http_${mediaResult.status}`;
-        notifyError(`⚠️ Could not attach image (${errorCode})`);
         analytics.shareResultApiError({ context, code: errorCode, status: mediaResult.status });
-        if (intentUrl) {
-          notifyWarn('ℹ️ Share text instead');
-        }
-        return { success: false, errorCode, fallbackIntentUrl: intentUrl || null };
+        const contractFallback = mediaResult.data?.fallback || null;
+        return handleShareContractError({ errorCode, contractFallback, mediaResult, intentUrl, context });
       }
     } catch (e) {
       logger.warn('⚠️ share media attach request error:', e);
-      notifyError('⚠️ Could not attach image (network_error)');
+      notifyError('Не удалось поделиться, попробуйте позже.');
       analytics.shareResultApiError({ context, code: 'network_error' });
-      if (intentUrl) {
-        notifyWarn('ℹ️ Share text instead');
-      }
       return { success: false, errorCode: 'network_error', fallbackIntentUrl: intentUrl || null };
     }
   } else if (preferredShareFlow === 'intent') {
     if (intentUrl) {
-      openUrl(intentUrl);
-      analytics.shareIntentOpened({ context, reason: 'preferred_share_flow_intent' });
+      openTextShareIntent(intentUrl, context, 'preferred_share_flow_intent');
     }
   } else if (intentUrl) {
-    openUrl(intentUrl);
-    analytics.shareIntentOpened({ context, reason: 'fallback_unknown_preferred_flow' });
+    openTextShareIntent(intentUrl, context, 'fallback_unknown_preferred_flow');
   }
 
 


### PR DESCRIPTION
### Motivation
- Убрать технический текст «ошибка прикрепления изображения» как основной пользовательский месседж и заменить его понятными действиями. 
- Поддержать контракт ошибок от backend (например, `fallback=text_intent`, `x_auth_expired`, `x_rate_limited`) и дать пользователю однозначный следующий шаг. 
- Сохранить чистый успех-путь: если backend вернул `posted=true`, никаких fallback-окон/CTA не показывать.

### Description
- Добавлена поддержка action-кнопки в toast-уведомлениях через параметры `actionLabel` и `onAction` в `js/notifier.js`.
- В `js/share/shareFlow.js` добавлены хелперы `openTextShareIntent` и `handleShareContractError` и добавлена обработка контрактных ошибок (`fallback=text_intent`, `x_auth_expired`, `x_rate_limited` и общий 5xx fallback).
- Логика отправки media-результата теперь извлекает поле `fallback` из ответа и вместо технического `Could not attach image` вызывает `handleShareContractError`, который показывает мягкие/действующие уведомления и запускает соответствующие потоки (открыть intent, reconnect X).
- Сохранены существующие успешные ветки (в частности поведение при `mediaResult.data?.posted`) и аналитика вызывается в тех же местах.

### Testing
- Запущена статическая проверка синтаксиса через `npm run check:syntax`, результат — успешно.
- Запущены автоматические request-тесты через `npm run test`, все тесты прошли успешно (84/84 passed) and pre-commit static-analysis checks также прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b74eeac883269ed335133d2ea47e)