### PR TITLE
Adjust tunnel visuals: disable mouth ring & bonus aura, enhance periodic stripes

### DIFF
--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -224,7 +224,6 @@ function renderObjectsPass(renderer, deps) {
   const obstacleCount = objectEntries.filter((entry) => entry.kind === 'obstacle').length;
   const bonusCount = objectEntries.filter((entry) => entry.kind === 'bonus').length;
   const coinCount = objectEntries.filter((entry) => entry.kind === 'coin').length;
-  const hasBonusAuraTexture = renderer.scene.textures.exists('bonus_aura_soft_01');
   const hasCoinGlintTexture = renderer.scene.textures.exists('coin_glint_star_01');
   const hasShadowTexture = renderer.scene.textures.exists('shadow_contact_ellipse_01');
   renderer.ensurePoolSize(renderer.obstacleSprites, obstacleCount, () => renderer.scene.add.sprite(0, 0, 'obstacles_1', 0));
@@ -245,11 +244,6 @@ function renderObjectsPass(renderer, deps) {
       ? renderer.scene.add.image(0, 0, 'shadow_contact_ellipse_01')
       : renderer.scene.add.ellipse(0, 0, 34, 10, 0x000000, 0.16)
   ));
-  renderer.ensurePoolSize(renderer.bonusAuraSprites, bonusCount, () => (
-    hasBonusAuraTexture
-      ? renderer.scene.add.sprite(0, 0, 'bonus_aura_soft_01')
-      : renderer.scene.add.circle(0, 0, 12, 0x8cefff, 0.35)
-  ));
   renderer.ensurePoolSize(renderer.coinGlintSprites, coinCount, () => (
     hasCoinGlintTexture
       ? renderer.scene.add.sprite(0, 0, 'coin_glint_star_01')
@@ -262,7 +256,6 @@ function renderObjectsPass(renderer, deps) {
   let bonusShadowIndex = 0;
   let coinIndex = 0;
   let coinShadowIndex = 0;
-  let bonusAuraIndex = 0;
   let coinGlintIndex = 0;
 
   for (const entry of objectEntries) {
@@ -338,19 +331,6 @@ function renderObjectsPass(renderer, deps) {
       sprite.setAlpha(0.95 * curveOcclusion);
       sprite.setVisible(true);
       renderer.objectLayer.add(sprite);
-      const aura = renderer.bonusAuraSprites[bonusAuraIndex++];
-      const auraAlpha = 0.26 + 0.12 * Math.sin(renderer.scene.time.now * 0.01 + item.z * 10);
-      aura.setPosition(projection.x, projection.y);
-      if (aura.type === 'Arc') {
-        aura.setRadius(size * 0.72);
-        aura.setFillStyle(0xffb55c, Math.max(0.1, auraAlpha * 0.58));
-      } else {
-        aura.setDisplaySize(size * 1.56, size * 1.56);
-        aura.setBlendMode(0);
-      }
-      aura.setAlpha(auraAlpha * curveOcclusion);
-      aura.setVisible(true);
-      renderer.objectLayer.add(aura);
     } else {
       const sprite = renderer.coinSprites[coinIndex++];
       const shadow = renderer.coinShadowSprites[coinShadowIndex++];
@@ -402,9 +382,6 @@ function renderObjectsPass(renderer, deps) {
   }
   for (let index = coinShadowIndex; index < renderer.coinShadowSprites.length; index += 1) {
     renderer.coinShadowSprites[index].setVisible(false);
-  }
-  for (let index = bonusAuraIndex; index < renderer.bonusAuraSprites.length; index += 1) {
-    renderer.bonusAuraSprites[index].setVisible(false);
   }
   for (let index = coinGlintIndex; index < renderer.coinGlintSprites.length; index += 1) {
     renderer.coinGlintSprites[index].setVisible(false);

--- a/js/phaser/tunnel/TunnelRenderer.js
+++ b/js/phaser/tunnel/TunnelRenderer.js
@@ -101,7 +101,6 @@ const GRID_FADE_OUT_MS = 3000;
 const GRID_DIM_HOLD_MS = 2000;
 const GRID_FADE_IN_MS = 3000;
 const SPAWNED_RING_ALPHA_MULTIPLIER = 0.14;
-const MOUTH_RING_ALPHA_MULTIPLIER = 0.4;
 const WAVE_BASE_ALPHA_CAP = 0.26;
 const WAVE_ALPHA_MULTIPLIER = 0.5;
 const WAVE_CORE_BAND_ALPHA_FACTOR = 0.72;
@@ -430,48 +429,8 @@ class TunnelRenderer {
     return this.smoothedTube;
   }
 
-  drawMouthRing(centerX, centerY, tube) {
-    const isTelegramClient = Boolean(
-      document?.body?.classList?.contains('is-telegram')
-      || document?.body?.classList?.contains('telegram-mini-app')
-    );
-    if (isTelegramClient) {
-      return;
-    }
-
-    const rimColor = 0xaedcff;
-    const outerRadius = CONFIG.TUBE_RADIUS * 1.2;
-    const innerRadius = CONFIG.TUBE_RADIUS * 1.24;
-    const borderScale = clamp(CONFIG.TUBE_RADIUS / 278, 0.75, 1.1);
-    const rimLift = Math.max(0, (278 - CONFIG.TUBE_RADIUS) * 0.25);
-    const mobileTubeDropPx = CONFIG.TUBE_RADIUS <= 230 ? 6 : 0;
-    const ringCenterY = centerY - rimLift - mobileTubeDropPx;
-    const centerShift = Math.hypot(tube.centerOffsetX || 0, tube.centerOffsetY || 0);
-    const shiftBoost = clamp(centerShift / 120, 0, 0.22);
-
-    this.lightGraphics.lineStyle(Math.max(2, 8 * borderScale), blendColor(0x1e2635, rimColor, 0.6), MOUTH_RING_ALPHA_MULTIPLIER);
-    this.lightGraphics.strokeEllipse(
-      centerX,
-      ringCenterY,
-      outerRadius * 2,
-      outerRadius * 2 * CONFIG.PLAYER_OFFSET,
-    );
-
-    this.lightGraphics.lineStyle(Math.max(1.5, 6 * borderScale), blendColor(rimColor, 0xffffff, 0.35), amplifiedAlpha((0.72 + shiftBoost) * MOUTH_RING_ALPHA_MULTIPLIER, 1));
-    this.lightGraphics.strokeEllipse(
-      centerX,
-      ringCenterY,
-      innerRadius * 2,
-      innerRadius * 2 * CONFIG.PLAYER_OFFSET,
-    );
-
-    this.lightGraphics.lineStyle(Math.max(1, 3 * borderScale), blendColor(rimColor, 0xffffff, 0.65), amplifiedAlpha((0.42 + shiftBoost) * MOUTH_RING_ALPHA_MULTIPLIER, 1));
-    this.lightGraphics.strokeEllipse(
-      centerX,
-      ringCenterY,
-      innerRadius * 1.96,
-      innerRadius * 1.96 * CONFIG.PLAYER_OFFSET,
-    );
+  drawMouthRing() {
+    // Intentionally disabled: front mouth ring effect removed for both web and telegram.
   }
 
   drawTunnel() {

--- a/js/phaser/tunnel/tunnel-periodic-stripes-pass.js
+++ b/js/phaser/tunnel/tunnel-periodic-stripes-pass.js
@@ -89,8 +89,9 @@ function buildPeriodicStripeOverlaysPass(renderer, deps, renderTube, frame, curv
       const chunkBlend = deps.clamp((chunkNoise - 0.35) / 0.65, 0, 1);
       if (chunkBlend <= 0.01) continue;
 
-      const x1 = centerX + Math.sin(boundaryA) * radius1 + curveOffsetX1 + centerOffsetX * bend1;
-      const y1 = centerY + Math.cos(boundaryA) * radius1 * deps.CONFIG.PLAYER_OFFSET + curveOffsetY1 + centerOffsetY * bend1;
+      const extensionForward = Math.max(6, deps.CONFIG.TUBE_RADIUS * 0.09);
+      const x1 = centerX + Math.sin(boundaryA) * (radius1 + extensionForward) + curveOffsetX1 + centerOffsetX * bend1;
+      const y1 = centerY + Math.cos(boundaryA) * (radius1 + extensionForward) * deps.CONFIG.PLAYER_OFFSET + curveOffsetY1 + centerOffsetY * bend1;
       const x4 = centerX + Math.sin(boundaryA) * radius2 + curveOffsetX2 + centerOffsetX * bend2;
       const y4 = centerY + Math.cos(boundaryA) * radius2 * deps.CONFIG.PLAYER_OFFSET + curveOffsetY2 + centerOffsetY * bend2;
 
@@ -118,7 +119,7 @@ function renderPeriodicStripeLayerPass(renderer, deps, periodicStripeOverlays, s
     const pulse = 0.7 + 0.3 * Math.sin((stripe.depthRatio + speedPulse * 0.2) * 13.2);
     const stripeColor = deps.PERIODIC_STRIPE_COLORS[stripe.colorIndex];
     const stripeAlpha = deps.amplifiedAlpha(deps.clamp(
-      (deps.PERIODIC_STRIPE_BASE_ALPHA + stripe.depthRatio * 0.08) *
+      (deps.PERIODIC_STRIPE_BASE_ALPHA + stripe.depthRatio * 0.14) *
         stripe.spawnBlend *
         stripe.wallCoverage *
         stripe.angleRail *
@@ -128,17 +129,17 @@ function renderPeriodicStripeLayerPass(renderer, deps, periodicStripeOverlays, s
       deps.PERIODIC_STRIPE_MAX_ALPHA,
     ), 1);
     if (stripeAlpha <= 0.003) continue;
-    const glowAlpha = Math.min(0.66, stripeAlpha * (0.74 + pulse * 0.28));
-    renderer.stripeGraphics.lineStyle(deps.PERIODIC_STRIPE_RAY_GLOW_LINE_WIDTH, stripeColor, glowAlpha);
+    const glowAlpha = Math.min(0.9, stripeAlpha * (0.88 + pulse * 0.34));
+    renderer.stripeGraphics.lineStyle(deps.PERIODIC_STRIPE_RAY_GLOW_LINE_WIDTH * 1.42, stripeColor, glowAlpha);
     renderer.stripeGraphics.beginPath();
     renderer.stripeGraphics.moveTo(stripe.x1, stripe.y1);
     renderer.stripeGraphics.lineTo(stripe.x4, stripe.y4);
     renderer.stripeGraphics.strokePath();
 
     renderer.stripeGraphics.lineStyle(
-      deps.PERIODIC_STRIPE_RAY_LINE_WIDTH,
+      deps.PERIODIC_STRIPE_RAY_LINE_WIDTH * 1.32,
       stripeColor,
-      Math.min(1, stripeAlpha * (0.98 + pulse * 0.22)),
+      Math.min(1, stripeAlpha * (1.06 + pulse * 0.28)),
     );
     renderer.stripeGraphics.beginPath();
     renderer.stripeGraphics.moveTo(stripe.x1, stripe.y1);


### PR DESCRIPTION
### Motivation
- Remove the front mouth ring effect because it is not needed for web or Telegram and causes visual overlap. 
- Make periodic orange wall stripes more visible and volumetric while allowing them to protrude forward past the rim. 
- Remove the (invisible) bonus aura to reduce unnecessary VFX work.

### Description
- Disabled the mouth ring rendering by replacing `drawMouthRing` with an intentionally empty method and removing the mouth-ring alpha constant in `js/phaser/tunnel/TunnelRenderer.js`.
- Enhanced periodic stripe visuals in `js/phaser/tunnel/tunnel-periodic-stripes-pass.js` by adding a forward `extensionForward` to stripe start coordinates, increasing depth alpha contribution, raising glow intensity and cap, and widening glow and core line widths to make stripes brighter and more volumetric.
- Removed bonus aura allocation and per-bonus aura rendering from `js/phaser/entities/entity-render-passes.js` by deleting the aura texture check, pool creation, `bonusAuraIndex`, and the aura draw/update block so bonus auras are no longer created or rendered.

### Testing
- Ran `npm run build` successfully to validate the bundle and ensure no syntax/static errors.
- Pre-commit automated checks ran and passed (`check:syntax` and `check:static-analysis`).
- The modified files were committed with the message `Adjust tunnel visuals: remove ring/aura and boost periodic stripes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fded61be688326aba563a47ea84e33)