### PR TITLE
Remove checkmark from purchased upgrade tiers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1572,7 +1572,6 @@ body.start-launching #walletCorner {
 
 .store-tier.purchased .store-tier-label { color: rgba(76, 175, 80, .8); }
 .store-tier.purchased .store-tier-price { text-decoration: line-through; opacity: 0.4; }
-.store-tier.purchased::after { content: "✓"; display: block; color: rgba(76, 175, 80, .7); font-size: 14px; margin-top: 2px; }
 
 .store-tier-price { font-size: 10px; opacity: .7; margin-top: 2px; }
 


### PR DESCRIPTION
### Motivation
- Remove the redundant checkmark from purchased upgrade tiers to reduce UI noise since the purchased state is already clear from existing styling.

### Description
- Deleted the `.store-tier.purchased::after` rule in `css/style.css` so purchased tiers retain the green label and struck-through price but no longer show the `✓` marker.

### Testing
- Ran pre-commit checks `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc5c0041083268ef1370c3be8d250)