### PR TITLE
Tighten Telegram analytics init gate to avoid SDK initialization outside WebApp

### DIFF
--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -64,12 +64,14 @@ function hasTelegramLaunchParams() {
   if (typeof window === 'undefined') return false;
 
   const tg = window.Telegram?.WebApp;
-  const hasInitData = Boolean(tg?.initData);
-  const hasInitDataUnsafe = Boolean(tg?.initDataUnsafe && Object.keys(tg.initDataUnsafe).length > 0);
-  const hasHashLaunchParams = window.location.hash.includes('tgWebAppData=');
-  const hasSearchLaunchParams = window.location.search.includes('tgWebAppData=');
+  if (!tg || typeof tg !== 'object') return false;
 
-  return hasInitData || hasInitDataUnsafe || hasHashLaunchParams || hasSearchLaunchParams;
+  const hasInitData = typeof tg.initData === 'string' && tg.initData.trim().length > 0;
+  const hasInitDataUnsafe = Boolean(tg.initDataUnsafe && Object.keys(tg.initDataUnsafe).length > 0);
+
+  // Strict Telegram-only gate: URL launch params can leak to non-Telegram browser sessions
+  // and trigger invalid SDK requests (HTTP 400).
+  return hasInitData || hasInitDataUnsafe;
 }
 
 function loadTelegramAnalyticsSdk() {


### PR DESCRIPTION
### Motivation
- Prevent the analytics SDK from starting in regular browser sessions and producing invalid requests (HTTP 400 to `tganalytics.xyz/events`) by tightening the Telegram launch detection.

### Description
- Update `js/telegram-analytics.js` to require a real `window.Telegram.WebApp` object and non-empty `initData`/`initDataUnsafe` before initializing the SDK, removing the URL `tgWebAppData` hash/search fallback and adding an inline comment explaining the safety rationale.

### Testing
- Ran `npm run -s check:syntax` and `npm run check:static-analysis`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcec31a5d08326a51e35e6a36a94bd)