### PR TITLE
Use new 6-frame obstacle assets and distance-based scaling

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -37,18 +37,8 @@ const BONUS_TEXTURES = {
   [BONUS_TYPES.SCORE_MINUS_500]: 'bonus_score_minus',
   [BONUS_TYPES.RECHARGE]: 'bonus_recharge',
 };
-const OBSTACLE_TEXTURES = {
-  fence: 'obstacles_1',
-  rock1: 'obstacles_1',
-  rock2: 'obstacles_1',
-  bull: 'obstacles_1',
-  wall_brick: 'obstacles_2',
-  wall_kactus: 'obstacles_2',
-  tree: 'obstacles_2',
-  pit: 'obstacles_3',
-  spikes: 'obstacles_3',
-  bottles: 'obstacles_3',
-};
+const OBSTACLE_TEXTURES = { fence: 'obstacle_fence', rock1: 'obstacle_rock', rock2: 'obstacle_rock', bull: 'obstacle_bull', wall_brick: 'obstacle_bricks', wall_kactus: 'obstacle_cactus', tree: 'obstacle_tree', pit: 'obstacle_pit', spikes: 'obstacle_hole', bottles: 'obstacle_bottles' };
+const OBSTACLE_ANIM_FRAMES = 6;
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
 const WIDE_BONUS_TEXTURES = new Set(['bonus_score_plus', 'bonus_score_minus']);
@@ -249,7 +239,7 @@ class EntityRenderer {
         frameHeight: PLAYER_FRAME_SIZE,
       });
     });
-    ['coins_gold', 'coins_silver', ...Object.values(BONUS_TEXTURES), ...Object.values(OBSTACLE_TEXTURES)].forEach((key) => {
+    ['coins_gold', 'coins_silver', ...Object.values(BONUS_TEXTURES)].forEach((key) => {
       if (WIDE_BONUS_TEXTURES.has(key)) {
         scene.load.image(key, assetUrl(`assets/${key}.png`));
         return;
@@ -258,6 +248,11 @@ class EntityRenderer {
         frameWidth: FRAME_SIZE,
         frameHeight: FRAME_SIZE,
       });
+    });
+    const uniqueObstacleTextures = [...new Set(Object.values(OBSTACLE_TEXTURES))];
+    uniqueObstacleTextures.forEach((key) => {
+      const obstacleFolder = key.replace('obstacle_', '');
+      for (let frameIndex = 1; frameIndex <= OBSTACLE_ANIM_FRAMES; frameIndex += 1) scene.load.image(`${key}_${frameIndex - 1}`, assetUrl(`assets/obstacles/${obstacleFolder}/${obstacleFolder}_${frameIndex}.webp`));
     });
     // Visual upgrade textures are generated procedurally at runtime in
     // ensureVisualUpgradeTextures(), so no static asset preload is required.

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -271,8 +271,7 @@ function renderObjectsPass(renderer, deps) {
     if (entry.kind === 'obstacle') {
       const sprite = renderer.obstacleSprites[obstacleIndex++];
       const shadow = renderer.obstacleShadowSprites[obstacleShadowIndex++];
-      const textureKey = deps.OBSTACLE_TEXTURES[item.subtype] || 'obstacles_1';
-      const frameMap = { fence: 0, rock1: 1, rock2: 2, bull: 3, wall_brick: 0, wall_kactus: 1, tree: 2, pit: 0, spikes: 1, bottles: 2 };
+      const textureKey = deps.OBSTACLE_TEXTURES[item.subtype] || 'obstacle_fence';
       const obstacleGrowthStartZ = 1.0;
       const obstacleNearZ = deps.CONFIG.PLAYER_Z;
       const hasPassedPlayer = item.z < obstacleNearZ;
@@ -291,7 +290,15 @@ function renderObjectsPass(renderer, deps) {
       const growth = hasPassedPlayer
         ? 2.5
         : 1 + (isApproachingPlayer ? 1.5 * tuning.approachT : 0);
-      const size = Math.max(36, deps.FRAME_SIZE * projection.scale)
+      const scaleToPlayer = deps.clamp(
+        (obstacleGrowthStartZ - item.z) / Math.max(0.0001, obstacleGrowthStartZ - obstacleNearZ),
+        0,
+        1,
+      );
+      const minObstacleSize = 40;
+      const maxObstacleSize = 128;
+      const interpolatedSize = minObstacleSize + (maxObstacleSize - minObstacleSize) * scaleToPlayer;
+      const size = interpolatedSize
         * growth
         * tuning.readabilityBoost
         * (radarPreviewActive ? 1.12 : 1);
@@ -302,7 +309,8 @@ function renderObjectsPass(renderer, deps) {
         .setAlpha(obstacleShadowAlpha)
         .setVisible(true);
       obstacleLayer.add(shadow);
-      sprite.setTexture(textureKey, frameMap[item.subtype] || 0);
+      const obstacleFrame = (Number(item.animFrame) || 0) % 6;
+      sprite.setTexture(`${textureKey}_${obstacleFrame}`);
       sprite.setPosition(projection.x, projection.y);
       sprite.setDisplaySize(size, size);
       const radarAlpha = radarPreviewActive ? (0.84 + 0.16 * radarPulse) : 1;


### PR DESCRIPTION
### Motivation
- Replace legacy obstacle atlases with the new per-obstacle folders (6 frames each) placed under `public/assets/obstacles/*` to support richer obstacle animations. 
- Animate obstacles with the supplied 6 frames and make distant obstacles downscaled while they grow to a readable size when approaching the player. 
- Preserve existing readability/radar tinting and occlusion logic while switching to the new assets.

### Description
- Updated obstacle texture mapping and constants in `js/phaser/entities/EntityRenderer.js` to use new keys like `obstacle_<type>` and added `OBSTACLE_ANIM_FRAMES = 6`. 
- Replaced atlas preload with per-frame preload of `assets/obstacles/<type>/<type>_N.webp` images (keys `obstacle_<type>_0..5`) during Phaser preload. 
- Changed obstacle rendering in `js/phaser/entities/entity-render-passes.js` to pick a frame using `animFrame % 6`, and to compute obstacle display size by interpolating from a small start size up to `128` px based on obstacle depth (`z`). 
- Kept radar/readability tinting and projection checks intact and added a conservative fallback texture key for safety.

### Testing
- Ran `npm run check:syntax` which completed successfully. 
- Ran `npm run check:static-analysis` which completed successfully. 
- Project pre-commit checks (syntax + static analysis) were executed and passed as part of the change validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3748c5c48326b6e29e6952b82ada)