### PR TITLE
Fix Telegram analytics bridge event mapping and frontend env docs

### DIFF
--- a/docs/telegram-analytics.md
+++ b/docs/telegram-analytics.md
@@ -1,8 +1,8 @@
 # Telegram Mini Apps Analytics integration
 
-## Required Railway Variables
+## Required frontend variables (Vercel / Vite build env)
 
-Set these **in Railway project variables** (frontend runtime/build env):
+Set these in the frontend project environment variables (for this repo on Vercel):
 
 - `VITE_TG_ANALYTICS_ENABLED=true`
 - `VITE_TG_ANALYTICS_TOKEN=<your Telegram analytics token>`
@@ -58,9 +58,9 @@ Use browser console to verify enabled/initialized and fire test events.
 ## How to validate in Telegram WebView
 
 1. Open Mini App inside Telegram.
-2. Ensure Railway variables are set and deployed.
+2. Ensure frontend env variables are set in Vercel and deployment is rebuilt.
 3. Open DevTools (remote debugging for mobile if needed).
 4. Check console logs prefixed with `[tg-analytics]` in DEV.
 5. In Network tab, filter requests by analytics endpoint domain used by SDK.
-6. Trigger flows (open app, start run, wait 10s, finish run, share, open store).
+6. Trigger flows (open app, start run, finish run, share result, donation, wallet connect).
 7. Verify payloads contain only allowed fields (no PII keys listed above).

--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -35,8 +35,15 @@ const ALLOWED_BRIDGE_EVENTS = new Set([
   'wallet_connect_success',
   'wallet_connect_failed',
   'share_clicked',
+  'share_result_clicked',
+  'share_intent_opened',
   'upload_opened'
 ]);
+
+const EVENT_NAME_ALIASES = {
+  share_result_clicked: 'share_clicked',
+  share_intent_opened: 'share_clicked',
+};
 
 let bridgeStarted = false;
 let initAttempted = false;
@@ -236,7 +243,8 @@ async function initTelegramAnalytics() {
 function trackTelegramEvent(eventName, payload = {}) {
   try {
     if (!initialized) return false;
-    const name = String(eventName || '').trim();
+    const rawName = String(eventName || '').trim();
+    const name = EVENT_NAME_ALIASES[rawName] || rawName;
     if (!name) return false;
 
     const client = getTelegramAnalyticsClient();


### PR DESCRIPTION
### Motivation
- Share-related runtime events were not forwarded to the Telegram analytics SDK because the bridge allowlist did not include aliases used by the app, causing missing telemetry in Telegram Analytics. 
- Documentation referenced Railway for frontend env vars which causes misconfiguration for this repo that is deployed from the frontend build (Vercel/Vite). 

### Description
- Added `share_result_clicked` and `share_intent_opened` to the Telegram bridge allowlist in `js/telegram-analytics.js`. 
- Implemented `EVENT_NAME_ALIASES` to map `share_result_clicked` and `share_intent_opened` to `share_clicked` so the Telegram SDK receives the expected event name. 
- Updated `docs/telegram-analytics.md` to instruct setting analytics variables in the frontend build environment (Vercel) and clarified validation steps. 
- The runtime event names emitted by the app were kept unchanged; normalization is performed at the bridge level only. 

### Testing
- Ran `npm run build` which completed successfully (Vite build produced production bundle). 
- Pre-commit and static checks passed via `check:syntax` and `check:static-analysis`. 
- Verified the modified files are syntactically valid and the analytics bridge compiles as part of the frontend build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcee2e640483268619999a1cc3df93)