### PR TITLE
Add experimental Web Share API image sharing (frontend-only)

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -8,6 +8,37 @@ import { BACKEND_URL } from '../config.js';
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
 
+const EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true;
+const EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png';
+
+
+
+async function tryExperimentalNativeImageShare(context) {
+  if (!navigator.share || !window.File) return false;
+  try {
+    const origin = window.location?.origin || '';
+    const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
+    const response = await fetch(imageUrl, { cache: 'no-store' });
+    if (!response.ok) return false;
+    const blob = await response.blob();
+    const fileName = EXPERIMENTAL_FRONTEND_X_IMAGE_PATH.split('/').pop() || 'share.png';
+    const file = new File([blob], fileName, { type: blob.type || 'image/png' });
+
+    if (navigator.canShare && !navigator.canShare({ files: [file] })) {
+      return false;
+    }
+
+    await navigator.share({
+      text: 'Experimental share from Ursasstube',
+      files: [file]
+    });
+    analytics.shareIntentOpened({ context, reason: 'experimental_frontend_native_image_share' });
+    return true;
+  } catch (e) {
+    logger.warn('⚠️ Native image share failed:', e);
+    return false;
+  }
+}
 function openUrl(url) {
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.openLink) {
     window.Telegram.WebApp.openLink(url);
@@ -89,6 +120,17 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
 
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
   analytics.shareResultClicked({ context });
+
+  if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+    // EXPERIMENT: Web Share API only (no backend, no link fallback) to validate real image attachment.
+    const sharedAsImage = await tryExperimentalNativeImageShare(context);
+    if (!sharedAsImage) {
+      notifyWarn('⚠️ Web Share API с файлом недоступен на этом устройстве/браузере.');
+      return { success: false, experimentalFrontendOnly: true, sharedAsImage: false };
+    }
+    return { success: true, experimentalFrontendOnly: true, sharedAsImage: true };
+  }
+
   let currentProfile = profile;
 
   if (!currentProfile) {


### PR DESCRIPTION
### Motivation
- Provide an experimental frontend-only path to validate real image attachments using the Web Share API without invoking backend share flows.

### Description
- Introduced feature flags and resources: `EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE` and `EXPERIMENTAL_FRONTEND_X_IMAGE_PATH` and added an image asset path to fetch for sharing.
- Added `tryExperimentalNativeImageShare(context)` which fetches the image, constructs a `File`, checks `navigator.canShare`, and calls `navigator.share` with `files` while logging via `analytics` and `logger` on failure.
- Short-circuited `performShare` to attempt the experimental native image share first when the flag is enabled and surface a user warning via `notifyWarn` if it is not available.
- Preserved existing share flow unchanged when the experimental flag is disabled, and added minimal user-facing messages for the experimental path.

### Testing
- No automated tests were added or executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c2c971148326bb8f3d1688792202)