### PR TITLE
Disable extra tunnel mouth ring in Telegram Mini App

### DIFF
--- a/js/phaser/tunnel/TunnelRenderer.js
+++ b/js/phaser/tunnel/TunnelRenderer.js
@@ -431,18 +431,21 @@ class TunnelRenderer {
   }
 
   drawMouthRing(centerX, centerY, tube) {
+    const isTelegramClient = Boolean(
+      document?.body?.classList?.contains('is-telegram')
+      || document?.body?.classList?.contains('telegram-mini-app')
+    );
+    if (isTelegramClient) {
+      return;
+    }
+
     const rimColor = 0xaedcff;
     const outerRadius = CONFIG.TUBE_RADIUS * 1.2;
     const innerRadius = CONFIG.TUBE_RADIUS * 1.24;
     const borderScale = clamp(CONFIG.TUBE_RADIUS / 278, 0.75, 1.1);
     const rimLift = Math.max(0, (278 - CONFIG.TUBE_RADIUS) * 0.25);
     const mobileTubeDropPx = CONFIG.TUBE_RADIUS <= 230 ? 6 : 0;
-    const isTelegramClient = Boolean(
-      document?.body?.classList?.contains('is-telegram')
-      || document?.body?.classList?.contains('telegram-mini-app')
-    );
-    const telegramRingLiftPx = isTelegramClient ? 3 : 0;
-    const ringCenterY = centerY - rimLift - mobileTubeDropPx - telegramRingLiftPx;
+    const ringCenterY = centerY - rimLift - mobileTubeDropPx;
     const centerShift = Math.hypot(tube.centerOffsetX || 0, tube.centerOffsetY || 0);
     const shiftBoost = clamp(centerShift / 120, 0, 0.22);
 


### PR DESCRIPTION
### Motivation
- Telegram Mini App showed a duplicated/protruding rim above the metallic outer frame; the extra procedurally drawn mouth ring must be skipped for Telegram clients so only the metal frame remains visible.

### Description
- In `js/phaser/tunnel/TunnelRenderer.js` the `drawMouthRing` function now returns early for Telegram Mini App clients (checks `document.body.classList` for `is-telegram` / `telegram-mini-app`) and the Telegram-specific lift offset was removed so `ringCenterY` is computed without that adjustment.

### Testing
- Ran a quick syntax check with `node --check js/phaser/tunnel/TunnelRenderer.js`, which succeeded.
- Pre-commit checks ran automatically and passed: `npm run check:syntax` and `npm run check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdce5686888326983d5f2495fb588d)