### PR TITLE
Inline referral Copy/Apply buttons in Player Menu (mobile/Telegram)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2776,6 +2776,27 @@ footer a:hover { color: #e0b0ff; }
   width: 100%;
 }
 
+
+.pm-referral-code-row,
+.pm-referral-apply-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.pm-referral-code-row .pm-input,
+.pm-referral-apply-row .pm-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pm-referral-code-row .pm-side-btn,
+.pm-referral-apply-row .pm-side-btn {
+  flex: 0 0 auto;
+  min-width: 84px;
+}
+
 .pm-input-referral {
   -webkit-user-select: text;
   user-select: text;
@@ -2797,8 +2818,21 @@ footer a:hover { color: #e0b0ff; }
     flex-wrap: wrap;
   }
 
-  .pm-input-referral {
-    flex-basis: 100%;
+  .pm-share-row.pm-referral-code-row,
+  .pm-share-row.pm-referral-apply-row {
+    flex-wrap: nowrap;
+  }
+}
+
+@media (max-width: 340px) {
+  .pm-share-row.pm-referral-code-row,
+  .pm-share-row.pm-referral-apply-row {
+    flex-wrap: wrap;
+  }
+
+  .pm-share-row.pm-referral-code-row .pm-side-btn,
+  .pm-share-row.pm-referral-apply-row .pm-side-btn {
+    min-width: 100%;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -253,11 +253,11 @@
 
       <div class="pm-row">
         <label class="pm-label" for="pmReferralCode">Your referral code</label>
-        <div class="pm-share-row">
+        <div class="pm-share-row pm-referral-code-row">
           <input id="pmReferralCode" class="pm-input pm-input--field pm-input-referral" type="text" readonly aria-label="Referral code">
           <button id="pmCopyReferralCodeBtn" class="pm-side-btn ui-btn ui-btn--secondary ui-btn--sm" aria-label="Copy referral code">Copy</button>
-          <button id="pmShareBtn" class="pm-share-btn is-share ui-btn ui-btn--secondary ui-btn--sm" disabled>SHARE RESULT</button>
         </div>
+        <button id="pmShareBtn" class="pm-share-btn is-share ui-btn ui-btn--secondary ui-btn--sm" disabled>SHARE RESULT</button>
       </div>
       <div class="pm-row">
         <label class="pm-label" for="pmCopyWebReferralBtn">Copy Web invite link</label>
@@ -269,7 +269,7 @@
       </div>
       <div class="pm-row">
         <label class="pm-label" for="pmReferralApplyInput">Have a referral code?</label>
-        <div class="pm-share-row">
+        <div class="pm-share-row pm-referral-apply-row">
           <input id="pmReferralApplyInput" class="pm-input pm-input--field" type="text" maxlength="64" placeholder="Enter code" aria-label="Enter referral code">
           <button id="pmReferralApplyBtn" class="pm-side-btn ui-btn ui-btn--primary ui-btn--sm">Apply</button>
         </div>


### PR DESCRIPTION
### Motivation
- Make the Player Menu referral area more compact and clearer on Telegram/mobile by visually attaching the `Copy` and `Apply` buttons to their related input fields to reduce wasted vertical space.

### Description
- Updated `index.html` to wrap the code+copy pair in `div.pm-share-row.pm-referral-code-row` and the apply pair in `div.pm-share-row.pm-referral-apply-row`, and moved `#pmShareBtn` out of the code+copy row so the copy button stays visually attached to the code input.
- Added CSS rules in `css/style.css` for `.pm-referral-code-row` and `.pm-referral-apply-row` with `display: flex; align-items: center; gap: 8px;` and made inputs grow (`flex: 1 1 auto; min-width: 0;`) while keeping buttons compact (`flex: 0 0 auto; min-width: 84px;`).
- Added responsive behavior to keep the rows inline on mobile/Telegram widths and allow wrapping only on very narrow screens (`@media (max-width: 340px)`) to avoid layout breakage.
- Preserved all existing element IDs and classes used by JavaScript (`pmReferralCode`, `pmCopyReferralCodeBtn`, `pmReferralApplyInput`, `pmReferralApplyBtn`, etc.) so existing bindings in `js/state.js` and `js/player-menu/controller.js` remain unchanged.

### Testing
- Ran syntax checks with `npm run check:syntax`, which completed successfully.
- Ran static analysis with `npm run check:static-analysis`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbdcec1e883268da8e495e08f1b15)