### PR TITLE
Refresh player stats when returning to Home from menu/game over

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -115,15 +115,18 @@ function resetLeaderboardUI() {
 
 /* ===== WALLET UI ===== */
 
+let lastLeaderboardRefreshAt = 0;
+let refreshPlayerStatsInFlight = null;
+
 async function updateWalletUI() {
   return refreshPlayerStats({ refreshLeaderboard: false });
 }
 
-let lastLeaderboardRefreshAt = 0;
-
 async function refreshPlayerStats(options = {}) {
+  if (refreshPlayerStatsInFlight) return refreshPlayerStatsInFlight;
+
   const { refreshLeaderboard = false, leaderboardCooldownMs = 5000 } = options || {};
-  return runRefreshPlayerStats({
+  refreshPlayerStatsInFlight = runRefreshPlayerStats({
     hasWalletAuthSession,
     getPrimaryAuthIdentifier,
     resetWalletPlayerUI,
@@ -133,10 +136,12 @@ async function refreshPlayerStats(options = {}) {
     leaderboardCooldownMs,
     getLastLeaderboardRefreshAt: () => lastLeaderboardRefreshAt,
     setLastLeaderboardRefreshAt: (value) => { lastLeaderboardRefreshAt = value; }
+  }).finally(() => {
+    refreshPlayerStatsInFlight = null;
   });
-}
 
-async function refreshPlayerStats() { await Promise.allSettled([loadAndDisplayLeaderboard(), updateWalletUI()]); }
+  return refreshPlayerStatsInFlight;
+}
 
 /**
  * @param {string} message

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -59,6 +59,7 @@ function createGameSessionController({
   let runStartedAt = null;
   let currentRunIndex = 1;
   let latestGameOverSummary = null; let gameOverRunToken = 0;
+  let pendingGameOverSaveResultPromise = null;
   let startTransitionInProgress = false;
   function getLocalStorageSafe() {
     if (typeof window === 'undefined') return null;
@@ -72,9 +73,7 @@ function createGameSessionController({
     const storage = getLocalStorageSafe();
     const previous = normalizeRunIndex(storage?.getItem(RUN_INDEX_STORAGE_KEY) || 0);
     const next = previous + 1;
-    if (storage?.setItem) {
-      storage.setItem(RUN_INDEX_STORAGE_KEY, String(next));
-    }
+    if (storage?.setItem) storage.setItem(RUN_INDEX_STORAGE_KEY, String(next));
     return next;
   }
   function resetUiAfterRideFailure() {
@@ -375,7 +374,15 @@ function createGameSessionController({
       }
     }, 5000);
   }
+  function refreshPlayerStatsAfterLatestSave() {
+    const savePromise = pendingGameOverSaveResultPromise;
+    if (!savePromise) return;
+    savePromise.then(() => refreshPlayerStats({ refreshLeaderboard: true })).catch(() => {}).finally(() => {
+      if (pendingGameOverSaveResultPromise === savePromise) pendingGameOverSaveResultPromise = null;
+    });
+  }
   function restartFromGameOver() {
+    refreshPlayerStatsAfterLatestSave();
     endGameInProgress = false;
     audioManager.stopSFX('gameover_screen');
     stopGameOverCrashAnimation();
@@ -430,6 +437,7 @@ function createGameSessionController({
     try {
       if (isEligibleForLeaderboardFlow()) {
         saveResultPromise = saveResultToLeaderboard({ runToken });
+        pendingGameOverSaveResultPromise = saveResultPromise;
       } else if (isUnauthRuntimeMode()) {
         logger.info('⚪ Unauth runtime mode — skipping leaderboard participant flow');
       }
@@ -554,6 +562,7 @@ function createGameSessionController({
     audioManager.stopAll();
     stopMenuLaunchAnimation();
     showMainMenuScreen();
+    refreshPlayerStatsAfterLatestSave();
     gameState.running = false;
     gameState.simulationRunning = false;
     gameState.preparingGameplay = false;
@@ -574,15 +583,8 @@ function createGameSessionController({
     gameState.spinCooldown = 0;
     resetGameSessionState();
     audioManager.playMusic('menu');
-    if (runStartedAt) {
-      trackAnalyticsEvent('session_length', {
-        seconds: Number(((Date.now() - runStartedAt) / 1000).toFixed(2))
-      });
-      runStartedAt = null;
-    }
-    if (hasWalletAuthSession() || isUnauthRuntimeMode()) {
-      loadPlayerRides().then(() => updateRidesDisplay());
-    }
+    if (runStartedAt) { trackAnalyticsEvent('session_length', { seconds: Number(((Date.now() - runStartedAt) / 1000).toFixed(2)) }); runStartedAt = null; }
+    if (hasWalletAuthSession() || isUnauthRuntimeMode()) loadPlayerRides().then(() => updateRidesDisplay());
     logger.info('✅ State reset');
   }
   return {

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -522,6 +522,7 @@ async function refreshCoinHistory() {
 function closePlayerMenu() {
   menuOpen = false;
   hidePlayerMenuScreen();
+  refreshPlayerStats().catch(() => {});
 }
 
 async function refreshPlayerMenu() {


### PR DESCRIPTION
### Motivation
- Players reported stale wallet/score after closing Player Menu or returning from Game Over to Home, so Home header needs an immediate refresh on those transitions.
- Avoid hammering the backend when multiple navigation events fire in quick succession by deduplicating concurrent refreshes.
- Ensure navigation/UI remain responsive even if network requests fail or user is unauthenticated.

### Description
- Added an in-flight guard to `refreshPlayerStats()` so concurrent callers reuse the same promise and only a single network request runs (`js/api.js`).
- Moved `updateWalletUI()` to call the guarded `refreshPlayerStats({ refreshLeaderboard: false })` to keep behavior identical while using the guard (`js/api.js`).
- Made `closePlayerMenu()` hide the menu immediately and then trigger a non-blocking `refreshPlayerStats()` so closing the menu never blocks on network errors (`js/player-menu/controller.js`).
- Tracked the latest Game Over save promise and added `refreshPlayerStatsAfterLatestSave()` which waits for the save to complete and triggers a leaderboard-aware refresh; this helper is invoked on restart and on returning to Home so stats are up-to-date without delaying navigation (`js/game/session.js`).
- Preserved unauthenticated runtime behavior and swallowed refresh errors to keep navigation responsive on failures.

### Testing
- Ran `npm run test` (unit suite): all tests passed (90 passed, 0 failed).
- Ran `npm run check:syntax`: syntax and static-analysis checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd8a695748326b3ef1fb4aa9c30eb)