### PR TITLE
Telegram analytics: payload sanitization, event aliases, init retry and docs/troubleshooting

### DIFF
--- a/docs/telegram-analytics.md
+++ b/docs/telegram-analytics.md
@@ -1,8 +1,8 @@
 # Telegram Mini Apps Analytics integration
 
-## Required Railway Variables
+## Required frontend variables (Vercel / Vite build env)
 
-Set these **in Railway project variables** (frontend runtime/build env):
+Set these in the frontend project environment variables (for this repo on Vercel):
 
 - `VITE_TG_ANALYTICS_ENABLED=true`
 - `VITE_TG_ANALYTICS_TOKEN=<your Telegram analytics token>`
@@ -34,10 +34,19 @@ Do not send personal data in custom events.
 Current integration sends:
 
 - `app_opened`
-- `video_view_start` (`videoId`, `source`)
-- `video_view_10s` (`videoId`)
-- `video_view_complete` (`videoId`, `durationSec`)
-- `share_clicked` (`videoId`)
+- `game_start`
+- `game_end`
+- `run_started`
+- `run_finished`
+- `second_run_started`
+- `leaderboard_opened`
+- `wallet_connect_started`
+- `wallet_connect_success`
+- `wallet_connect_failed`
+- `donation_started`
+- `donation_success`
+- `donation_failed`
+- `share_clicked` (bridge alias for `share_result_clicked` and `share_intent_opened`)
 - `upload_opened`
 
 ## Dev debugging
@@ -58,9 +67,23 @@ Use browser console to verify enabled/initialized and fire test events.
 ## How to validate in Telegram WebView
 
 1. Open Mini App inside Telegram.
-2. Ensure Railway variables are set and deployed.
+2. Ensure frontend env variables are set in Vercel and deployment is rebuilt.
 3. Open DevTools (remote debugging for mobile if needed).
 4. Check console logs prefixed with `[tg-analytics]` in DEV.
 5. In Network tab, filter requests by analytics endpoint domain used by SDK.
-6. Trigger flows (open app, start run, wait 10s, finish run, share, open store).
+6. Trigger flows (open app, start run, finish run, share result, donation, wallet connect).
 7. Verify payloads contain only allowed fields (no PII keys listed above).
+
+## Troubleshooting (`POST /events` returns 400)
+
+If Telegram analytics dashboard still shows `Waiting for SDK` or browser console shows `POST https://tganalytics.xyz/events 400`:
+
+1. Verify `VITE_TG_ANALYTICS_TOKEN` and `VITE_TG_ANALYTICS_APP_NAME` match the exact key/identifier in Telegram analytics cabinet.
+2. Confirm app is opened inside Telegram Mini App, not regular browser tab.
+3. Rebuild/redeploy frontend after env changes (Vite embeds `VITE_*` at build time).
+4. Check request payload in Network tab: event name must be non-empty string, payload should contain only primitive values.
+5. Temporarily trigger minimal event:
+   ```js
+   window.__tgAnalyticsDebug?.trackTelegramEvent('app_opened', { source: 'manual_check' });
+   ```
+   If this works but gameplay events fail, issue is in specific event payload shape.

--- a/js/main.js
+++ b/js/main.js
@@ -55,7 +55,14 @@ async function bootstrap() {
     initLogger();
     stabilizeMenuLoad();
     try {
-      await initTelegramAnalytics();
+      const initialized = await initTelegramAnalytics();
+      if (!initialized && typeof window !== 'undefined') {
+        window.setTimeout(() => {
+          initTelegramAnalytics().catch(() => {
+            console.warn('⚠️ Telegram analytics retry init failed');
+          });
+        }, 1500);
+      }
     } catch (error) {
       console.warn('⚠️ Telegram analytics init failed');
     }

--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -35,8 +35,15 @@ const ALLOWED_BRIDGE_EVENTS = new Set([
   'wallet_connect_success',
   'wallet_connect_failed',
   'share_clicked',
+  'share_result_clicked',
+  'share_intent_opened',
   'upload_opened'
 ]);
+
+const EVENT_NAME_ALIASES = {
+  share_result_clicked: 'share_clicked',
+  share_intent_opened: 'share_clicked',
+};
 
 let bridgeStarted = false;
 let initAttempted = false;
@@ -52,7 +59,32 @@ function getConfig() {
 
 function sanitizePayload(payload) {
   if (!payload || typeof payload !== 'object') return {};
-  return Object.fromEntries(Object.entries(payload).filter(([key]) => !PRIVATE_KEYS.has(key)));
+  const entries = [];
+  const sourceEntries = Object.entries(payload);
+
+  for (const [key, value] of sourceEntries) {
+    if (PRIVATE_KEYS.has(key)) continue;
+    if (value === undefined) continue;
+
+    const valueType = typeof value;
+    if (valueType === 'string') {
+      entries.push([key, value.slice(0, 120)]);
+      continue;
+    }
+    if (valueType === 'number') {
+      if (Number.isFinite(value)) entries.push([key, value]);
+      continue;
+    }
+    if (valueType === 'boolean') {
+      entries.push([key, value]);
+      continue;
+    }
+    if (value === null) {
+      entries.push([key, null]);
+    }
+  }
+
+  return Object.fromEntries(entries.slice(0, 32));
 }
 
 function getTelegramAnalyticsClient() {
@@ -69,9 +101,9 @@ function hasTelegramLaunchParams() {
   const hasInitData = typeof tg.initData === 'string' && tg.initData.trim().length > 0;
   const hasInitDataUnsafe = Boolean(tg.initDataUnsafe && Object.keys(tg.initDataUnsafe).length > 0);
 
-  // Strict Telegram-only gate: URL launch params can leak to non-Telegram browser sessions
-  // and trigger invalid SDK requests (HTTP 400).
-  return hasInitData || hasInitDataUnsafe;
+  // In some Telegram clients initData can arrive slightly позже bootstrap.
+  // If WebApp object is present, allow init and rely on SDK-side validation.
+  return hasInitData || hasInitDataUnsafe || Boolean(tg);
 }
 
 function loadTelegramAnalyticsSdk() {
@@ -203,7 +235,7 @@ async function initTelegramAnalytics() {
     }
 
     if (!hasTelegramLaunchParams()) {
-      logger.warn('[tg-analytics] init skipped: Telegram launch params missing', {
+      logger.warn('[tg-analytics] init skipped: Telegram WebApp missing', {
         href: window.location.href,
         origin: window.location.origin,
         isTelegramWebApp: Boolean(window.Telegram?.WebApp),
@@ -230,13 +262,18 @@ async function initTelegramAnalytics() {
     }
   })();
 
-  return initPromise;
+  const result = await initPromise;
+  if (!initialized) {
+    initPromise = null;
+  }
+  return result;
 }
 
 function trackTelegramEvent(eventName, payload = {}) {
   try {
     if (!initialized) return false;
-    const name = String(eventName || '').trim();
+    const rawName = String(eventName || '').trim();
+    const name = EVENT_NAME_ALIASES[rawName] || rawName;
     if (!name) return false;
 
     const client = getTelegramAnalyticsClient();


### PR DESCRIPTION
### Motivation

- Harden analytics integration to avoid sending PII and malformed payloads to Telegram analytics. 
- Add missing gameplay and wallet/donation events and normalize bridge event names. 
- Improve reliability of SDK initialization in flaky WebView startup conditions and make onboarding/troubleshooting clearer in docs.

### Description

- Update docs: clarify frontend env variables are Vercel/Vite build-time `VITE_*` vars, add new tracked events list, and add a troubleshooting section for `POST /events` 400 errors. 
- Add more allowed bridge events and introduce `EVENT_NAME_ALIASES` to map `share_result_clicked` and `share_intent_opened` to the canonical `share_clicked`. 
- Replace simple `sanitizePayload` with a stricter sanitizer that removes private keys, drops `undefined`, truncates strings to 120 chars, only allows finite numbers/booleans/null, and caps payload entries to 32 keys. 
- Loosen Telegram launch gating to allow initialization if `window.Telegram.WebApp` exists (to handle late-arriving `initData`) and update log messages accordingly. 
- Make `initTelegramAnalytics` return an explicit success boolean and clear the cached `initPromise` on failure, and add a retry attempt from `bootstrap()` after 1500ms when initial init did not succeed. 
- Make `trackTelegramEvent` apply alias mapping before sending and keep safe guards for missing SDK methods.

### Testing

- Ran linter and a local frontend build with `npm run lint` and `npm run build`; both completed successfully. 
- Verified manual DEV console helper `window.__tgAnalyticsDebug` exposure and that `trackTelegramEvent` accepts aliased names using the debug helper; manual checks succeeded in DEV. 
- No automated unit tests were modified by this change and existing test suite (if present in CI) was not altered by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcee2e640483268619999a1cc3df93)