### PR TITLE
Harden Telegram Analytics SDK adapter API detection

### DIFF
--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -89,8 +89,8 @@ async function initTelegramAnalytics() {
     try {
       const moduleName = '@telegram-apps/analytics';
       const sdk = await import(/* @vite-ignore */ moduleName);
-      const initFn = sdk?.init || sdk?.default?.init;
-      const trackFn = sdk?.track || sdk?.default?.track;
+      const initFn = sdk?.init || sdk?.default?.init || sdk?.telegramAnalytics?.init || sdk?.default?.telegramAnalytics?.init;
+      const trackFn = sdk?.track || sdk?.default?.track || sdk?.trackEvent || sdk?.default?.trackEvent || sdk?.sendEvent || sdk?.default?.sendEvent || sdk?.event || sdk?.default?.event;
 
       if (typeof initFn !== 'function' || typeof trackFn !== 'function') {
         logger.warn('[tg-analytics] init skipped: sdk api unavailable');


### PR DESCRIPTION
### Motivation
- Избежать runtime-ошибок при изменчивых формах экспорта пакета `@telegram-apps/analytics` и обеспечить работу аналитики при разных версиях/реализациях SDK.
- Гарантировать, что `initTelegramAnalytics` безопасно no-op'ит при отключённой или неполной конфигурации (`VITE_TG_ANALYTICS_*`).
- Предотвратить утечку токена в логах и сохранить существующее поведение при отсутствии SDK.

### Description
- В `js/telegram-analytics.js` добавлена расширенная детекция API SDK: `init` теперь ищется через `sdk.init`, `sdk.default.init`, `sdk.telegramAnalytics.init` и `sdk.default.telegramAnalytics.init`.
- В том же файле добавлены fallback-имена для отправки событий: `track`, `trackEvent`, `sendEvent`, `event` (в named и default экспортах) и результат сохраняется в `sdkTrack`.
- Существующая логика санитизации полезной нагрузки, разрешённых bridge-событий и поведение `trackTelegramEvent`/`initTelegramAnalytics` оставлены без изменений и всё ещё не логируют токен.

### Testing
- `npm install` был запущен, но завершился с ошибкой `403 Forbidden` при попытке загрузить `@telegram-apps/analytics` из npm registry в этом окружении, поэтому реальная runtime-инсталляция пакета проверить не удалось.
- `npm run build` выполняется успешно и сборка проходит без ошибок.
- `npm run test` выполняется успешно; тестовый прогон отчитался `90` пройденных тестов и `0` упавших.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba2b6f69c8326b39b44444e0ab4af)