### PR TITLE
Refresh global stats after share reward confirmation

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -136,7 +136,6 @@ async function refreshPlayerStats(options = {}) {
   });
 }
 
-async function refreshPlayerStats() { await Promise.allSettled([loadAndDisplayLeaderboard(), updateWalletUI()]); }
 
 /**
  * @param {string} message

--- a/js/share/shareFlow.js
+++ b/js/share/shareFlow.js
@@ -1,4 +1,4 @@
-import { fetchMyProfile, startShare, confirmShare, getXOAuthAuthorizeUrl } from '../api.js';
+import { fetchMyProfile, startShare, confirmShare, getXOAuthAuthorizeUrl, refreshPlayerStats } from '../api.js';
 import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';
 import { isTelegramMiniApp, getPrimaryAuthIdentifier, getSigningWalletAddress } from '../features/auth/index.js';
 import { logger } from '../logger.js';
@@ -199,7 +199,7 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
       }
 
       if (result.ok && result.data) {
-        const { awarded, goldAwarded, shareStreak } = result.data;
+        const { awarded, goldAwarded, shareStreak, totalGold } = result.data;
         if (awarded && goldAwarded > 0) {
           notifySuccess(`+${goldAwarded} 🪙 gold earned for sharing!`);
         } else if (eligibleForReward === false) {
@@ -207,8 +207,14 @@ async function performShare({ context = 'menu', profile = null, onProfileUpdated
         } else {
           notifySuccess('✅ Shared!');
         }
+
+        const shouldRefreshStats = (awarded === true && Number(goldAwarded) > 0) || Number.isFinite(Number(totalGold));
+        if (shouldRefreshStats) {
+          refreshPlayerStats().catch((e) => logger.warn('⚠️ refreshPlayerStats after share confirm failed:', e));
+        }
+
         if (typeof onProfileUpdated === 'function') {
-          onProfileUpdated({ shareStreak, totalGold: result.data.totalGold });
+          onProfileUpdated({ shareStreak, totalGold });
         }
         return { success: true, awarded, goldAwarded };
       }


### PR DESCRIPTION
### Motivation
- The visible coin balance and global player stats can remain stale after a share reward is confirmed asynchronously by the backend.  
- The share confirmation flow must refresh global stats without blocking the share intent flow or duplicating Player Menu updates.

### Description
- Imported `refreshPlayerStats` into `js/share/shareFlow.js` and call it after a successful `confirmShare` when either a reward was awarded (`awarded === true && goldAwarded > 0`) or the backend returned `totalGold` to keep UI consistent.  
- The stats refresh is fire-and-forget and wrapped with `.catch(...)` to handle refresh errors gracefully and avoid blocking the share flow or creating retry loops.  
- Kept the existing `onProfileUpdated({ shareStreak, totalGold })` callback so the Player Menu still refreshes via its current mechanism when open.  
- Removed a duplicate `refreshPlayerStats` declaration in `js/api.js` to fix a syntax error and ensure the import is valid.

### Testing
- Ran `npm run test` and all tests passed.  
- Ran `npm run check:syntax` and syntax checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd7eab2d08326861d5dd1ab1d7ffc)