### PR TITLE
Unify Telegram safe-area/content gap across Rules and Store layouts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3232,6 +3232,19 @@ body.telegram-mini-app #rulesScreen .rules-fixed-nav {
   z-index: 9000;
 }
 
+body.is-telegram,
+body.telegram-mini-app {
+  --menu-safe-controls-width: 40px;
+  --menu-safe-content-gap: 12px;
+  --menu-safe-content-inset-left: calc(
+    env(safe-area-inset-left, 0px) +
+    12px +
+    var(--menu-safe-controls-width) +
+    var(--menu-safe-content-gap)
+  );
+  --menu-safe-content-inset-right: calc(env(safe-area-inset-right, 0px) + 12px);
+}
+
 body.is-web .game-audio-nav {
   bottom: max(14px, calc(env(safe-area-inset-bottom, 0px) + 8px));
 }
@@ -3327,9 +3340,9 @@ body.is-telegram #rulesScreen {
 body.is-telegram #rulesScreen .rules-content,
 body.telegram-mini-app #rulesScreen .rules-content {
   width: auto;
-  max-width: calc(100vw - (env(safe-area-inset-left, 0px) + 57px) - (env(safe-area-inset-right, 0px) + 12px));
-  margin-left: calc(env(safe-area-inset-left, 0px) + 57px);
-  margin-right: calc(env(safe-area-inset-right, 0px) + 12px);
+  max-width: calc(100vw - var(--menu-safe-content-inset-left) - var(--menu-safe-content-inset-right));
+  margin-left: var(--menu-safe-content-inset-left);
+  margin-right: var(--menu-safe-content-inset-right);
   touch-action: pan-y;
 }
 
@@ -3341,7 +3354,8 @@ body.telegram-mini-app #rulesScreen .rules-section {
 
 body.is-telegram #storeScreen,
 body.telegram-mini-app #storeScreen {
-  padding-left: 78px;
+  padding-left: var(--menu-safe-content-inset-left);
+  padding-right: var(--menu-safe-content-inset-right);
 }
 
 body.is-telegram #storeScreen .store-header,
@@ -3353,8 +3367,10 @@ body.telegram-mini-app #storeScreen .store-list,
 body.is-telegram #storeScreen .store-donation-shell,
 body.telegram-mini-app #storeScreen .store-donation-shell,
 body.is-telegram #storeScreen .store-donation-grid,
-body.telegram-mini-app #storeScreen .store-donation-grid {
-  max-width: calc(100vw - 116px);
+body.telegram-mini-app #storeScreen .store-donation-grid,
+body.is-telegram #storeScreen .store-panel,
+body.telegram-mini-app #storeScreen .store-panel {
+  max-width: calc(100vw - var(--menu-safe-content-inset-left) - var(--menu-safe-content-inset-right));
 }
 
 body.is-telegram #rulesScreen {


### PR DESCRIPTION
### Motivation
- Rules and Store used different hardcoded horizontal offsets which produced inconsistent gaps between the left safe-area controls and right content across pages and tabs.
- The goal is to centralize the horizontal gap so Rules, Store tabs, upgrade cards and donation cards start at the same X position without per-card hacks or JS changes.
- The change must preserve Back/Sound control positioning and maintain consistent responsive behavior in Telegram scopes.

### Description
- Added Telegram-scoped CSS variables: `--menu-safe-controls-width`, `--menu-safe-content-gap` and derived insets `--menu-safe-content-inset-left` / `--menu-safe-content-inset-right` in `css/style.css` to define a single gap contract.
- Replaced hardcoded `57px` offset used by `.rules-content` with the shared inset variables for `max-width`, `margin-left` and `margin-right` so Rules uses the same gap.
- Replaced hardcoded `padding-left: 78px` on `#storeScreen` with the same inset variables, added symmetrical right inset, and unified `max-width` constraints for store header/tabs/list/donation shell/grid and `store-panel` to avoid tab shifts.
- The change is CSS-only and does not alter Back/Sound control layout, JS, business logic, prices, or behavior.

### Testing
- Pre-commit hooks ran and executed `check:syntax` which passed successfully.
- Static analysis ran via `check:static-analysis` and passed with no regressions.
- The changes are localized to `css/style.css` and the automated checks above reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc41acbb08326ad35b4ab50282d30)