### PR TITLE
Add safe diagnostics for Telegram analytics init failures

### DIFF
--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -67,13 +67,20 @@ function loadTelegramAnalyticsSdk() {
   const existingScript = document.querySelector('script[data-tg-analytics-sdk="true"]');
   if (existingScript) {
     return new Promise((resolve) => {
-      const timeoutId = setTimeout(() => resolve(false), 5000);
+      const timeoutId = setTimeout(() => {
+        logger.warn('[tg-analytics] script load timeout');
+        resolve(false);
+      }, 5000);
       existingScript.addEventListener('load', () => {
         clearTimeout(timeoutId);
+        logger.info('[tg-analytics] script loaded', {
+          hasClient: Boolean(getTelegramAnalyticsClient())
+        });
         resolve(Boolean(getTelegramAnalyticsClient()));
       }, { once: true });
       existingScript.addEventListener('error', () => {
         clearTimeout(timeoutId);
+        logger.warn('[tg-analytics] script load failed');
         resolve(false);
       }, { once: true });
     });
@@ -81,7 +88,10 @@ function loadTelegramAnalyticsSdk() {
 
   return new Promise((resolve) => {
     const script = document.createElement('script');
-    const timeoutId = setTimeout(() => resolve(false), 5000);
+    const timeoutId = setTimeout(() => {
+      logger.warn('[tg-analytics] script load timeout');
+      resolve(false);
+    }, 5000);
 
     script.src = TG_ANALYTICS_CDN_URL;
     script.async = true;
@@ -89,11 +99,15 @@ function loadTelegramAnalyticsSdk() {
 
     script.addEventListener('load', () => {
       clearTimeout(timeoutId);
+      logger.info('[tg-analytics] script loaded', {
+        hasClient: Boolean(getTelegramAnalyticsClient())
+      });
       resolve(Boolean(getTelegramAnalyticsClient()));
     }, { once: true });
 
     script.addEventListener('error', () => {
       clearTimeout(timeoutId);
+      logger.warn('[tg-analytics] script load failed');
       resolve(false);
     }, { once: true });
 
@@ -148,6 +162,18 @@ async function initTelegramAnalytics() {
     const client = getTelegramAnalyticsClient();
     const initFn = client?.init;
 
+    logger.info('[tg-analytics] sdk loaded', {
+      hasClient: Boolean(client),
+      hasInit: typeof initFn === 'function',
+      clientKeys: Object.keys(client || {}).slice(0, 20),
+      appName,
+      hasToken: Boolean(token),
+      href: window.location.href,
+      origin: window.location.origin,
+      isTelegramWebApp: Boolean(window.Telegram?.WebApp),
+      tgPlatform: window.Telegram?.WebApp?.platform || null
+    });
+
     if (typeof initFn !== 'function') {
       logger.warn('[tg-analytics] init skipped: sdk init unavailable');
       setDebugState({ reason: 'sdk_init_unavailable' });
@@ -161,7 +187,11 @@ async function initTelegramAnalytics() {
       logger.info('[tg-analytics] initialized');
       return true;
     } catch (error) {
-      logger.warn('[tg-analytics] init failed');
+      logger.warn('[tg-analytics] init failed', {
+        message: error?.message || 'unknown',
+        name: error?.name || 'Error',
+        stack: import.meta.env?.DEV ? error?.stack : undefined
+      });
       setDebugState({ reason: 'init_error', error: error?.message || 'unknown' });
       return false;
     }


### PR DESCRIPTION
### Motivation
- Improve observability for Telegram Analytics initialization failures beyond the generic `[tg-analytics] init failed` message. 
- Provide contextual diagnostics to help triage SDK loading and init issues while avoiding sensitive data exposure. 

### Description
- Add `script loaded`, `script load failed`, and `script load timeout` logs to `loadTelegramAnalyticsSdk()` to surface SDK load status. 
- Add a pre-init `logger.info('[tg-analytics] sdk loaded', {...})` with environment and client context (including `hasToken` boolean and client keys) before calling the SDK `init` function. 
- Replace the generic `logger.warn('[tg-analytics] init failed')` with a structured warning that includes `message`, `name`, and `stack` (the `stack` is only included when `import.meta.env.DEV` is true). 
- Do not change token handling and do not log the token value; only a boolean `hasToken` is emitted. 

### Testing
- Ran `npm run build` successfully and produced the production `dist` artifacts. 
- Pre-commit checks including `check:syntax` passed during commit. 
- Static analysis checks via `check:static-analysis` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbdc78c708326acc52a0c3ec55846)