### PR TITLE
Do not use Telegram primaryId as wallet; load donation catalog without wallet

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -441,8 +441,7 @@ function buildAuthHeaders() {
   const headers = { 'Content-Type': 'application/json' };
   if (primaryId) {
     headers['X-Primary-Id'] = String(primaryId);
-    // legacy fallback
-    headers['X-Wallet'] = String(wallet || primaryId);
+    if (wallet) headers['X-Wallet'] = String(wallet);
   }
   // in Telegram Mini App also send initData
   try {

--- a/js/donation-service.js
+++ b/js/donation-service.js
@@ -92,13 +92,17 @@ function createJsonOptions(method, payload, options = {}) {
   };
 }
 
-async function getDonationProducts(wallet, options = {}) {
+async function getDonationProducts(wallet = '', options = {}) {
   const { paymentMode = '', ...requestOptions } = options;
   const query = new URLSearchParams();
   if (paymentMode) query.set('paymentMode', paymentMode);
   const queryString = query.toString();
+  const normalizedWallet = String(wallet || '').trim();
+  const endpoint = normalizedWallet
+    ? `${BACKEND_URL}/api/store/donations/${encodeURIComponent(normalizedWallet)}`
+    : `${BACKEND_URL}/api/store/donations`;
   const { ok, status, data } = await requestJsonResult(
-    `${BACKEND_URL}/api/store/donations/${encodeURIComponent(wallet)}${queryString ? `?${queryString}` : ''}`,
+    `${endpoint}${queryString ? `?${queryString}` : ''}`,
     { ...REQUEST_PROFILE_STORE_READ, ...requestOptions }
   );
   return { response: { ok, status }, data };

--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -65,7 +65,7 @@ async function postShareResultMedia(shareResultEndpoint, payload = {}) {
   const headers = { 'Content-Type': 'application/json' };
   if (primaryId) {
     headers['X-Primary-Id'] = String(primaryId);
-    headers['X-Wallet'] = String(wallet || primaryId);
+    if (wallet) headers['X-Wallet'] = String(wallet);
   }
   if (isTelegramMiniApp() && window.Telegram?.WebApp?.initData) {
     headers['X-Telegram-Init-Data'] = window.Telegram.WebApp.initData;

--- a/js/store/donation-controller.js
+++ b/js/store/donation-controller.js
@@ -24,6 +24,7 @@ const DONATION_FINAL_STATUSES = new Set(['credited', 'paid', 'failed', 'expired'
 const DONATION_PENDING_STATUS = 'pending';
 const DONATION_REFRESH_COOLDOWN_MS = 60 * 1000;
 const DONATION_PENDING_TIMEOUT_MS = 30 * 60 * 1000;
+const EVM_WALLET_PATTERN = /^0x[a-fA-F0-9]{40}$/;
 
 function trackDonationAnalyticsEvent(name, payload = {}) {
   trackAnalyticsEvent(name, payload);
@@ -73,6 +74,12 @@ export function createDonationController({
 
   function getDonationIdentifier() {
     return String(getAuthIdentifier() || '').trim();
+  }
+
+  function getDonationWalletAddress() {
+    const identifier = getDonationIdentifier();
+    if (!identifier) return '';
+    return EVM_WALLET_PATTERN.test(identifier) ? identifier.toLowerCase() : '';
   }
 
   function getTelegramWebApp() {
@@ -268,7 +275,7 @@ export function createDonationController({
 
   async function loadDonationHistory({ silent = false } = {}) {
     if (!isAuthenticated()) return;
-    const wallet = getDonationIdentifier();
+    const wallet = getDonationWalletAddress();
     if (!wallet) return;
 
     donationUiState.historyLoading = !silent;
@@ -393,9 +400,7 @@ export function createDonationController({
   }
 
   async function loadDonationProducts({ silent = false } = {}) {
-    if (!isAuthenticated()) return;
-    const wallet = getDonationIdentifier();
-    if (!wallet) return;
+    const wallet = getDonationWalletAddress();
     const useTelegramStars = canUseTelegramStarsFlow();
 
     donationUiState.isLoading = !silent;
@@ -405,12 +410,12 @@ export function createDonationController({
     try {
       let { response, data } = await getDonationProducts(wallet, {
         paymentMode: useTelegramStars ? 'telegram-stars' : '',
-        headers: { 'X-Wallet': wallet }
+        headers: wallet ? { 'X-Wallet': wallet } : undefined
       });
 
       if (useTelegramStars && (!response.ok || !data)) {
         ({ response, data } = await getDonationProducts(wallet, {
-          headers: { 'X-Wallet': wallet }
+          headers: wallet ? { 'X-Wallet': wallet } : undefined
         }));
       }
 


### PR DESCRIPTION
### Motivation
- Telegram mini-app users had broken flows because `primaryId` (e.g. `telegram:<id>`) was treated as an EVM `wallet`, causing wallet-only endpoints to fail and blocking UI (leaderboard/store/donations).
- The goal is to separate authenticated identity (`X-Primary-Id`) from real EVM wallet usage and ensure public donation catalog and store balances render for Telegram-only and unauthenticated users.

### Description
- Make donation catalog endpoint wallet-optional by updating `getDonationProducts()` to call `/api/store/donations` when no wallet is provided, instead of always using a wallet path parameter (`js/donation-service.js`).
- Add EVM wallet validation and a `getDonationWalletAddress()` helper that only returns a wallet when the identifier matches `0x` + 40 hex chars, and use it for wallet-only donation history/payment requests (`js/store/donation-controller.js`).
- Only attach `X-Wallet` header when a real signing wallet exists; always send `X-Primary-Id` for identity in `buildAuthHeaders()` used by profile/leaderboard/profile APIs (`js/api.js`).
- Apply same `X-Wallet` conditional header change to the share media posting flow so Telegram `primaryId` is not used as wallet (`js/share/shareFlow.js`).

### Testing
- Ran `npm run build` and produced a successful production build (Vite build completed).
- Ran pre-commit checks which ran `npm run check:syntax` and `npm run check:static-analysis`, both succeeded.
- Verified lint/static-analysis hooks ran during commit and no unresolved issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc1c642d883269fdc4337cc248dd6)