### PR TITLE
Redesign top HUD: add Player card to top-left and compact Wallet to top-right

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -125,6 +125,13 @@ body {
 }
 
 /* ===== WALLET CORNER ===== */
+#playerCorner {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px) + 10px);
+  left: calc(env(safe-area-inset-left, 0px) + 12px);
+  z-index: 9000;
+}
+
 #walletCorner {
   position: fixed;
   top: calc(env(safe-area-inset-top, 0px) + 10px);
@@ -133,7 +140,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 6px;
+  gap: 10px;
 }
 
 .wallet-btn-corner {
@@ -2596,38 +2603,51 @@ footer a:hover { color: #e0b0ff; }
   text-overflow: ellipsis;
 }
 
-/* ===== PLAYER AVATAR BTN ===== */
-.player-avatar-btn {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
+/* ===== PLAYER CARD ===== */
+.player-card {
+  min-width: 260px;
+  padding: 14px 18px;
+  border-radius: 24px;
   border: 1px solid rgba(56, 189, 248, 0.45);
-  background: radial-gradient(circle at 30% 30%, rgba(34, 211, 238, 0.25), rgba(15, 23, 42, 0.85));
+  background: linear-gradient(135deg, rgba(5, 8, 20, 0.9), rgba(14, 18, 35, 0.82));
+  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.25), 0 0 26px rgba(56, 189, 248, 0.12);
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
+}
+
+.player-card[hidden] { display: none; }
+
+.player-avatar-shell {
+  width: 74px;
+  height: 74px;
+  border-radius: 50%;
+  border: 2px solid rgba(34, 211, 238, 0.7);
+  background: radial-gradient(circle at 35% 30%, rgba(34, 211, 238, 0.3), rgba(15, 23, 42, 0.85));
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  color: #e6f4ff;
-  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
   flex-shrink: 0;
 }
 
-.player-avatar-btn[hidden] { display: none; }
-
-.player-avatar-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 0 18px rgba(56, 189, 248, .35);
-  border-color: rgba(168, 85, 247, .65);
+.player-card-meta {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
 }
 
-.player-avatar-btn:active {
-  transform: scale(0.95);
-}
+.player-card-title { font-family: 'Orbitron', sans-serif; font-size: 36px; font-weight: 700; line-height: 1; color: rgba(255,255,255,.92); }
+.player-card-rank { font-family: 'Orbitron', sans-serif; font-size: 36px; font-weight: 700; line-height: 1; color: #a78bfa; }
+.player-card-score { font-family: 'Orbitron', sans-serif; font-size: 44px; font-weight: 700; line-height: 1; color: #c084fc; }
+
+.player-card:hover { box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.45), 0 0 30px rgba(56, 189, 248, 0.2); }
+.player-card:active { transform: scale(0.98); }
 
 .player-avatar-icon {
-  width: 28px;
-  height: 28px;
+  width: 42px;
+  height: 42px;
   object-fit: contain;
   pointer-events: none;
   filter: drop-shadow(0 0 4px rgba(255,255,255,0.25));
@@ -3110,7 +3130,7 @@ body.is-telegram .pm-telegram-connect-row .pm-side-btn {
 .app-fixed-nav { position: fixed; left: calc(env(safe-area-inset-left, 0px) + 10px); top: calc(env(safe-area-inset-top, 0px) + 8px); z-index: 120; display: flex; flex-direction: column; gap: 8px; }
 .app-nav-btn { width: 40px; height: 40px; min-width: 40px; min-height: 40px; border-radius: 50%; }
 .stars,.stars2 { animation: none !important; }
-body.loading-ui #walletCorner { opacity: 0; pointer-events: none; }
+body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; pointer-events: none; }
 #rulesScreen { padding-top: calc(env(safe-area-inset-top, 0px) + 64px); }
 .rules-content,.rules-section { width: min(92vw, 500px); margin-left: auto; margin-right: auto; }
 .pm-history-title { text-align: center; width: 100%; }

--- a/index.html
+++ b/index.html
@@ -20,17 +20,25 @@
 <body class="loading-ui">
   
 <!-- ===== WALLET + INFO ===== -->
+<div id="playerCorner">
+  <button class="player-card" id="playerAvatarBtn" hidden aria-label="Open player menu">
+    <span class="player-avatar-shell">
+      <img src="img/ursas_bear_head_white.svg" class="player-avatar-icon" alt="" aria-hidden="true">
+    </span>
+    <span class="player-card-meta">
+      <span class="player-card-title">PLAYER</span>
+      <span class="player-card-rank" id="walletRank">#1</span>
+      <span class="player-card-score" id="walletBest">150983</span>
+    </span>
+  </button>
+</div>
+
 <div id="walletCorner">
   <div class="wallet-corner-row">
     <button class="wallet-btn-corner ui-btn ui-btn--secondary ui-btn--sm" id="walletBtn">Connect Wallet</button>
     <span class="tg-account-badge" id="tgAccountBadge" hidden></span>
-    <button class="player-avatar-btn ui-btn ui-btn--icon ui-btn--ghost" id="playerAvatarBtn" hidden aria-label="Open player menu">
-      <img src="img/ursas_bear_head_white.svg" class="player-avatar-icon" alt="" aria-hidden="true">
-    </button>
   </div>
   <div class="wallet-info" id="walletInfo">
-    <div class="wallet-info-row"><span class="icon-atlas" style="width:16px;height:16px;background-size:80px auto;background-position:-16px 0px"></span> <span class="val" id="walletRank">—</span></div>
-    <div class="wallet-info-row"><span class="icon-atlas" style="width:16px;height:16px;background-size:80px auto;background-position:-64px -16px"></span> <span class="val" id="walletBest">0</span></div>
     <div class="wallet-info-row"><img src="img/icon_gold.png"> <span class="val-gold" id="walletGold">0</span></div>
     <div class="wallet-info-row"><img src="img/icon_silver.png"> <span class="val-silver" id="walletSilver">0</span></div>
   </div>

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -1,4 +1,4 @@
-import { createIconAtlas, createImageIcon } from './dom-render.js';
+import { createImageIcon } from './dom-render.js';
 
 function normalizeTelegramUsername(value) {
   return String(value || '').trim().replace(/^@+/, '');
@@ -36,28 +36,6 @@ function createWalletInfoRow({ iconNode, valueId, valueClass, defaultValue }) {
 
 function renderWalletStats(infoRoot) {
   infoRoot.append(
-    createWalletInfoRow({
-      iconNode: createIconAtlas({
-        width: 16,
-        height: 16,
-        backgroundSize: '80px auto',
-        backgroundPosition: '-16px 0px'
-      }),
-      valueId: 'walletRank',
-      valueClass: 'val',
-      defaultValue: '—'
-    }),
-    createWalletInfoRow({
-      iconNode: createIconAtlas({
-        width: 16,
-        height: 16,
-        backgroundSize: '80px auto',
-        backgroundPosition: '-64px -16px'
-      }),
-      valueId: 'walletBest',
-      valueClass: 'val',
-      defaultValue: '0'
-    }),
     createWalletInfoRow({
       iconNode: createImageIcon({ src: 'img/icon_gold.png' }),
       valueId: 'walletGold',


### PR DESCRIPTION
### Motivation
- Move the bear-head player trigger into a dedicated top-left Player block and present player metadata (avatar, PLAYER title, rank, score) as a compact card. 
- Keep the top-right area focused on authentication and currency balances so the HUD is visually clean and aligned with current design direction. 
- Preserve existing DOM wiring for rank/score updates while simplifying the wallet info to only show currencies (gold/silver).

### Description
- Added a new `#playerCorner` block and `button.player-card` markup in `index.html` containing the circular bear avatar, `PLAYER` title, `#1` rank and `150983` score while keeping IDs `walletRank` and `walletBest`. 
- Removed the avatar button from the previous wallet corner and simplified wallet DOM to a compact `#walletCorner` with only the wallet button and currency rows (`walletGold`, `walletSilver`) in `index.html`. 
- Updated `css/style.css` to introduce `#playerCorner` positioning, styles for `.player-card`, `.player-avatar-shell`, and typography/hover effects, and adjusted `#walletCorner` spacing and loading visibility to include the new player block. 
- Modified `js/auth-ui.js` to render only currency rows in the wallet info (replaced atlas-based rank/best rows) and removed the unused `createIconAtlas` import in favor of `createImageIcon`, preserving the existing IDs so current data binding continues to work.

### Testing
- Ran the project's syntax checks via `node scripts/check-syntax.mjs`, which completed successfully. 
- Pre-commit hooks executed `check:syntax` and `check-static-analysis` as part of the commit, and both automated checks passed. 
- No runtime UI unit tests were added; changes were limited to static HTML/CSS/JS layout and static analysis validations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f918f83ae88326990d00c8c23f46bf)