### PR TITLE
Add experimental frontend-only X image share intent

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -8,6 +8,18 @@ import { BACKEND_URL } from '../config.js';
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
 
+const EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true;
+const EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png';
+
+function openExperimentalFrontendXImageIntent(context) {
+  const origin = window.location?.origin || '';
+  const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
+  const text = 'Experimental share from Ursasstube';
+  const intent = `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(imageUrl)}`;
+  openUrl(intent);
+  analytics.shareIntentOpened({ context, reason: 'experimental_frontend_image_intent' });
+}
+
 function openUrl(url) {
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.openLink) {
     window.Telegram.WebApp.openLink(url);
@@ -89,6 +101,13 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
 
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
   analytics.shareResultClicked({ context });
+
+  if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+    // EXPERIMENT: bypass backend share APIs entirely to avoid dependency on backend availability.
+    openExperimentalFrontendXImageIntent(context);
+    return { success: true, experimentalFrontendOnly: true };
+  }
+
   let currentProfile = profile;
 
   if (!currentProfile) {
@@ -163,7 +182,10 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
       return { success: false, errorCode: 'network_error', fallbackIntentUrl: intentUrl || null };
     }
   } else if (preferredShareFlow === 'intent') {
-    if (intentUrl) {
+    if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+      // EXPERIMENT: client-only X flow with a fixed front-end image URL.
+      openExperimentalFrontendXImageIntent(context);
+    } else if (intentUrl) {
       openTextShareIntent(intentUrl, context, 'preferred_share_flow_intent');
     }
   } else if (intentUrl) {


### PR DESCRIPTION
### Motivation
- Provide an experimental client-side X (Twitter) share flow to allow sharing a fixed frontend-hosted image without relying on backend share APIs.

### Description
- Add `EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE` flag and `EXPERIMENTAL_FRONTEND_X_IMAGE_PATH` constant pointing to the frontend image asset.
- Implement `openExperimentalFrontendXImageIntent(context)` to build an X intent URL (`https://x.com/intent/tweet`) with a fixed image URL and open it via `openUrl`, and emit `analytics.shareIntentOpened` with a special reason.
- Short-circuit `performShare` to invoke the experimental intent and return `{ success: true, experimentalFrontendOnly: true }` when the flag is enabled.
- Use the experimental intent path in the `preferredShareFlow === 'intent'` branch as an alternate client-only flow.

### Testing
- Ran unit tests with `npm test`, and the test suite passed.
- Ran the linter with `npm run lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c2c971148326bb8f3d1688792202)