### PR TITLE
Fix UI button lint failure for player avatar trigger

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   
 <!-- ===== WALLET + INFO ===== -->
 <div id="playerCorner">
-  <button class="player-card" id="playerAvatarBtn" hidden aria-label="Open player menu">
+  <button class="player-card ui-btn" id="playerAvatarBtn" hidden aria-label="Open player menu">
     <span class="player-avatar-shell">
       <img src="img/ursas_bear_head_white.svg" class="player-avatar-icon" alt="" aria-hidden="true">
     </span>


### PR DESCRIPTION
### Motivation
- The UI button linter reported that `#playerAvatarBtn` was missing the required `.ui-btn` class, causing CI to fail.

### Description
- Added the `ui-btn` class to the `playerAvatarBtn` element in `index.html` to satisfy the UI button style/lint rule.

### Testing
- Ran `npm run check:ui-buttons` which passed, and pre-commit checks including `npm run check:syntax` and `npm run check:static-analysis` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91b5598a8832698fe60d148865682)