### PR TITLE
Fix wallet button initial position jump on load

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -127,8 +127,8 @@ body {
 /* ===== WALLET CORNER ===== */
 #walletCorner {
   position: fixed;
-  top: calc(env(safe-area-inset-top, 0px) + 10px);
-  right: calc(env(safe-area-inset-right, 0px) + 12px);
+  top: max(10px, env(safe-area-inset-top));
+  right: calc(env(safe-area-inset-right, 0px) + 20px);
   z-index: 9000;
   display: flex;
   flex-direction: column;
@@ -3126,7 +3126,7 @@ body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
 @keyframes goConfettiUp { to { transform: translate3d(var(--dx), calc(-35vh - var(--dy)), 0) rotate(var(--rot)); opacity: 0; } }
 @media (max-width: 768px) {
   #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 8px); top: calc(env(safe-area-inset-top, 0px) + 8px); }
-  #walletCorner { position: fixed; top: calc(env(safe-area-inset-top, 0px) + 10px); right: calc(env(safe-area-inset-right, 0px) + 10px); }
+  #walletCorner { position: fixed; top: max(10px, env(safe-area-inset-top)); right: calc(env(safe-area-inset-right, 0px) + 20px); }
 }
 
 /* --- Platform scoped regression fixes (web + telegram) --- */


### PR DESCRIPTION
### Motivation
- Prevent the Connect Wallet button from shifting position after the page fully initializes by ensuring its initial CSS anchors match the final web/telegram layout.
- Make the placement consistent across viewport sizes so the button stays at the same spot shown on the final UI (second screenshot).

### Description
- Updated `css/style.css` to align the base `#walletCorner` offsets with the web-scoped offsets by changing `top` to `max(10px, env(safe-area-inset-top))` and increasing `right` to `calc(env(safe-area-inset-right, 0px) + 20px)`.
- Synchronized the mobile media-query (`@media (max-width: 768px)`) `#walletCorner` rule to the same `top`/`right` anchors to avoid a different initial placement on narrow viewports.
- Changes are contained in `css/style.css` only and were committed with the message `Fix wallet button initial position jump on load`.

### Testing
- Pre-commit hooks ran and executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed successfully.
- All automated static-analysis and syntax checks included in the pre-commit pipeline completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f906c084388326815f8c03ec9cc967)