### PR TITLE
Polish responsive player menu and compact HUD/wallet UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,11 +144,23 @@ body {
 }
 
 .wallet-btn-corner {
+  width: 156px;
+  min-width: 156px;
+  max-width: 156px;
+  height: 40px;
   padding: 8px 16px;
   background: var(--glass);
   border: 1px solid var(--border-accent);
   border-radius: var(--radius-pill);
+  font: 700 12px/1 'Orbitron', sans-serif !important;
+  letter-spacing: 0;
+  justify-content: center;
+  box-sizing: border-box;
+  text-rendering: geometricPrecision;
+  font-synthesis: none;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .wallet-btn-corner:active { transform: scale(0.96); }
@@ -875,31 +887,31 @@ body.start-launching #walletCorner {
 /* ===== GAME HUD ===== */
 #uiTopLeft {
   position: absolute;
-  top: 12px; left: 12px;
+  top: 4px; left: 4px;
   z-index: 10;
   background: transparent;
   backdrop-filter: none;
-  padding: 10px 14px;
+  padding: 3px 5px;
   border-radius: var(--radius);
   border: none;
   font-family: 'Orbitron', sans-serif;
-  width: 186px;
+  width: 62px;
   box-sizing: border-box;
 }
 
-#uiTopLeft > div { margin: 4px 0; font-weight: 600; font-size: 13px; }
+#uiTopLeft > div { margin: 1px 0; font-weight: 600; font-size: 4px; }
 #uiTopLeft > div:last-child { margin-bottom: 0; }
-#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 15px; }
-#uiTopLeft .score { color: #c084fc; font-size: 15px; }
-#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 15px; }
+#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 5px; }
+#uiTopLeft .score { color: #c084fc; font-size: 5px; }
+#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 5px; }
 #uiTopLeft .hud-main-row {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 3px;
 }
 #uiTopLeft .hud-main-value {
-  min-width: 92px;
+  min-width: 31px;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
@@ -2605,26 +2617,26 @@ footer a:hover { color: #e0b0ff; }
 
 /* ===== PLAYER CARD ===== */
 .player-card {
-  min-width: 470px;
-  min-height: 180px;
-  padding: 18px 26px;
-  border-radius: 28px;
-  border: 1px solid rgba(56, 189, 248, 0.45);
-  background: linear-gradient(135deg, rgba(5, 8, 20, 0.9), rgba(14, 18, 35, 0.82));
-  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.25), 0 0 26px rgba(56, 189, 248, 0.12);
+  min-width: 150px;
+  min-height: 60px;
+  padding: 6px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-accent);
+  background: var(--glass);
+  box-shadow: 0 0 15px rgba(140, 80, 255, .25);
   display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: 5px;
   cursor: pointer;
 }
 
 .player-card[hidden] { display: none; }
 
 .player-avatar-shell {
-  width: 116px;
-  height: 116px;
+  width: 45px;
+  height: 45px;
   border-radius: 50%;
-  border: 2px solid rgba(34, 211, 238, 0.7);
+  border: 1px solid rgba(34, 211, 238, 0.7);
   background: radial-gradient(circle at 35% 30%, rgba(34, 211, 238, 0.3), rgba(15, 23, 42, 0.85));
   display: inline-flex;
   align-items: center;
@@ -2636,20 +2648,21 @@ footer a:hover { color: #e0b0ff; }
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 10px;
+  gap: 3px;
+  margin-left: 15px;
 }
 
 
-.player-card-title { font-family: 'Orbitron', sans-serif; font-size: 52px; font-weight: 700; line-height: 1; color: rgba(255,255,255,.92); }
-.player-card-rank { font-family: 'Orbitron', sans-serif; font-size: 48px; font-weight: 700; line-height: 1; color: #a78bfa; }
-.player-card-score { font-family: 'Orbitron', sans-serif; font-size: 56px; font-weight: 700; line-height: 1; color: #c084fc; }
+.player-card-title { font-family: 'Orbitron', sans-serif; font-size: 12px; font-weight: 700; line-height: 1; color: rgba(255,255,255,.92); }
+.player-card-rank { font-family: 'Orbitron', sans-serif; font-size: 11px; font-weight: 700; line-height: 1; color: #a78bfa; }
+.player-card-score { font-family: 'Orbitron', sans-serif; font-size: 13px; font-weight: 700; line-height: 1; color: #c084fc; }
 
-.player-card:hover { box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.45), 0 0 30px rgba(56, 189, 248, 0.2); }
+.player-card:hover { box-shadow: 0 0 15px rgba(140, 80, 255, .25); transform: translateY(-1px); }
 .player-card:active { transform: scale(0.98); }
 
 .player-avatar-icon {
-  width: 66px;
-  height: 66px;
+  width: 22px;
+  height: 22px;
   object-fit: contain;
   pointer-events: none;
   filter: drop-shadow(0 0 4px rgba(255,255,255,0.25));
@@ -2991,6 +3004,11 @@ footer a:hover { color: #e0b0ff; }
   flex-shrink: 0;
 }
 
+.pm-side.pm-side--inline {
+  width: 100%;
+  margin-top: 12px;
+}
+
 .pm-side-btn {
   width: 100%;
   padding: 12px 16px;
@@ -3080,6 +3098,13 @@ body.is-telegram .pm-telegram-connect-row .pm-side-btn {
   display: none;
 }
 
+body.is-telegram .pm-mobile-connect-row,
+body.telegram-mini-app .pm-mobile-connect-row {
+  display: grid;
+  gap: 8px;
+  margin-top: -8px;
+}
+
 .pm-mobile-connect-row .pm-side-btn,
 .pm-mobile-connect-row .pm-side-x {
   width: 100%;
@@ -3137,7 +3162,7 @@ body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; point
 #gameStart .start-audio-nav {
   position: fixed;
   left: calc(env(safe-area-inset-left, 0px) + 12px);
-  top: calc(env(safe-area-inset-top, 0px) + 214px);
+  top: calc(env(safe-area-inset-top, 0px) + 80px);
   z-index: 9000;
 }
 
@@ -3154,7 +3179,7 @@ body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; point
 .go-confetti { position: absolute; bottom: -10px; width: 6px; height: 12px; border-radius: 2px; animation: goConfettiUp 900ms ease-out forwards; }
 @keyframes goConfettiUp { to { transform: translate3d(var(--dx), calc(-35vh - var(--dy)), 0) rotate(var(--rot)); opacity: 0; } }
 @media (max-width: 768px) {
-  #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 8px); top: calc(env(safe-area-inset-top, 0px) + 214px); }
+  #gameStart .start-audio-nav { display: flex; position: fixed; left: calc(env(safe-area-inset-left, 0px) + 12px); top: calc(env(safe-area-inset-top, 0px) + 80px); }
   #walletCorner { position: fixed; top: max(10px, env(safe-area-inset-top)); right: calc(env(safe-area-inset-right, 0px) + 20px); }
 }
 
@@ -3162,8 +3187,6 @@ body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; point
 
 
 
-body.is-telegram #gameStart .start-audio-nav,
-body.telegram-mini-app #gameStart .start-audio-nav,
 body.is-telegram #storeScreen .store-fixed-nav,
 body.telegram-mini-app #storeScreen .store-fixed-nav,
 body.is-telegram #rulesScreen .rules-fixed-nav,
@@ -3213,9 +3236,11 @@ body.is-web #walletCorner .tg-account-badge {
 body.is-web #walletCorner .wallet-btn-corner {
   width: 156px;
   min-width: 156px;
+  max-width: 156px;
   white-space: nowrap;
   text-align: center;
   word-break: normal;
+  font: 700 12px/1 'Orbitron', sans-serif !important;
 }
 
 body.is-web #walletCorner .wallet-info {
@@ -3325,5 +3350,5 @@ body.is-telegram #playerMenuOverlay .pm-center #pmXBlock {
 
 body.is-telegram #gameStart .start-audio-nav,
 body.telegram-mini-app #gameStart .start-audio-nav {
-  top: calc(env(safe-area-inset-top, 0px) + 214px);
+  top: calc(env(safe-area-inset-top, 0px) + 80px);
 }

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -198,33 +198,39 @@ function updateWalletBlock(profile) {
 function applyResponsivePlayerMenuLayout() {
   const xBlock = DOM.pmXBlock;
   const telegramBtn = DOM.pmConnectTelegramBtn;
+  const walletBtn = DOM.pmConnectWalletBtn;
   const sideColumn = document.querySelector('.pm-side');
+  const contentRoot = document.querySelector('.pm-content');
   const centerColumn = document.querySelector('.pm-center');
   const bestScore = centerColumn?.querySelector('.pm-best');
-  if (!xBlock || !telegramBtn || !sideColumn || !centerColumn || !bestScore) return;
+  if (!xBlock || !telegramBtn || !sideColumn || !centerColumn || !bestScore || !contentRoot) return;
 
   const isMobile = window.matchMedia('(max-width: 640px)').matches;
+  const isTelegramApp = document.body.classList.contains('is-telegram')
+    || document.body.classList.contains('telegram-mini-app');
 
-  if (isMobile) {
-    let connectRow = centerColumn.querySelector('.pm-mobile-connect-row');
-    if (!connectRow) {
-      connectRow = document.createElement('div');
-      connectRow.className = 'pm-mobile-connect-row';
-      bestScore.insertAdjacentElement('afterend', connectRow);
-    }
-
-    connectRow.appendChild(telegramBtn);
-    connectRow.appendChild(xBlock);
+  if (isMobile || isTelegramApp) {
+    bestScore.insertAdjacentElement('afterend', sideColumn);
+    sideColumn.classList.add('pm-side--inline');
+    sideColumn.appendChild(telegramBtn);
+    sideColumn.appendChild(xBlock);
+    if (walletBtn) sideColumn.appendChild(walletBtn);
     xBlock.classList.add('pm-x-wrap--mobile-inline');
     return;
   }
 
+  if (sideColumn.parentElement !== contentRoot) {
+    contentRoot.appendChild(sideColumn);
+  }
+  sideColumn.classList.remove('pm-side--inline');
   sideColumn.insertBefore(telegramBtn, sideColumn.firstChild);
-  const walletBtn = DOM.pmConnectWalletBtn;
   if (walletBtn && walletBtn.parentElement === sideColumn) {
     sideColumn.insertBefore(xBlock, walletBtn);
   } else {
     sideColumn.appendChild(xBlock);
+  }
+  if (walletBtn && walletBtn.parentElement !== sideColumn) {
+    sideColumn.appendChild(walletBtn);
   }
   xBlock.classList.remove('pm-x-wrap--mobile-inline');
 }
@@ -278,6 +284,7 @@ async function loadProfile() {
     fillProfileData(profile);
   }
   renderCoinHistory(coinHistory);
+  applyResponsivePlayerMenuLayout();
   // If profile is null (e.g. 401), keep any fallback values already shown
   return profile;
 }


### PR DESCRIPTION
### Motivation
- Make the player menu, wallet corner and HUD more compact and consistent across desktop, mobile and Telegram mini-app contexts to improve layout and readability.
- Ensure connect buttons (Telegram / Wallet / X block) flow correctly into the player menu on narrow screens and in Telegram environments.

### Description
- Shrink and restyle HUD and player card elements in `css/style.css` including reduced paddings, font sizes, avatar sizes, and updated visual treatment for `.player-card` and top-left HUD.
- Standardize wallet corner button sizing and overflow handling by setting fixed width, font, ellipsis behavior and web-specific overrides for `#walletCorner` and `.wallet-btn-corner`.
- Add responsive helper styles such as `.pm-side--inline`, show/hide mobile connect rows for Telegram contexts, and adjust positions for `.start-audio-nav` across breakpoints and Telegram modes.
- Update `js/player-menu/controller.js` to improve `applyResponsivePlayerMenuLayout` by adding detection for Telegram app mode, handling the wallet button (`pmConnectWalletBtn`), ensuring `pm-side` is attached to the correct root, reordering DOM children appropriately, and calling the layout function after profile load.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm test` (unit tests) and all tests passed.
- Ran `npm run build` (CI build) and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91f13982483269e2cd86110197e03)