### PR TITLE
Fix player HUD visibility to main menu only

### DIFF
--- a/js/screens.js
+++ b/js/screens.js
@@ -19,6 +19,8 @@ function setVisibilityClass(node, className, isVisible) {
 function setMenuUiVisible(isVisible) {
   setDisplay(DOM.walletCorner, isVisible ? 'flex' : 'none');
   if (DOM.walletCorner) DOM.walletCorner.classList.toggle('is-screen-hidden', !isVisible);
+  setDisplay(DOM.playerCorner, isVisible ? 'block' : 'none');
+  if (DOM.playerCorner) DOM.playerCorner.classList.toggle('is-screen-hidden', !isVisible);
 }
 
 function setEyesVisibility(isVisible) {

--- a/js/state.js
+++ b/js/state.js
@@ -95,6 +95,7 @@ const DOM_IDS = {
   rulesScreen: 'rulesScreen',
   darkScreen: 'darkScreen',
   walletCorner: 'walletCorner',
+  playerCorner: 'playerCorner',
   ridesInfo: 'ridesInfo',
   ridesText: 'ridesText',
   ridesTimer: 'ridesTimer',


### PR DESCRIPTION
### Motivation
- Prevent the player HUD / player menu card (`#playerCorner`) from overlaying other screens by making it visible only on the main menu.

### Description
- Add `playerCorner` to the centralized `DOM_IDS` in `js/state.js` and update `setMenuUiVisible` in `js/screens.js` to toggle `DOM.playerCorner` display and `is-screen-hidden` class alongside `DOM.walletCorner`.

### Testing
- Verified the module loads with `node -e "import('./js/screens.js')..."` and ran pre-commit checks including `npm run check:syntax` (`scripts/check-syntax.mjs`) and `npm run check:static-analysis` (`scripts/check-static-analysis.mjs`), all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91ce888388326a1190fada13d6001)