### PR TITLE
Add experimental client-side X image share flow with native share and intent fallback

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -8,6 +8,46 @@ import { BACKEND_URL } from '../config.js';
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
 
+const EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true;
+const EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png';
+
+
+
+async function tryExperimentalNativeImageShare(context) {
+  if (!navigator.share || !window.File) return false;
+  try {
+    const origin = window.location?.origin || '';
+    const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
+    const response = await fetch(imageUrl, { cache: 'no-store' });
+    if (!response.ok) return false;
+    const blob = await response.blob();
+    const fileName = EXPERIMENTAL_FRONTEND_X_IMAGE_PATH.split('/').pop() || 'share.png';
+    const file = new File([blob], fileName, { type: blob.type || 'image/png' });
+
+    if (navigator.canShare && !navigator.canShare({ files: [file] })) {
+      return false;
+    }
+
+    await navigator.share({
+      text: 'Experimental share from Ursasstube',
+      files: [file]
+    });
+    analytics.shareIntentOpened({ context, reason: 'experimental_frontend_native_image_share' });
+    return true;
+  } catch (e) {
+    logger.warn('⚠️ Native image share failed:', e);
+    return false;
+  }
+}
+function openExperimentalFrontendXImageIntent(context) {
+  const origin = window.location?.origin || '';
+  const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
+  const text = 'Experimental share from Ursasstube';
+  const intent = `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(imageUrl)}`;
+  openUrl(intent);
+  analytics.shareIntentOpened({ context, reason: 'experimental_frontend_image_intent' });
+}
+
 function openUrl(url) {
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.openLink) {
     window.Telegram.WebApp.openLink(url);
@@ -89,6 +129,16 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
 
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
   analytics.shareResultClicked({ context });
+
+  if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+    // EXPERIMENT: bypass backend share APIs entirely to avoid dependency on backend availability.
+    const sharedAsImage = await tryExperimentalNativeImageShare(context);
+    if (!sharedAsImage) {
+      openExperimentalFrontendXImageIntent(context);
+    }
+    return { success: true, experimentalFrontendOnly: true, sharedAsImage };
+  }
+
   let currentProfile = profile;
 
   if (!currentProfile) {
@@ -163,7 +213,10 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
       return { success: false, errorCode: 'network_error', fallbackIntentUrl: intentUrl || null };
     }
   } else if (preferredShareFlow === 'intent') {
-    if (intentUrl) {
+    if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+      // EXPERIMENT: client-only X flow with a fixed front-end image URL.
+      openExperimentalFrontendXImageIntent(context);
+    } else if (intentUrl) {
       openTextShareIntent(intentUrl, context, 'preferred_share_flow_intent');
     }
   } else if (intentUrl) {


### PR DESCRIPTION
### Motivation
- Introduce an experimental client-only share flow to X that avoids backend share APIs and tests sharing a fixed front-end image using the Web Share API or an X intent URL as a fallback.

### Description
- Add feature flags `EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE` and `EXPERIMENTAL_FRONTEND_X_IMAGE_PATH` and implement `tryExperimentalNativeImageShare` to fetch a bundled image, wrap it in a `File`, and invoke `navigator.share` when supported.
- Add `openExperimentalFrontendXImageIntent` to open an X/tweet intent URL pointing at the front-end image and record analytics with `analytics.shareIntentOpened` and logging on failures via `logger.warn`.
- Short-circuit `performShare` to run the experimental flow when the flag is enabled, bypassing backend share APIs and using the native share attempt with an intent fallback; also use the experimental intent path in the preferred `intent` branch.
- Preserve existing error handling and analytics for non-experimental flows and maintain the previous behavior when the experimental flag is disabled.

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Ran the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c2c971148326bb8f3d1688792202)