### PR TITLE
Guard Telegram Analytics init when launch params are missing

### DIFF
--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -60,6 +60,18 @@ function getTelegramAnalyticsClient() {
   return window.telegramAnalytics || window.TelegramAnalytics || window.tgAnalytics || null;
 }
 
+function hasTelegramLaunchParams() {
+  if (typeof window === 'undefined') return false;
+
+  const tg = window.Telegram?.WebApp;
+  const hasInitData = Boolean(tg?.initData);
+  const hasInitDataUnsafe = Boolean(tg?.initDataUnsafe && Object.keys(tg.initDataUnsafe).length > 0);
+  const hasHashLaunchParams = window.location.hash.includes('tgWebAppData=');
+  const hasSearchLaunchParams = window.location.search.includes('tgWebAppData=');
+
+  return hasInitData || hasInitDataUnsafe || hasHashLaunchParams || hasSearchLaunchParams;
+}
+
 function loadTelegramAnalyticsSdk() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return Promise.resolve(false);
   if (getTelegramAnalyticsClient()) return Promise.resolve(true);
@@ -167,7 +179,6 @@ async function initTelegramAnalytics() {
       hasInit: typeof initFn === 'function',
       clientKeys: Object.keys(client || {}).slice(0, 20),
       appName,
-      hasToken: Boolean(token),
       href: window.location.href,
       origin: window.location.origin,
       isTelegramWebApp: Boolean(window.Telegram?.WebApp),
@@ -177,6 +188,17 @@ async function initTelegramAnalytics() {
     if (typeof initFn !== 'function') {
       logger.warn('[tg-analytics] init skipped: sdk init unavailable');
       setDebugState({ reason: 'sdk_init_unavailable' });
+      return false;
+    }
+
+    if (!hasTelegramLaunchParams()) {
+      logger.warn('[tg-analytics] init skipped: Telegram launch params missing', {
+        href: window.location.href,
+        origin: window.location.origin,
+        isTelegramWebApp: Boolean(window.Telegram?.WebApp),
+        tgPlatform: window.Telegram?.WebApp?.platform || null
+      });
+      setDebugState({ reason: 'telegram_launch_params_missing' });
       return false;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent the analytics SDK from failing with "Unable to retrieve launch parameters" when the app runs outside Telegram Mini App by skipping `client.init()` if Telegram launch params are not present.

### Description
- Added `hasTelegramLaunchParams()` to `js/telegram-analytics.js` to detect `Telegram.WebApp.initData`, `initDataUnsafe`, or `tgWebAppData` in the URL (`location.hash`/`location.search`).
- Added a guard in `initTelegramAnalytics()` after SDK load and before calling `client.init()` that logs `init skipped: Telegram launch params missing`, sets `setDebugState({ reason: 'telegram_launch_params_missing' })`, and returns `false` when launch params are absent.
- Left the normal initialization path intact and kept calling `client.init({ token, appName })` when params are present.
- Removed the `hasToken` field from the SDK-loaded diagnostic log to avoid extra token-related logging.

### Testing
- Ran `npm run build`; build completed successfully.
- Pre-commit checks (including `check:syntax` and `check:static-analysis`) ran during the commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc095c0a883268c1882f89901358a)