### PR TITLE
Use per-obstacle textures and animated frames with improved obstacle scaling

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -37,18 +37,8 @@ const BONUS_TEXTURES = {
   [BONUS_TYPES.SCORE_MINUS_500]: 'bonus_score_minus',
   [BONUS_TYPES.RECHARGE]: 'bonus_recharge',
 };
-const OBSTACLE_TEXTURES = {
-  fence: 'obstacles_1',
-  rock1: 'obstacles_1',
-  rock2: 'obstacles_1',
-  bull: 'obstacles_1',
-  wall_brick: 'obstacles_2',
-  wall_kactus: 'obstacles_2',
-  tree: 'obstacles_2',
-  pit: 'obstacles_3',
-  spikes: 'obstacles_3',
-  bottles: 'obstacles_3',
-};
+const OBSTACLE_TEXTURES = { fence: 'obstacle_fence', rock1: 'obstacle_rock', rock2: 'obstacle_rock', bull: 'obstacle_bull', wall_brick: 'obstacle_bricks', wall_kactus: 'obstacle_cactus', tree: 'obstacle_tree', pit: 'obstacle_pit', spikes: 'obstacle_hole', bottles: 'obstacle_bottles' };
+const OBSTACLE_ANIM_FRAMES = 6;
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
 const WIDE_BONUS_TEXTURES = new Set(['bonus_score_plus', 'bonus_score_minus']);
@@ -249,7 +239,7 @@ class EntityRenderer {
         frameHeight: PLAYER_FRAME_SIZE,
       });
     });
-    ['coins_gold', 'coins_silver', ...Object.values(BONUS_TEXTURES), ...Object.values(OBSTACLE_TEXTURES)].forEach((key) => {
+    ['coins_gold', 'coins_silver', ...Object.values(BONUS_TEXTURES)].forEach((key) => {
       if (WIDE_BONUS_TEXTURES.has(key)) {
         scene.load.image(key, assetUrl(`assets/${key}.png`));
         return;
@@ -258,6 +248,11 @@ class EntityRenderer {
         frameWidth: FRAME_SIZE,
         frameHeight: FRAME_SIZE,
       });
+    });
+    const uniqueObstacleTextures = [...new Set(Object.values(OBSTACLE_TEXTURES))];
+    uniqueObstacleTextures.forEach((key) => {
+      const obstacleFolder = key.replace('obstacle_', '');
+      for (let frameIndex = 1; frameIndex <= OBSTACLE_ANIM_FRAMES; frameIndex += 1) scene.load.image(`${key}_${frameIndex - 1}`, assetUrl(`assets/obstacles/${obstacleFolder}/${obstacleFolder}_${frameIndex}.webp`));
     });
     // Visual upgrade textures are generated procedurally at runtime in
     // ensureVisualUpgradeTextures(), so no static asset preload is required.

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -271,8 +271,7 @@ function renderObjectsPass(renderer, deps) {
     if (entry.kind === 'obstacle') {
       const sprite = renderer.obstacleSprites[obstacleIndex++];
       const shadow = renderer.obstacleShadowSprites[obstacleShadowIndex++];
-      const textureKey = deps.OBSTACLE_TEXTURES[item.subtype] || 'obstacles_1';
-      const frameMap = { fence: 0, rock1: 1, rock2: 2, bull: 3, wall_brick: 0, wall_kactus: 1, tree: 2, pit: 0, spikes: 1, bottles: 2 };
+      const textureKey = deps.OBSTACLE_TEXTURES[item.subtype] || 'obstacle_fence';
       const obstacleGrowthStartZ = 1.0;
       const obstacleNearZ = deps.CONFIG.PLAYER_Z;
       const hasPassedPlayer = item.z < obstacleNearZ;
@@ -291,7 +290,15 @@ function renderObjectsPass(renderer, deps) {
       const growth = hasPassedPlayer
         ? 2.5
         : 1 + (isApproachingPlayer ? 1.5 * tuning.approachT : 0);
-      const size = Math.max(36, deps.FRAME_SIZE * projection.scale)
+      const scaleToPlayer = deps.clamp(
+        (obstacleGrowthStartZ - item.z) / Math.max(0.0001, obstacleGrowthStartZ - obstacleNearZ),
+        0,
+        1,
+      );
+      const minObstacleSize = 32;
+      const maxObstacleSize = 70;
+      const interpolatedSize = minObstacleSize + (maxObstacleSize - minObstacleSize) * scaleToPlayer;
+      const size = interpolatedSize
         * growth
         * tuning.readabilityBoost
         * (radarPreviewActive ? 1.12 : 1);
@@ -302,7 +309,8 @@ function renderObjectsPass(renderer, deps) {
         .setAlpha(obstacleShadowAlpha)
         .setVisible(true);
       obstacleLayer.add(shadow);
-      sprite.setTexture(textureKey, frameMap[item.subtype] || 0);
+      const obstacleFrame = (Number(item.animFrame) || 0) % 6;
+      sprite.setTexture(`${textureKey}_${obstacleFrame}`);
       sprite.setPosition(projection.x, projection.y);
       sprite.setDisplaySize(size, size);
       const radarAlpha = radarPreviewActive ? (0.84 + 0.16 * radarPulse) : 1;


### PR DESCRIPTION
### Motivation

- Replace legacy grouped obstacle sprite sheets with per-obstacle image sequences to allow distinct artwork and per-frame animation. 
- Improve visual readability and sizing of obstacles as they approach the player by using an interpolated size instead of a fixed floor.

### Description

- Replaced `OBSTACLE_TEXTURES` mapping to reference new per-obstacle texture keys like `obstacle_fence`, `obstacle_rock`, etc., and added `OBSTACLE_ANIM_FRAMES` constant.
- Modified `EntityRenderer.preload` to stop loading obstacles as a single spritesheet and instead load per-frame images from `assets/obstacles/<obstacleFolder>/<obstacleFolder>_<n>.webp` using names like `<textureKey>_<frameIndex>`.
- Updated rendering logic in `renderObjectsPass` to select obstacle frames via `item.animFrame % 6` and call `setTexture` with the generated frame key (e.g. ```${textureKey}_${obstacleFrame}```) instead of using the old `frameMap` approach.
- Reworked obstacle sizing: compute `scaleToPlayer` and interpolate between `minObstacleSize` and `maxObstacleSize`, clamp the value, and apply growth/readability/radar multipliers for smoother size transitions.

### Testing

- Ran linting via `npm run lint` and unit tests via `npm test`, and they completed without failures.
- Performed an automated render smoke check to ensure obstacle frames load and display with the new texture keys and sizing logic, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3748c5c48326b6e29e6952b82ada)