### PR TITLE
Ограничить увод трубы вниз до 1500м

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -311,7 +311,8 @@ function update(delta) {
   player.y = p.y - CONFIG.FRAME_SIZE / 2;
 
   gameState.centerOffsetX = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_X;
-  gameState.centerOffsetY = Math.sin(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_Y;
+  const nextCenterOffsetY = Math.sin(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_Y;
+  gameState.centerOffsetY = gameState.distance < 1500 ? Math.min(nextCenterOffsetY, 0) : nextCenterOffsetY;
 
   // Camera shake from speed
   const speedRatio = (gameState.speed - CONFIG.SPEED_START) / (CONFIG.SPEED_MAX - CONFIG.SPEED_START);


### PR DESCRIPTION
### Motivation
- Сделать ранний участок забега более читаемым и комфортным, запретив смещение трубы вниз до прохождения 1500м.

### Description
- В `js/physics.js` добавлена промежуточная переменная `nextCenterOffsetY` и `gameState.centerOffsetY` теперь устанавливается в `Math.min(nextCenterOffsetY, 0)` когда `gameState.distance < 1500`, иначе поведение остаётся прежним.

### Testing
- Прогонялись тесты через `npm run -s test -- scripts/tunnel-math-utils.test.mjs` (все тесты успешно прошли — 90/90) и pre-commit хуки `check:syntax` и `check:static-analysis` также прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcc0dca6083268334b0399d908054)