### PR TITLE
Revert frontend file-attachment X share experiment

### DIFF
--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -8,40 +8,6 @@ import { BACKEND_URL } from '../config.js';
 const SHARE_CONFIRM_DELAY_MS = 33000; // 30s minimum + 3s buffer for network latency
 const SHARE_CONFIRM_RETRY_BUFFER_MS = 1200;
 
-const EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE = true;
-const EXPERIMENTAL_FRONTEND_X_IMAGE_PATH = '/assets/bonus_invert.png';
-const EXPERIMENTAL_X_COMPOSE_URL = 'https://x.com/compose/post';
-
-
-
-async function tryExperimentalNativeImageShare(context) {
-  if (!navigator.share || !window.File) return false;
-  try {
-    const origin = window.location?.origin || '';
-    const imageUrl = `${origin}${EXPERIMENTAL_FRONTEND_X_IMAGE_PATH}`;
-    const response = await fetch(imageUrl, { cache: 'no-store' });
-    if (!response.ok) return false;
-    const blob = await response.blob();
-    const fileName = EXPERIMENTAL_FRONTEND_X_IMAGE_PATH.split('/').pop() || 'share.png';
-    const file = new File([blob], fileName, { type: blob.type || 'image/png' });
-
-    if (navigator.canShare && !navigator.canShare({ files: [file] })) {
-      return false;
-    }
-
-    await navigator.share({
-      text: 'Experimental share from Ursasstube',
-      files: [file]
-    });
-    analytics.shareIntentOpened({ context, reason: 'experimental_frontend_native_image_share' });
-    // EXPERIMENT: after successful native share, open X composer page explicitly.
-    openUrl(EXPERIMENTAL_X_COMPOSE_URL);
-    return true;
-  } catch (e) {
-    logger.warn('⚠️ Native image share failed:', e);
-    return false;
-  }
-}
 function openUrl(url) {
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.openLink) {
     window.Telegram.WebApp.openLink(url);
@@ -124,15 +90,6 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
 async function performShare({ context = 'menu', profile = null, onProfileUpdated = null } = {}) {
   analytics.shareResultClicked({ context });
 
-  if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
-    // EXPERIMENT: Web Share API only (no backend, no link fallback) to validate real image attachment.
-    const sharedAsImage = await tryExperimentalNativeImageShare(context);
-    if (!sharedAsImage) {
-      notifyWarn('⚠️ Web Share API с файлом недоступен на этом устройстве/браузере.');
-      return { success: false, experimentalFrontendOnly: true, sharedAsImage: false };
-    }
-    return { success: true, experimentalFrontendOnly: true, sharedAsImage: true };
-  }
 
   let currentProfile = profile;
 
@@ -208,10 +165,7 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
       return { success: false, errorCode: 'network_error', fallbackIntentUrl: intentUrl || null };
     }
   } else if (preferredShareFlow === 'intent') {
-    if (EXPERIMENTAL_FRONTEND_X_IMAGE_SHARE) {
-      // EXPERIMENT: client-only X flow with a fixed front-end image URL.
-      openExperimentalFrontendXImageIntent(context);
-    } else if (intentUrl) {
+    if (intentUrl) {
       openTextShareIntent(intentUrl, context, 'preferred_share_flow_intent');
     }
   } else if (intentUrl) {


### PR DESCRIPTION
### Motivation
- The frontend experiment that attached a local `File` via the Web Share API intercepted `performShare` and bypassed the backend contract, and it needs to be removed so sharing is backend-driven again.

### Description
- Removed the experimental constants and `tryExperimentalNativeImageShare` helper and the early experimental branch in `performShare` to restore the normal backend-driven flow in `js/share/shareFlow.js`.
- Simplified the `preferredShareFlow === 'intent'` branch to always use the backend-provided `intentUrl` instead of a client-only image fallback.

### Testing
- Ran `npm run check:syntax` and `npm run test:request` and both succeeded. Pre-commit hooks also ran `check:static-analysis` successfully during the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f70b0d8c8326966d69c50dff5473)