### PR TITLE
Increase player menu bear head icon size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2662,8 +2662,8 @@ footer a:hover { color: #e0b0ff; }
 .player-card:active { transform: scale(0.98); }
 
 .player-avatar-icon {
-  width: 22px;
-  height: 22px;
+  width: 44px;
+  height: 44px;
   object-fit: contain;
   pointer-events: none;
   filter: drop-shadow(0 0 4px rgba(255,255,255,0.25));


### PR DESCRIPTION
### Motivation
- Make the bear head icon in the player menu visually larger to match the requested 2x scale by updating its CSS size.

### Description
- Change `.player-avatar-icon` width/height from `22px` to `44px` in `css/style.css`, keeping the surrounding container and layout unchanged.

### Testing
- Pre-commit hooks ran the automated checks `npm run check:syntax` and `npm run check:static-analysis` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc0a4d1608326aa7441e221c11e4b)