### PR TITLE
Fix obstacle z-order so passed obstacles render above player

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -268,6 +268,7 @@ class EntityRenderer {
     this.root = null;
     this.objectLayer = null;
     this.playerLayer = null;
+    this.foregroundObjectLayer = null;
     this.targetLayer = null;
     this.coinSprites = []; this.coinShadowSprites = [];
     this.bonusSprites = []; this.bonusShadowSprites = [];
@@ -292,8 +293,9 @@ class EntityRenderer {
     this.root = this.scene.add.container(0, 0).setDepth(14);
     this.objectLayer = this.scene.add.container(0, 0).setDepth(14);
     this.playerLayer = this.scene.add.container(0, 0).setDepth(15);
-    this.targetLayer = this.scene.add.container(0, 0).setDepth(16);
-    this.root.add([this.objectLayer, this.playerLayer, this.targetLayer]);
+    this.foregroundObjectLayer = this.scene.add.container(0, 0).setDepth(16);
+    this.targetLayer = this.scene.add.container(0, 0).setDepth(17);
+    this.root.add([this.objectLayer, this.playerLayer, this.foregroundObjectLayer, this.targetLayer]);
     this.playerShadow = this.scene.textures.exists('shadow_contact_ellipse_01')
       ? this.scene.add.image(0, 0, 'shadow_contact_ellipse_01').setAlpha(0.34)
       : this.scene.add.ellipse(0, 0, 82, 28, 0x000000, 0.34);
@@ -345,6 +347,8 @@ class EntityRenderer {
     this.collectEffectSprites.forEach((sprite) => sprite.destroy());
     this.collectEffectSprites.clear();
     this.collectEffectSeenIds.clear();
+    this.foregroundObjectLayer?.destroy();
+    this.foregroundObjectLayer = null;
     this.root?.destroy();
     this.root = null;
   }

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -283,6 +283,9 @@ function renderObjectsPass(renderer, deps) {
       const obstacleGrowthStartZ = 1.0;
       const obstacleNearZ = deps.CONFIG.PLAYER_Z;
       const hasPassedPlayer = item.z < obstacleNearZ;
+      const obstacleLayer = hasPassedPlayer && renderer.foregroundObjectLayer
+        ? renderer.foregroundObjectLayer
+        : renderer.objectLayer;
       const isApproachingPlayer = item.z <= obstacleGrowthStartZ && item.z >= obstacleNearZ;
       const tuning = getObstacleReadabilityTuning({
         z: item.z,
@@ -305,7 +308,7 @@ function renderObjectsPass(renderer, deps) {
         .setDisplaySize(size * 0.92, size * 0.28)
         .setAlpha(obstacleShadowAlpha)
         .setVisible(true);
-      renderer.objectLayer.add(shadow);
+      obstacleLayer.add(shadow);
       sprite.setTexture(textureKey, frameMap[item.subtype] || 0);
       sprite.setPosition(projection.x, projection.y);
       sprite.setDisplaySize(size, size);
@@ -319,7 +322,7 @@ function renderObjectsPass(renderer, deps) {
         sprite.clearTint();
       }
       sprite.setVisible(true);
-      renderer.objectLayer.add(sprite);
+      obstacleLayer.add(sprite);
     } else if (entry.kind === 'bonus') {
       const sprite = renderer.bonusSprites[bonusIndex++];
       const shadow = renderer.bonusShadowSprites[bonusShadowIndex++];


### PR DESCRIPTION
### Motivation
- Player was always rendered in a separate `playerLayer` above `objectLayer`, causing obstacles that have been passed (lower `z`) to remain drawn under the player instead of in front. 
- The intent is to separate obstacles that should appear in front of the player into their own foreground layer so z-order matches `item.z` relative to `CONFIG.PLAYER_Z` without any asset or quality changes.

### Description
- Added a new `foregroundObjectLayer` property to `EntityRenderer` and initialized it in the constructor as `this.foregroundObjectLayer = null`.
- Created `foregroundObjectLayer` in `create()` and adjusted depths/order to `objectLayer: 14`, `playerLayer: 15`, `foregroundObjectLayer: 16`, and `targetLayer: 17`, and added them to `root` in that order. 
- Cleaned up lifecycle by destroying and nulling `foregroundObjectLayer` in `destroy()`.
- Updated `renderObjectsPass` to route obstacle `shadow` and `sprite` into `renderer.foregroundObjectLayer` when `item.z < CONFIG.PLAYER_Z`, otherwise keep them in `renderer.objectLayer`; bonuses and coins remain unchanged in `objectLayer`.

### Testing
- Pre-commit automated checks run during commit succeeded, including `check:syntax` (syntax checks) and `check:static-analysis` (static analysis guardrails). 
- Verified the changed files are `js/phaser/entities/EntityRenderer.js` and `js/phaser/entities/entity-render-passes.js` and that only obstacle routing/layering logic was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde0f5d98083269b2c3986797c1a7a)