### PR TITLE
Use real @telegram-apps/analytics dependency and remove local stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@walletconnect/ethereum-provider": "file:vendor/walletconnect-ethereum-provider",
     "phaser": "^3.90.0",
     "posthog-js": "file:vendor/posthog-js",
-    "@telegram-apps/analytics": "file:vendor/telegram-apps-analytics"
+    "@telegram-apps/analytics": "^1.3.4"
   },
   "engines": {
     "node": ">=22"

--- a/vendor/telegram-apps-analytics/index.js
+++ b/vendor/telegram-apps-analytics/index.js
@@ -1,9 +1,0 @@
-export async function init() {
-  return true;
-}
-
-export function track(_eventName, _payload = {}) {
-  return true;
-}
-
-export default { init, track };

--- a/vendor/telegram-apps-analytics/package.json
+++ b/vendor/telegram-apps-analytics/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "@telegram-apps/analytics",
-  "version": "0.0.0-local",
-  "type": "module",
-  "main": "index.js"
-}


### PR DESCRIPTION
### Motivation
- Replace a local no-op stub package with the real `@telegram-apps/analytics` npm dependency so Telegram events are sent by the real SDK. 
- Ensure the analytics integration still initializes before the game bootstrap and does not leak sensitive tokens into logs.

### Description
- Updated `package.json` to replace `"@telegram-apps/analytics": "file:vendor/telegram-apps-analytics"` with `"@telegram-apps/analytics": "^1.3.4"`.
- Removed the local stub package at `vendor/telegram-apps-analytics` (deleted `index.js` and `package.json`).
- Verified the integration code supports both `sdk.init` / `sdk.track` and `sdk.default.init` / `sdk.default.track` fallbacks in `initTelegramAnalytics` and `trackTelegramEvent` so behavior remains compatible with the real SDK.
- Kept initialization order unchanged so `initTelegramAnalytics()` still runs before `bootstrapGameFeature()` and the token is not logged.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run test` and the full request/test suite passed (90 tests passed, 0 failed).
- Pre-commit static checks (`check:syntax` and `check:static-analysis`) ran and passed during the commit hook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9d87e8e483269eaa96f8189b4a7e)