### PR TITLE
Fix top-left HUD metric font size parity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -887,31 +887,32 @@ body.start-launching #walletCorner {
 /* ===== GAME HUD ===== */
 #uiTopLeft {
   position: absolute;
-  top: 4px; left: 4px;
+  top: 12px; left: 12px;
   z-index: 10;
   background: transparent;
   backdrop-filter: none;
-  padding: 3px 5px;
+  padding: 10px 14px;
   border-radius: var(--radius);
   border: none;
   font-family: 'Orbitron', sans-serif;
-  width: 62px;
+  font-size: 11px;
+  width: 138px;
   box-sizing: border-box;
 }
 
-#uiTopLeft > div { margin: 1px 0; font-weight: 600; font-size: 4px; }
+#uiTopLeft > div { margin: 3px 0; font-weight: 600; }
 #uiTopLeft > div:last-child { margin-bottom: 0; }
-#uiTopLeft .speed { color: rgba(255,255,255,.9); font-size: 5px; }
-#uiTopLeft .score { color: #c084fc; font-size: 5px; }
-#uiTopLeft .distance { color: rgba(255,255,255,.8); font-size: 5px; }
+#uiTopLeft .speed { color: rgba(255,255,255,.9); }
+#uiTopLeft .score { color: #c084fc; }
+#uiTopLeft .distance { color: rgba(255,255,255,.8); }
 #uiTopLeft .hud-main-row {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 3px;
+  gap: 8px;
 }
 #uiTopLeft .hud-main-value {
-  min-width: 31px;
+  min-width: 52px;
   text-align: right;
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
### Motivation
- В игре уменьшился размер шрифта и габариты блока с метриками (speed, distance, score) в левом верхнем углу, из-за чего он визуально не соответствует правому HUD.
- Нужно восстановить единый размер шрифта и отступы для консистентного отображения HUD по обеим сторонам экрана.

### Description
- Изменены стили `#uiTopLeft` в `css/style.css` для приведения к параметрам правого HUD: `font-size: 11px`, `width: 138px`, позиционирование и padding приведены к `top: 12px; left: 12px;` и `padding: 10px 14px`.
- Увеличены отступы и интервал между элементами: `#uiTopLeft > div { margin: 3px 0 }` и `gap: 8px` в `.hud-main-row`.
- Удалены локальные маленькие значения шрифта для отдельных элементов и добавлены единые цвета, а колонке числовых значений установлен `min-width: 52px` для корректного выравнивания.
- Изменение ограничено файлом `css/style.css` и не затрагивает JS-логику игры.

### Testing
- Запущен синтакс-проход `node scripts/check-syntax.mjs`, который завершился с ошибкой из-за уже существующей синтаксической ошибки в `js/telegram-analytics.js:142`, не связанной с этим CSS-изменением.
- Pre-commit запускал тот же синтакс-проход и тоже падал по той же ошибке; сам CSS-патч не вызвал ошибок линтинга JavaScript-файлов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb88364f0832684452fd6b51821f3)