### PR TITLE
Adjust mobile player menu social buttons placement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3054,6 +3054,19 @@ body.is-telegram .pm-telegram-connect-row .pm-side-btn {
   width: 100%;
 }
 
+.pm-mobile-connect-row {
+  display: none;
+}
+
+.pm-mobile-connect-row .pm-side-btn,
+.pm-mobile-connect-row .pm-side-x {
+  width: 100%;
+}
+
+.pm-x-wrap--mobile-inline {
+  margin-top: 0;
+}
+
 /* Game Over share button variants */
 .go-btn-share.is-connect-x {
   background: linear-gradient(135deg, rgba(0,0,0,.6), rgba(30,30,30,.75));
@@ -3075,6 +3088,12 @@ body.is-telegram .pm-telegram-connect-row .pm-side-btn {
 
   .pm-side {
     width: 100%;
+  }
+
+  .pm-mobile-connect-row {
+    display: grid;
+    gap: 8px;
+    margin-top: -8px;
   }
 
   .pm-rank {

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -195,26 +195,38 @@ function updateWalletBlock(profile) {
 }
 
 
-function applyTelegramPlayerMenuLayout() {
-  const isTelegramClient = document.body.classList.contains('telegram-mini-app') || document.body.classList.contains('is-telegram');
-  if (!isTelegramClient) return;
-
-  const walletBtn = DOM.pmConnectWalletBtn;
+function applyResponsivePlayerMenuLayout() {
   const xBlock = DOM.pmXBlock;
+  const telegramBtn = DOM.pmConnectTelegramBtn;
+  const sideColumn = document.querySelector('.pm-side');
   const centerColumn = document.querySelector('.pm-center');
   const bestScore = centerColumn?.querySelector('.pm-best');
-  if (!walletBtn || !xBlock || !centerColumn || !bestScore) return;
+  if (!xBlock || !telegramBtn || !sideColumn || !centerColumn || !bestScore) return;
 
-  let connectRow = centerColumn.querySelector('.pm-telegram-connect-row');
-  if (!connectRow) {
-    connectRow = document.createElement('div');
-    connectRow.className = 'pm-telegram-connect-row';
-    bestScore.insertAdjacentElement('afterend', connectRow);
+  const isMobile = window.matchMedia('(max-width: 640px)').matches;
+
+  if (isMobile) {
+    let connectRow = centerColumn.querySelector('.pm-mobile-connect-row');
+    if (!connectRow) {
+      connectRow = document.createElement('div');
+      connectRow.className = 'pm-mobile-connect-row';
+      bestScore.insertAdjacentElement('afterend', connectRow);
+    }
+
+    connectRow.appendChild(telegramBtn);
+    connectRow.appendChild(xBlock);
+    xBlock.classList.add('pm-x-wrap--mobile-inline');
+    return;
   }
 
-  connectRow.appendChild(xBlock);
-  connectRow.appendChild(walletBtn);
-  xBlock.classList.add('pm-x-wrap--telegram-inline');
+  sideColumn.insertBefore(telegramBtn, sideColumn.firstChild);
+  const walletBtn = DOM.pmConnectWalletBtn;
+  if (walletBtn && walletBtn.parentElement === sideColumn) {
+    sideColumn.insertBefore(xBlock, walletBtn);
+  } else {
+    sideColumn.appendChild(xBlock);
+  }
+  xBlock.classList.remove('pm-x-wrap--mobile-inline');
 }
 
 function fillProfileData(profile) {
@@ -296,7 +308,7 @@ function initPlayerMenuEvents() {
   if (eventsInitialized) return;
   eventsInitialized = true;
 
-  applyTelegramPlayerMenuLayout();
+  applyResponsivePlayerMenuLayout();
 
   if (DOM.pmBackBtn) {
     DOM.pmBackBtn.addEventListener('click', () => closePlayerMenu());
@@ -473,6 +485,7 @@ async function openPlayerMenu() {
     DOM.pmBestScore.textContent = headerBest;
   }
 
+  applyResponsivePlayerMenuLayout();
   await loadProfile();
 }
 
@@ -483,6 +496,7 @@ function closePlayerMenu() {
 
 async function refreshPlayerMenu() {
   if (!menuOpen) return;
+  applyResponsivePlayerMenuLayout();
   await loadProfile();
 }
 


### PR DESCRIPTION
### Motivation
- Адаптировать страницу меню игрока при переносе дизайна с веб на мобильные устройства, чтобы кнопки `Connect Telegram` и `Connect X` были расположены сразу под строкой `Best score` на узких экранах.
- Сохранить существующее поведение на десктопе, возвращая кнопки в правую колонку вне мобильного брейкпоинта.

### Description
- Добавлена функция `applyResponsivePlayerMenuLayout()` в `js/player-menu/controller.js`, которая на мобильных (`max-width: 640px`) создаёт `div.pm-mobile-connect-row` и перемещает в него `DOM.pmConnectTelegramBtn` и `DOM.pmXBlock` (с установкой класса `pm-x-wrap--mobile-inline`), а на десктопе возвращает элементы в правую колонку.
- Вызовы адаптивного рендера подключены при инициализации меню, при открытии `openPlayerMenu()` и при `refreshPlayerMenu()` для корректной перестановки при изменении состояния/размера экрана.
- Добавлены стили в `css/style.css` для нового блока (`.pm-mobile-connect-row`) и мобильных правил (отображение как grid, ширина кнопок и небольшой отступ), а также мелкие правки класса `pm-x-wrap--mobile-inline`.

### Testing
- Выполнен сборочный прогон `npm run build`, сборка прошла успешно и сгенерировались продакшн-артефакты.
- Прогнали предкоммитные проверки, включая `check:syntax` и `check:static-analysis`, которые завершились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c0b8f5948326a933c735e4fd0b8b)