### PR TITLE
Refresh global and menu stats after referral code apply

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -142,6 +142,8 @@ async function updateWalletUI() {
   }
 }
 
+async function refreshPlayerStats() { await Promise.allSettled([loadAndDisplayLeaderboard(), updateWalletUI()]); }
+
 /**
  * @param {string} message
  * @returns {Promise<string|null>}
@@ -434,7 +436,6 @@ async function fetchSharePayload(wallet) {
 }
 
 /* ===== NEW PROFILE & REFERRAL & SHARE & X API HELPERS ===== */
-
 function buildAuthHeaders() {
   const primaryId = getPrimaryAuthIdentifier();
   const wallet = getSigningWalletAddress(); // real wallet address, if available
@@ -575,6 +576,7 @@ export {
   isAuthenticated,
   getAuthIdentifier,
   updateWalletUI,
+  refreshPlayerStats,
   resetWalletPlayerUI,
   signMessage,
   loadAndDisplayLeaderboard,

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -1,5 +1,5 @@
 import { DOM } from '../state.js';
-import { fetchMyProfile, fetchCoinHistory, disconnectX, setNickname, setLeaderboardDisplay, applyReferralCode, updateWalletUI } from '../api.js';
+import { fetchMyProfile, fetchCoinHistory, disconnectX, setNickname, setLeaderboardDisplay, applyReferralCode, refreshPlayerStats } from '../api.js';
 import { hasAuthenticatedSession, linkTelegram, linkWallet } from '../features/auth/index.js';
 import { isTelegramAuthMode } from '../auth-state.js';
 import { showPlayerMenuScreen, hidePlayerMenuScreen } from '../screens.js';
@@ -354,7 +354,7 @@ function initPlayerMenuEvents() {
   if (DOM.pmCopyWebReferralBtn) { DOM.pmCopyWebReferralBtn.addEventListener('click', async () => { const val = resolveWebReferralUrl(currentProfile); if (!val) return; await navigator.clipboard?.writeText(val); analytics.referralWebLinkCopied?.(); notifySuccess('Web link copied'); }); }
   if (DOM.pmCopyTelegramReferralBtn) { DOM.pmCopyTelegramReferralBtn.addEventListener('click', async () => { const val = currentProfile?.telegramReferralUrl || ''; if (!val) return; await navigator.clipboard?.writeText(val); analytics.referralTelegramLinkCopied?.(); notifySuccess('Telegram link copied'); }); }
   if (DOM.pmReferralApplyInput) { DOM.pmReferralApplyInput.addEventListener('input', () => { const raw = DOM.pmReferralApplyInput.value.toUpperCase().replace(/[^A-Z0-9_-]/g, '').slice(0,64); DOM.pmReferralApplyInput.value = raw; setReferralMessage(DOM.pmReferralError, ''); }); }
-  if (DOM.pmReferralApplyBtn) { DOM.pmReferralApplyBtn.addEventListener('click', async () => { if (currentProfile?.hasAppliedReferralCode) return; analytics.referralCodeApplyClicked?.(); const code = normalizeReferralCode(DOM.pmReferralApplyInput?.value || ''); if (!code) { setReferralMessage(DOM.pmReferralError, 'Please enter a valid code (A-Z, 0-9, _, -).'); return; } const ownCode = normalizeReferralCode(currentProfile?.referralCode || ''); if (code === ownCode) { setReferralMessage(DOM.pmReferralError, 'You cannot use your own referral code.'); return; } DOM.pmReferralApplyBtn.disabled = true; const { ok, data } = await applyReferralCode(code); if (ok) { analytics.referralCodeApplySuccess?.(); setReferralMessage(DOM.pmReferralError, ''); setReferralMessage(DOM.pmReferralHint, ''); notifySuccess(buildReferralSuccessMessage(data)); await Promise.all([refreshPlayerMenu(), updateWalletUI()]); } else { analytics.referralCodeApplyError?.(); setReferralMessage(DOM.pmReferralError, resolveReferralApplyErrorMessage(data)); DOM.pmReferralApplyBtn.disabled = false; } }); }
+  if (DOM.pmReferralApplyBtn) { DOM.pmReferralApplyBtn.addEventListener('click', async () => { if (currentProfile?.hasAppliedReferralCode) return; analytics.referralCodeApplyClicked?.(); const code = normalizeReferralCode(DOM.pmReferralApplyInput?.value || ''); if (!code) { setReferralMessage(DOM.pmReferralError, 'Please enter a valid code (A-Z, 0-9, _, -).'); return; } const ownCode = normalizeReferralCode(currentProfile?.referralCode || ''); if (code === ownCode) { setReferralMessage(DOM.pmReferralError, 'You cannot use your own referral code.'); return; } DOM.pmReferralApplyBtn.disabled = true; const { ok, data } = await applyReferralCode(code); if (ok) { analytics.referralCodeApplySuccess?.(); setReferralMessage(DOM.pmReferralError, ''); setReferralMessage(DOM.pmReferralHint, ''); const optimisticGold = toRewardAmount(data?.totalGold ?? data?.updatedTotalGold ?? data?.gold ?? data?.wallet?.totalGoldCoins); if (optimisticGold !== null && DOM.walletGold) DOM.walletGold.textContent = optimisticGold.toLocaleString('en-US'); notifySuccess(buildReferralSuccessMessage(data)); await Promise.all([refreshPlayerStats(), refreshPlayerMenu(), refreshCoinHistory()]); } else { analytics.referralCodeApplyError?.(); setReferralMessage(DOM.pmReferralError, resolveReferralApplyErrorMessage(data)); DOM.pmReferralApplyBtn.disabled = false; } }); }
 
   if (DOM.pmShareBtn) {
     DOM.pmShareBtn.addEventListener('click', async () => {
@@ -511,6 +511,12 @@ async function openPlayerMenu() {
 
   applyResponsivePlayerMenuLayout();
   await loadProfile();
+}
+
+async function refreshCoinHistory() {
+  if (!menuOpen) return;
+  const coinHistory = await fetchCoinHistory(50);
+  renderCoinHistory(coinHistory);
 }
 
 function closePlayerMenu() {


### PR DESCRIPTION
### Motivation
- Applying a referral updated the player menu and coin history but left global wallet/header and Home-visible stats stale.
- The change ensures referral success refreshes both menu UI and global player stats so wallet balance and Home remain correct.

### Description
- Added `refreshPlayerStats()` in `js/api.js` to run `loadAndDisplayLeaderboard()` and `updateWalletUI()` together and exported it for reuse.
- Updated `js/player-menu/controller.js` to import `refreshPlayerStats()` and on successful `applyReferralCode(code)` do an optimistic wallet update from backend response when available, then call `refreshPlayerStats()`, `refreshPlayerMenu()` (if open), and a new `refreshCoinHistory()` to update history.
- Added a `refreshCoinHistory()` helper in the player-menu controller that re-fetches and renders coin history when the menu is open.
- Kept existing validation/error flows (empty code, own code, already applied) and left the Apply button disabled after a successful apply (only re-enabled on error).

### Testing
- Ran unit/integration tests with `npm run test`, all tests passed.
- Ran static/syntax checks with `npm run check:syntax`, which passed along with project static-analysis checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd5e665008326899a751fd8010831)