### PR TITLE
Refresh player stats after successful leaderboard save

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -136,7 +136,6 @@ async function refreshPlayerStats(options = {}) {
   });
 }
 
-async function refreshPlayerStats() { await Promise.allSettled([loadAndDisplayLeaderboard(), updateWalletUI()]); }
 
 /**
  * @param {string} message
@@ -363,7 +362,7 @@ async function saveResultToLeaderboard(options = {}) {
       logger.info("✅ Result saved!");
       showBonusText("✅ In leaderboard!");
       await loadAndDisplayLeaderboard({ runToken });
-      await refreshPlayerStats();
+      await refreshPlayerStats({ source: 'saveResultToLeaderboard' });
       return { status: SAVE_RESULT_STATUS.SAVED, gameOverPrompt: savePrompt };
     }
     


### PR DESCRIPTION
### Motivation
- Ensure player UI (best score and coin balances) is refreshed only after a successful `/api/leaderboard/save` so Game Over and Home show current stats.
- Replace the previous direct wallet update call in the save success path with the centralized `refreshPlayerStats` flow to avoid stale UI and duplicate updates.

### Description
- After a successful leaderboard save the code now parses the response, updates the game-over prompt as before, calls `loadAndDisplayLeaderboard({ runToken })`, and then calls `refreshPlayerStats({ source: 'saveResultToLeaderboard' })`.
- Removed the legacy duplicate `refreshPlayerStats()` definition so the options-aware implementation is the single active implementation used by `updateWalletUI` and the save flow.
- Preserved existing `SAVE_RESULT_STATUS` return values, JSON parsing and prompt update logic, and the signature retry/fallback branches; the change only adjusts success-path refresh wiring.

### Testing
- Ran `npm run test` and all frontend automated tests passed (`90` tests, `0` failed).
- Ran `npm run check:syntax` and the syntax/static checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd80d1a10832688a8be91bec1091e)