### PR TITLE
Fix player menu layout across web / Telegram / mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3327,7 +3327,7 @@ body.is-telegram #rulesScreen {
 }
 
 body.is-telegram #walletCorner {
-  position: fixed;
+  position: absolute;
   top: max(8px, env(safe-area-inset-top));
   right: calc(env(safe-area-inset-right, 0px) + 20px);
   z-index: 8000;
@@ -3360,3 +3360,32 @@ body.telegram-mini-app #gameStart .start-audio-nav {
 }
 
 .pm-help-text{font-size:12px;opacity:.85;margin-top:6px}.pm-error-text{font-size:12px;color:#ff8080;margin-top:6px}
+
+
+.pm-side.pm-side--fixed-slot { margin-top: 2px; }
+
+body.is-telegram #playerMenuOverlay .pm-history,
+body.telegram-mini-app #playerMenuOverlay .pm-history,
+body.is-web #playerMenuOverlay .pm-history { display: block; }
+
+body.is-telegram #pmReferralApplyInput,
+body.telegram-mini-app #pmReferralApplyInput,
+body.is-telegram #pmReferralCode,
+body.telegram-mini-app #pmReferralCode {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+body.is-telegram #pmReferralApplyBtn,
+body.telegram-mini-app #pmReferralApplyBtn,
+body.is-telegram #pmCopyReferralCodeBtn,
+body.telegram-mini-app #pmCopyReferralCodeBtn {
+  flex: 0 0 84px;
+  min-width: 84px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+body.telegram-mini-app #walletCorner,
+body.is-telegram #playerCorner,
+body.telegram-mini-app #playerCorner { position: absolute; }

--- a/index.html
+++ b/index.html
@@ -227,6 +227,14 @@
     <div class="pm-center">
       <div class="pm-rank">You're <span id="pmRankNumber">#—</span></div>
       <div class="pm-best">Best score: <span id="pmBestScore">0</span></div>
+      <aside class="pm-side pm-side--inline pm-side--fixed-slot">
+        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
+        <div class="pm-side-x pm-x-wrap" id="pmXBlock">
+          <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
+          <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
+        </div>
+        <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
+      </aside>
       <div class="pm-row pm-nickname-row">
         <label for="pmNicknameInput" class="pm-label">Nickname</label>
         <div class="pm-nickname-field">
@@ -247,7 +255,7 @@
         <label class="pm-label" for="pmReferralCode">Your referral code</label>
         <div class="pm-share-row">
           <input id="pmReferralCode" class="pm-input pm-input--field pm-input-referral" type="text" readonly aria-label="Referral code">
-          <button id="pmCopyReferralCodeBtn" class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" aria-label="Copy referral code">Copy code</button>
+          <button id="pmCopyReferralCodeBtn" class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" aria-label="Copy referral code">Copy</button>
           <button id="pmShareBtn" class="pm-share-btn is-share ui-btn ui-btn--secondary ui-btn--sm" disabled>SHARE RESULT</button>
         </div>
       </div>
@@ -299,15 +307,6 @@
       </section>
     </div>
 
-    <!-- Right column: account connections -->
-    <aside class="pm-side">
-      <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectTelegramBtn">Connect Telegram</button>
-      <div class="pm-side-x pm-x-wrap" id="pmXBlock">
-        <button class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectXBtn" data-state="disconnected">Connect X</button>
-        <button class="pm-x-disconnect ui-btn ui-btn--danger ui-btn--sm" id="pmXDisconnectBtn" hidden>Disconnect X</button>
-      </div>
-      <button class="pm-side-btn pm-connect-wallet-top ui-btn ui-btn--secondary ui-btn--sm" id="pmConnectWalletBtn" hidden>Connect Wallet</button>
-    </aside>
   </div>
 </div>
 

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -207,42 +207,8 @@ function updateWalletBlock(profile) {
 
 function applyResponsivePlayerMenuLayout() {
   const xBlock = DOM.pmXBlock;
-  const telegramBtn = DOM.pmConnectTelegramBtn;
-  const walletBtn = DOM.pmConnectWalletBtn;
-  const sideColumn = document.querySelector('.pm-side');
-  const contentRoot = document.querySelector('.pm-content');
-  const centerColumn = document.querySelector('.pm-center');
-  const bestScore = centerColumn?.querySelector('.pm-best');
-  if (!xBlock || !telegramBtn || !sideColumn || !centerColumn || !bestScore || !contentRoot) return;
-
-  const isMobile = window.matchMedia('(max-width: 640px)').matches;
-  const isTelegramApp = document.body.classList.contains('is-telegram')
-    || document.body.classList.contains('telegram-mini-app');
-
-  if (isMobile || isTelegramApp) {
-    bestScore.insertAdjacentElement('afterend', sideColumn);
-    sideColumn.classList.add('pm-side--inline');
-    sideColumn.appendChild(telegramBtn);
-    sideColumn.appendChild(xBlock);
-    if (walletBtn) sideColumn.appendChild(walletBtn);
-    xBlock.classList.add('pm-x-wrap--mobile-inline');
-    return;
-  }
-
-  if (sideColumn.parentElement !== contentRoot) {
-    contentRoot.appendChild(sideColumn);
-  }
-  sideColumn.classList.remove('pm-side--inline');
-  sideColumn.insertBefore(telegramBtn, sideColumn.firstChild);
-  if (walletBtn && walletBtn.parentElement === sideColumn) {
-    sideColumn.insertBefore(xBlock, walletBtn);
-  } else {
-    sideColumn.appendChild(xBlock);
-  }
-  if (walletBtn && walletBtn.parentElement !== sideColumn) {
-    sideColumn.appendChild(walletBtn);
-  }
-  xBlock.classList.remove('pm-x-wrap--mobile-inline');
+  if (!xBlock) return;
+  xBlock.classList.add('pm-x-wrap--mobile-inline');
 }
 
 function fillProfileData(profile) {


### PR DESCRIPTION
### Motivation
- Restore the Player Menu `History` block visibility in web and Telegram contexts and prevent it from being hidden by platform styles.
- Ensure referral fields/buttons in the Telegram player menu fit on one line so `Apply` and `Copy` sit next to their inputs.
- Move and lock the account connect controls into a stable slot between `Best score` and `Nickname` to avoid unwanted reflows.
- Remove rigid fixed-position pinning for HUD corners in Telegram/mobile so the main screen layout behaves correctly on small clients.

### Description
- Inserted a fixed slot aside between `pm-best` and the nickname row in `index.html` to hold `Connect Telegram`, `Connect X` and `Connect Wallet` controls and removed the duplicate right-column placement.
- Changed the referral copy button label from `Copy code` to `Copy` in `index.html` to shorten text for narrow layouts.
- Simplified `applyResponsivePlayerMenuLayout` in `js/player-menu/controller.js` to stop reparenting sidebar controls and instead keep the connect block in-place by applying the mobile-inline wrapper class only.
- Added CSS rules in `css/style.css` to expose the `pm-history` block across contexts, introduce `.pm-side--fixed-slot` spacing, make referral inputs shrink (`flex: 1 1 auto`) and lock `Apply`/`Copy` buttons at a fixed width on Telegram/mobile, and switch `body.is-telegram`/`telegram-mini-app` HUD corners (`#walletCorner`, `#playerCorner`) from `position: fixed` to `position: absolute`.

### Testing
- Ran `node scripts/check-syntax.mjs` with no errors and the repo syntax checks passed.
- Pre-commit hooks executed during commit and `check:static-analysis` passed with no violations.
- Commit succeeded and no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5a4c818c8326bb991a7a510e1999)