### PR TITLE
Fix syntax error in Telegram analytics fetch trace handler

### DIFF
--- a/js/telegram-analytics.js
+++ b/js/telegram-analytics.js
@@ -139,12 +139,6 @@ function installTelegramAnalyticsFetchTrace() {
       if (!response.ok) {
         console.warn('[tg-analytics][trace] /events non-2xx', tracePayload);
       }
-      };
-      logger.info('[tg-analytics][trace] /events response', tracePayload);
-      if (!response.ok) {
-        console.warn('[tg-analytics][trace] /events non-2xx', tracePayload);
-      }
-
     } catch (_error) {
       // no-op
     }


### PR DESCRIPTION
### Motivation
- A stray duplicated logging block and an extra `};` inside `installTelegramAnalyticsFetchTrace` caused a syntax error that broke file parsing and made pre-commit checks fail.
- Restore correct control flow so the fetch trace wrapper returns the `response` and the file is syntactically valid.

### Description
- Removed the accidentally duplicated `logger.info` / `console.warn` block and the stray `};` inside `js/telegram-analytics.js` to fix the broken `try/catch` and return flow in `installTelegramAnalyticsFetchTrace`.
- Restored a single, well-formed `try { ... } catch { ... }` block and the final `return response;` so the function is properly structured.

### Testing
- Ran `node --check js/telegram-analytics.js` which completed successfully.
- Ran pre-commit static checks (`npm run check:syntax` and `npm run check:static-analysis`) which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbaa823e88326a1862a7fc3b41c4c)