### PR TITLE
Reduce player HUD block size by 3x

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -875,31 +875,31 @@ body.start-launching #walletCorner {
 /* ===== GAME HUD ===== */
 #uiTopLeft {
   position: absolute;
-  top: 12px; left: 12px;
+  top: 4px; left: 4px;
   z-index: 10;
   background: transparent;
   backdrop-filter: none;
-  padding: 10px 14px;
+  padding: 3px 5px;
   border-radius: var(--radius);
   border: none;
   font-family: 'Orbitron', sans-serif;
-  width: 186px;
+  width: 62px;
   box-sizing: border-box;
 }
 
-#uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft > div { margin: 1px 0; font-weight: 600; font-size: 4px; }
 #uiTopLeft > div:last-child { margin-bottom: 0; }
-#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
-#uiTopLeft .score { color: #c084fc; font-size: 15px; }
-#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
+#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 5px; }
+#uiTopLeft .score { color: #c084fc; font-size: 5px; }
+#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 5px; }
 #uiTopLeft .hud-main-row {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 3px;
 }
 #uiTopLeft .hud-main-value {
-  min-width: 92px;
+  min-width: 31px;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
### Motivation
- Сделать интерфейс HUD игрока более компактным, чтобы он занимал примерно в 3 раза меньше места на экране при запуске игры.
- Уменьшить визуальный вес и расстояния между элементами HUD для лучшей интеграции с игровым полем на мобильных и десктопах.

### Description
- Изменён CSS блока HUD `#uiTopLeft` в файле `css/style.css`: смещён ближе к краю (`top`/`left` с `12px` на `4px`), уменьшены внутренние отступы (`padding` с `10px 14px` на `3px 5px`) и ширина контейнера (`width` с `186px` на `62px`).
- Пропорционально уменьшены типографика и отступы для строк HUD: `#uiTopLeft > div` (`margin` и `font-size`), а также `speed`, `score`, `distance` (`font-size` с `15px` на `5px`).
- Сокращён интер-элементный gap (`gap` с `8px` на `3px`) и минимальная ширина значения HUD (`.hud-main-value min-width` с `92px` на `31px`).

### Testing
- Префиксные проверки запускались автоматически при коммите: `npm run check:syntax` и `npm run check:static-analysis`.
- Оба автоматизированных теста/проверки завершились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91f13982483269e2cd86110197e03)