### PR TITLE
feat(share): experimental frontend-only X image share intent

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -8,6 +8,18 @@ import { BACKEND_URL } from '../config.js';
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
 
+const EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true;
+const EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png';
+
+function openExperimentalFrontendXImageIntent(context) {
+  const origin = window.location?.origin || '';
+  const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
+  const text = 'Experimental share from Ursasstube';
+  const intent = `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(imageUrl)}`;
+  openUrl(intent);
+  analytics.shareIntentOpened({ context, reason: 'experimental_frontend_image_intent' });
+}
+
 function openUrl(url) {
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.openLink) {
     window.Telegram.WebApp.openLink(url);
@@ -163,7 +175,10 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
       return { success: false, errorCode: 'network_error', fallbackIntentUrl: intentUrl || null };
     }
   } else if (preferredShareFlow === 'intent') {
-    if (intentUrl) {
+    if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+      // EXPERIMENT: client-only X flow with a fixed front-end image URL.
+      openExperimentalFrontendXImageIntent(context);
+    } else if (intentUrl) {
       openTextShareIntent(intentUrl, context, 'preferred_share_flow_intent');
     }
   } else if (intentUrl) {


### PR DESCRIPTION
### Motivation
- Provide a minimal frontend-only experiment to attach a fixed image to an X post when users press `SHARE RESULT` without relying on backend media attachment logic. 
- Keep the experiment easily reversible by marking it in code and analytics so it can be removed if it doesn't meet expectations.

### Description
- Added two constants: `EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true` and `EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png'` in `js/share/shareFlow.js`.
- Implemented helper `openExperimentalFrontendXImageIntent(context)` that builds an absolute URL from `window.location.origin` and opens `https://x.com/intent/tweet` with the image URL and a short text.
- When `preferredShareFlow === 'intent'` the code now invokes the experimental helper instead of the regular `intentUrl` path, while leaving the `x_api` branch and other fallbacks unchanged.
- The experimental flow logs an analytics reason `experimental_frontend_image_intent` to make the run observable and reversible.

### Testing
- Ran `node --check js/share/shareFlow.js` and it succeeded.
- Pre-commit hooks executed automatically and passed `check:syntax` and `check:static-analysis` during the commit.
- The change was committed successfully and static analysis/syntax guards reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c2c971148326bb8f3d1688792202)