### PR TITLE
Init Telegram Analytics even when SDK has no track method

### DIFF
--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -45,7 +45,7 @@ let initPromise = null;
 function getConfig() {
   const enabled = String(import.meta.env?.VITE_TG_ANALYTICS_ENABLED || '').trim() === 'true';
   const token = String(import.meta.env?.VITE_TG_ANALYTICS_TOKEN || '').trim();
-  const appName = String(import.meta.env?.VITE_TG_ANALYTICS_APP_NAME || '').trim();
+  const appName = String(import.meta.env?.VITE_TG_ANALYTICS_APP_NAME || 'ursass_tube').trim();
   return { enabled, token, appName };
 }
 
@@ -89,19 +89,20 @@ async function initTelegramAnalytics() {
     try {
       const moduleName = '@telegram-apps/analytics';
       const sdk = await import(/* @vite-ignore */ moduleName);
-      const initFn = sdk?.init || sdk?.default?.init || sdk?.telegramAnalytics?.init || sdk?.default?.telegramAnalytics?.init;
-      const trackFn = sdk?.track || sdk?.default?.track || sdk?.trackEvent || sdk?.default?.trackEvent || sdk?.sendEvent || sdk?.default?.sendEvent || sdk?.event || sdk?.default?.event;
+      const sdkClient = sdk?.default || sdk;
+      const initFn = sdkClient?.init || sdkClient?.telegramAnalytics?.init;
+      const trackFn = sdkClient?.track || sdkClient?.trackEvent || sdkClient?.sendEvent || sdkClient?.event;
 
-      if (typeof initFn !== 'function' || typeof trackFn !== 'function') {
+      if (typeof initFn !== 'function') {
         logger.warn('[tg-analytics] init skipped: sdk api unavailable');
         setDebugState({ reason: 'sdk_api_unavailable' });
         return false;
       }
 
       await initFn({ token, appName });
-      sdkTrack = trackFn;
+      sdkTrack = typeof trackFn === 'function' ? trackFn : null;
       initialized = true;
-      setDebugState({ reason: 'initialized' });
+      setDebugState({ reason: sdkTrack ? 'initialized' : 'initialized_without_track' });
       logger.info('[tg-analytics] initialized');
       return true;
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Make Telegram analytics initialization resilient to SDKs that provide `init` but do not expose a track-like API so app-init/app-hide automatic events still work. 
- Ensure `appName` defaults to `ursass_tube` when not provided via env. 

### Description
- Use dynamic import and resolve the client with `sdk?.default || sdk` and search `init` on the resolved client. 
- Require only an `init` function for successful initialization and call `initFn({ token, appName })` when present. 
- Keep `sdkTrack` optional by detecting `track`, `trackEvent`, `sendEvent`, or `event` and storing it only if found, while still setting `initialized = true` regardless. 
- Leave `trackTelegramEvent` safe-failing so it returns `false` if no `sdkTrack` is present and does not crash the app. 

### Testing
- Ran `npm run build` (which executes `npm run check:conflicts && vite build`) and the build completed successfully. 
- Pre-flight checks including `node scripts/check-no-conflict-markers.mjs`, `node scripts/check-syntax.mjs`, and `node scripts/check-static-analysis.mjs` ran as part of the build/pre-commit and passed. 
- Verified that initialization succeeds when `init` exists even if no track-like API is present and that `trackTelegramEvent` returns `false` safely when tracking is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba78c7d248326b11765a6f2beb179)