### PR TITLE
Add experimental Web Share API image sharing flow and short-circuit performShare

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -8,6 +8,40 @@ import { BACKEND_URL } from '../config.js';
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
 
+const EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true;
+const EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png';
+const EXPERIMENTAL_X_COMPOSE_URL = 'https://x.com/compose/post';
+
+
+
+async function tryExperimentalNativeImageShare(context) {
+  if (!navigator.share || !window.File) return false;
+  try {
+    const origin = window.location?.origin || '';
+    const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
+    const response = await fetch(imageUrl, { cache: 'no-store' });
+    if (!response.ok) return false;
+    const blob = await response.blob();
+    const fileName = EXPERIMENTAL_FRONTEND_X_IMAGE_PATH.split('/').pop() || 'share.png';
+    const file = new File([blob], fileName, { type: blob.type || 'image/png' });
+
+    if (navigator.canShare && !navigator.canShare({ files: [file] })) {
+      return false;
+    }
+
+    await navigator.share({
+      text: 'Experimental share from Ursasstube',
+      files: [file]
+    });
+    analytics.shareIntentOpened({ context, reason: 'experimental_frontend_native_image_share' });
+    // EXPERIMENT: after successful native share, open X composer page explicitly.
+    openUrl(EXPERIMENTAL_X_COMPOSE_URL);
+    return true;
+  } catch (e) {
+    logger.warn('⚠️ Native image share failed:', e);
+    return false;
+  }
+}
 function openUrl(url) {
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.openLink) {
     window.Telegram.WebApp.openLink(url);
@@ -89,6 +123,17 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
 
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
   analytics.shareResultClicked({ context });
+
+  if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
+    // EXPERIMENT: Web Share API only (no backend, no link fallback) to validate real image attachment.
+    const sharedAsImage = await tryExperimentalNativeImageShare(context);
+    if (!sharedAsImage) {
+      notifyWarn('⚠️ Web Share API с файлом недоступен на этом устройстве/браузере.');
+      return { success: false, experimentalFrontendOnly: true, sharedAsImage: false };
+    }
+    return { success: true, experimentalFrontendOnly: true, sharedAsImage: true };
+  }
+
   let currentProfile = profile;
 
   if (!currentProfile) {


### PR DESCRIPTION
### Motivation

- Add a quick experiment to attach a local frontend image to the system share sheet using the Web Share API to validate native file attachment behavior without backend involvement. 
- Provide an explicit path to open X compose after a successful native share and surface a warning when the Web Share API with files is unavailable. 

### Description

- Introduce feature flags and constants: `EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE`, `EXPERIMENTAL_FRONTEND_X_IMAGE_PATH`, and `EXPERIMENTAL_X_COMPOSE_URL` to control the experiment. 
- Add `tryExperimentalNativeImageShare(context)` which fetches the configured image asset, creates a `File`, checks `navigator.canShare`, invokes `navigator.share` with `files`, logs analytics via `analytics.shareIntentOpened`, and opens the X composer on success. 
- Update `performShare` to short-circuit into the experimental flow when enabled, returning structured results and showing a `notifyWarn` message if native file sharing is unavailable. 
- Keep existing share flow intact when the experiment flag is disabled and reuse `openUrl` behavior for Telegram and web. 

### Testing

- Ran unit and integration tests with `npm run test` which completed successfully. 
- Ran linting with `npm run lint` which passed without errors. 
- Verified that the modified `performShare` returns the experimental result object shape when `EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE` is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c2c971148326bb8f3d1688792202)