### PR TITLE
Compact UI and player-card style overhaul for smaller screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -875,31 +875,31 @@ body.start-launching #walletCorner {
 /* ===== GAME HUD ===== */
 #uiTopLeft {
   position: absolute;
-  top: 12px; left: 12px;
+  top: 4px; left: 4px;
   z-index: 10;
   background: transparent;
   backdrop-filter: none;
-  padding: 10px 14px;
+  padding: 3px 5px;
   border-radius: var(--radius);
   border: none;
   font-family: 'Orbitron', sans-serif;
-  width: 186px;
+  width: 62px;
   box-sizing: border-box;
 }
 
-#uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft > div { margin: 1px 0; font-weight: 600; font-size: 4px; }
 #uiTopLeft > div:last-child { margin-bottom: 0; }
-#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
-#uiTopLeft .score { color: #c084fc; font-size: 15px; }
-#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
+#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 5px; }
+#uiTopLeft .score { color: #c084fc; font-size: 5px; }
+#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 5px; }
 #uiTopLeft .hud-main-row {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 3px;
 }
 #uiTopLeft .hud-main-value {
-  min-width: 92px;
+  min-width: 31px;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
@@ -2605,26 +2605,26 @@ footer a:hover { color: #e0b0ff; }
 
 /* ===== PLAYER CARD ===== */
 .player-card {
-  min-width: 470px;
-  min-height: 180px;
-  padding: 18px 26px;
-  border-radius: 28px;
-  border: 1px solid rgba(56, 189, 248, 0.45);
-  background: linear-gradient(135deg, rgba(5, 8, 20, 0.9), rgba(14, 18, 35, 0.82));
-  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.25), 0 0 26px rgba(56, 189, 248, 0.12);
+  min-width: 168px;
+  min-height: 60px;
+  padding: 6px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-accent);
+  background: var(--glass);
+  box-shadow: 0 0 15px rgba(140, 80, 255, .25);
   display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: 5px;
   cursor: pointer;
 }
 
 .player-card[hidden] { display: none; }
 
 .player-avatar-shell {
-  width: 116px;
-  height: 116px;
+  width: 39px;
+  height: 39px;
   border-radius: 50%;
-  border: 2px solid rgba(34, 211, 238, 0.7);
+  border: 1px solid rgba(34, 211, 238, 0.7);
   background: radial-gradient(circle at 35% 30%, rgba(34, 211, 238, 0.3), rgba(15, 23, 42, 0.85));
   display: inline-flex;
   align-items: center;
@@ -2636,20 +2636,20 @@ footer a:hover { color: #e0b0ff; }
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 10px;
+  gap: 3px;
 }
 
 
-.player-card-title { font-family: 'Orbitron', sans-serif; font-size: 52px; font-weight: 700; line-height: 1; color: rgba(255,255,255,.92); }
-.player-card-rank { font-family: 'Orbitron', sans-serif; font-size: 48px; font-weight: 700; line-height: 1; color: #a78bfa; }
-.player-card-score { font-family: 'Orbitron', sans-serif; font-size: 56px; font-weight: 700; line-height: 1; color: #c084fc; }
+.player-card-title { font-family: 'Orbitron', sans-serif; font-size: 12px; font-weight: 700; line-height: 1; color: rgba(255,255,255,.92); }
+.player-card-rank { font-family: 'Orbitron', sans-serif; font-size: 11px; font-weight: 700; line-height: 1; color: #a78bfa; }
+.player-card-score { font-family: 'Orbitron', sans-serif; font-size: 13px; font-weight: 700; line-height: 1; color: #c084fc; }
 
-.player-card:hover { box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.45), 0 0 30px rgba(56, 189, 248, 0.2); }
+.player-card:hover { box-shadow: 0 0 15px rgba(140, 80, 255, .25); transform: translateY(-1px); }
 .player-card:active { transform: scale(0.98); }
 
 .player-avatar-icon {
-  width: 66px;
-  height: 66px;
+  width: 22px;
+  height: 22px;
   object-fit: contain;
   pointer-events: none;
   filter: drop-shadow(0 0 4px rgba(255,255,255,0.25));
@@ -3137,7 +3137,7 @@ body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; point
 #gameStart .start-audio-nav {
   position: fixed;
   left: calc(env(safe-area-inset-left, 0px) + 12px);
-  top: calc(env(safe-area-inset-top, 0px) + 214px);
+  top: calc(env(safe-area-inset-top, 0px) + 80px);
   z-index: 9000;
 }
 
@@ -3154,7 +3154,7 @@ body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; point
 .go-confetti { position: absolute; bottom: -10px; width: 6px; height: 12px; border-radius: 2px; animation: goConfettiUp 900ms ease-out forwards; }
 @keyframes goConfettiUp { to { transform: translate3d(var(--dx), calc(-35vh - var(--dy)), 0) rotate(var(--rot)); opacity: 0; } }
 @media (max-width: 768px) {
-  #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 8px); top: calc(env(safe-area-inset-top, 0px) + 214px); }
+  #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 12px); top: calc(env(safe-area-inset-top, 0px) + 80px); }
   #walletCorner { position: fixed; top: max(10px, env(safe-area-inset-top)); right: calc(env(safe-area-inset-right, 0px) + 20px); }
 }
 
@@ -3162,8 +3162,6 @@ body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; point
 
 
 
-body.is-telegram #gameStart .start-audio-nav,
-body.telegram-mini-app #gameStart .start-audio-nav,
 body.is-telegram #storeScreen .store-fixed-nav,
 body.telegram-mini-app #storeScreen .store-fixed-nav,
 body.is-telegram #rulesScreen .rules-fixed-nav,
@@ -3325,5 +3323,5 @@ body.is-telegram #playerMenuOverlay .pm-center #pmXBlock {
 
 body.is-telegram #gameStart .start-audio-nav,
 body.telegram-mini-app #gameStart .start-audio-nav {
-  top: calc(env(safe-area-inset-top, 0px) + 214px);
+  top: calc(env(safe-area-inset-top, 0px) + 80px);
 }


### PR DESCRIPTION
### Motivation
- Reduce HUD and player-card footprint to improve layout on compact and mobile displays and to harmonize visual polish across platforms. 
- Replace some hard-coded sizes with theme variables and simplify shadows/borders for a cleaner, consistent look. 

### Description
- Scaled down top-left HUD sizes and spacing by reducing `#uiTopLeft` padding, `top/left` offsets, `width`, and child font sizes and gaps. 
- Reworked `.player-card` styling to use smaller dimensions, theme variables (`--radius-pill`, `--border-accent`, `--glass`), reduced padding/gaps, smaller avatar and icon sizes, and updated hover/active effects. 
- Replaced several large fixed font sizes with compact values for `.player-card-title`, `.player-card-rank`, and `.player-card-score`, and simplified box-shadow rules. 
- Adjusted positioning for `.start-audio-nav` (moved from `214px` to `80px`) in global and media-query rules to better suit compact/telegram layouts. 

### Testing
- Ran `stylelint` on the modified `css/style.css` file and it passed without errors. 
- Executed automated responsive smoke checks (headless Chrome emulation) for desktop and mobile breakpoints to verify HUD and player-card layouts and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91f13982483269e2cd86110197e03)