### PR TITLE
feat: switch bonus rendering to animated bonus atlas

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -25,39 +25,24 @@ const PLAYER_FRAME_COUNTS = {
   [PLAYER_TEXTURES.spin]: 14,
 };
 const BONUS_TEXTURES = {
-  [BONUS_TYPES.SHIELD]: 'bonus_shield',
-  [BONUS_TYPES.SPEED_DOWN]: 'bonus_speed',
-  [BONUS_TYPES.SPEED_UP]: 'bonus_speed',
-  [BONUS_TYPES.MAGNET]: 'bonus_magnet',
-  [BONUS_TYPES.INVERT]: 'bonus_invert',
-  [BONUS_TYPES.SCORE_300]: 'bonus_score_plus',
-  [BONUS_TYPES.SCORE_500]: 'bonus_score_plus',
-  [BONUS_TYPES.X2]: 'bonus_score_plus',
-  [BONUS_TYPES.SCORE_MINUS_300]: 'bonus_score_minus',
-  [BONUS_TYPES.SCORE_MINUS_500]: 'bonus_score_minus',
-  [BONUS_TYPES.RECHARGE]: 'bonus_recharge',
+  [BONUS_TYPES.SHIELD]: 'shield',
+  [BONUS_TYPES.SPEED_DOWN]: 'speed_down',
+  [BONUS_TYPES.SPEED_UP]: 'speed_up',
+  [BONUS_TYPES.MAGNET]: 'magnet',
+  [BONUS_TYPES.INVERT]: 'invert_controls',
+  [BONUS_TYPES.SCORE_300]: 'score_300',
+  [BONUS_TYPES.SCORE_500]: 'score_500',
+  [BONUS_TYPES.X2]: 'x2',
+  [BONUS_TYPES.SCORE_MINUS_300]: 'anti_score_300',
+  [BONUS_TYPES.SCORE_MINUS_500]: 'anti_score_500',
+  [BONUS_TYPES.RECHARGE]: 'battery',
 };
 const OBSTACLE_TEXTURES = { fence: 'fence', rock1: 'rock', rock2: 'rock', bull: 'bull', wall_brick: 'bricks', wall_kactus: 'cactus', tree: 'tree', pit: 'hole', spikes: 'spikes', bottles: 'bottles' };
 const OBSTACLE_ANIM_FRAMES = 6;
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
-const WIDE_BONUS_TEXTURES = new Set(['bonus_score_plus', 'bonus_score_minus']);
-const BONUS_FRAME_DEFS = {
-  bonus_score_plus: [
-    { name: 'score_300_0', x: 0, y: 0, width: 128, height: 64 },
-    { name: 'score_300_1', x: 128, y: 0, width: 64, height: 64 },
-    { name: 'score_500_0', x: 192, y: 0, width: 128, height: 64 },
-    { name: 'score_500_1', x: 320, y: 0, width: 64, height: 64 },
-    { name: 'x2_0', x: 384, y: 0, width: 128, height: 64 },
-    { name: 'x2_1', x: 512, y: 0, width: 64, height: 64 },
-  ],
-  bonus_score_minus: [
-    { name: 'score_minus_300_0', x: 0, y: 0, width: 128, height: 64 },
-    { name: 'score_minus_300_1', x: 128, y: 0, width: 64, height: 64 },
-    { name: 'score_minus_500_0', x: 192, y: 0, width: 128, height: 64 },
-    { name: 'score_minus_500_1', x: 320, y: 0, width: 64, height: 64 },
-  ],
-};
+const BONUS_ATLAS_KEY = 'bonus_atlas';
+const BONUS_ANIM_FRAMES = 6;
 function assetUrl(path) {
   const normalizedBase = BASE_URL.endsWith('/') ? BASE_URL : `${BASE_URL}/`;
   return `${normalizedBase}${path}`;
@@ -191,45 +176,9 @@ function projectPolar(angle, z, viewport, tube, radiusFactor = 0.65) {
   };
 }
 function getBonusFrame(item) {
-  const frame = item.animFrame || 0;
-  const toggle = Math.floor(frame / 4) % 2;
-  switch (item.type) {
-    case BONUS_TYPES.SHIELD:
-      return frame % 4;
-    case BONUS_TYPES.SPEED_DOWN:
-      return toggle;
-    case BONUS_TYPES.SPEED_UP:
-      return 2 + toggle;
-    case BONUS_TYPES.MAGNET:
-      return Math.floor(frame / 2) % 6;
-    case BONUS_TYPES.INVERT:
-      return toggle;
-    case BONUS_TYPES.SCORE_300:
-      return `score_300_${toggle}`;
-    case BONUS_TYPES.SCORE_500:
-      return `score_500_${toggle}`;
-    case BONUS_TYPES.X2:
-      return `x2_${toggle}`;
-    case BONUS_TYPES.SCORE_MINUS_300:
-      return `score_minus_300_${toggle}`;
-    case BONUS_TYPES.SCORE_MINUS_500:
-      return `score_minus_500_${toggle}`;
-    case BONUS_TYPES.RECHARGE:
-      return Math.floor(frame / 3) % 5;
-    default:
-      return 0;
-  }
-}
-function registerCustomBonusFrames(scene) {
-  Object.entries(BONUS_FRAME_DEFS).forEach(([textureKey, frames]) => {
-    const texture = scene.textures.get(textureKey);
-    if (!texture) return;
-    frames.forEach((frameDef) => {
-      if (!texture.has(frameDef.name)) {
-        texture.add(frameDef.name, 0, frameDef.x, frameDef.y, frameDef.width, frameDef.height);
-      }
-    });
-  });
+  const bonusPrefix = BONUS_TEXTURES[item.type] || BONUS_TEXTURES[BONUS_TYPES.SHIELD];
+  const frameNumber = ((Number(item.animFrame) || 0) % BONUS_ANIM_FRAMES) + 1;
+  return `${bonusPrefix}_${String(frameNumber).padStart(2, '0')}`;
 }
 class EntityRenderer {
   static preload(scene) {
@@ -239,16 +188,17 @@ class EntityRenderer {
         frameHeight: PLAYER_FRAME_SIZE,
       });
     });
-    ['coins_gold', 'coins_silver', ...Object.values(BONUS_TEXTURES)].forEach((key) => {
-      if (WIDE_BONUS_TEXTURES.has(key)) {
-        scene.load.image(key, assetUrl(`assets/${key}.png`));
-        return;
-      }
+    ['coins_gold', 'coins_silver'].forEach((key) => {
       scene.load.spritesheet(key, assetUrl(`assets/${key}.png`), {
         frameWidth: FRAME_SIZE,
         frameHeight: FRAME_SIZE,
       });
     });
+    scene.load.multiatlas(
+      BONUS_ATLAS_KEY,
+      assetUrl('assets/bonus_atlas_phaser.json'),
+      assetUrl('assets/'),
+    );
     scene.load.multiatlas(
       'obstacles_atlas',
       assetUrl('assets/obstacles_atlas_phaser.json'),
@@ -284,7 +234,6 @@ class EntityRenderer {
   }
   create() {
     ensureVisualUpgradeTextures(this.scene);
-    registerCustomBonusFrames(this.scene);
     this.root = this.scene.add.container(0, 0).setDepth(14);
     this.objectLayer = this.scene.add.container(0, 0).setDepth(14);
     this.playerLayer = this.scene.add.container(0, 0).setDepth(15);

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -126,9 +126,11 @@ function renderCollectAnimationsPass(renderer, deps) {
     }
 
     const textureKey = kind === 'bonus'
-      ? (deps.BONUS_TEXTURES[bonusType] || 'bonus_shield')
+      ? (deps.BONUS_TEXTURES[bonusType] || 'shield')
       : (coinType === 'silver' ? 'coins_silver' : 'coins_gold');
-    const sprite = renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, textureKey, 0);
+    const sprite = kind === 'bonus'
+      ? renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, 'bonus_atlas', `${textureKey}_01`)
+      : renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, textureKey, 0);
     sprite.setDepth(22);
     sprite.setAlpha(0.98);
     sprite.setScale(kind === 'bonus' ? 0.9 : (coinType === 'silver' ? 0.72 : 0.8));
@@ -232,7 +234,7 @@ function renderObjectsPass(renderer, deps) {
       ? renderer.scene.add.image(0, 0, 'shadow_contact_ellipse_01')
       : renderer.scene.add.ellipse(0, 0, 52, 16, 0x000000, 0.2)
   ));
-  renderer.ensurePoolSize(renderer.bonusSprites, bonusCount, () => renderer.scene.add.sprite(0, 0, 'bonus_shield', 0));
+  renderer.ensurePoolSize(renderer.bonusSprites, bonusCount, () => renderer.scene.add.sprite(0, 0, 'bonus_atlas', 'shield_01'));
   renderer.ensurePoolSize(renderer.bonusShadowSprites, bonusCount, () => (
     hasShadowTexture
       ? renderer.scene.add.image(0, 0, 'shadow_contact_ellipse_01')
@@ -328,16 +330,16 @@ function renderObjectsPass(renderer, deps) {
     } else if (entry.kind === 'bonus') {
       const sprite = renderer.bonusSprites[bonusIndex++];
       const shadow = renderer.bonusShadowSprites[bonusShadowIndex++];
-      const textureKey = deps.BONUS_TEXTURES[item.type] || 'bonus_shield';
+      const textureKey = deps.BONUS_TEXTURES[item.type] || 'shield';
       const baseSize = Math.max(18, deps.FRAME_SIZE * projection.scale * 0.94);
-      const size = textureKey === 'bonus_chkey' ? baseSize * 1.25 : baseSize;
+      const size = textureKey === 'x2' ? baseSize * 1.25 : baseSize;
       shadow
         .setPosition(projection.x, projection.y + size * 0.44)
         .setDisplaySize(size * 0.95, size * 0.28)
         .setAlpha((0.14 + projection.scale * 0.2) * curveOcclusion)
         .setVisible(true);
       renderer.objectLayer.add(shadow);
-      sprite.setTexture(textureKey, deps.getBonusFrame(item));
+      sprite.setTexture('bonus_atlas', deps.getBonusFrame(item));
       sprite.setPosition(projection.x, projection.y);
       sprite.setDisplaySize(size, size);
       sprite.setAlpha(0.95 * curveOcclusion);


### PR DESCRIPTION
### Motivation
- Новые ассеты бонусов поставляются как multi-atlas (`bonus_atlas.webp` + `bonus_atlas_phaser.json`) с 6 кадрами на бонус (128×128), поэтому рендер должен использовать atlas frames и программно даунскейлить до игрового размера. 

### Description
- Перевёл маппинг бонусов на префиксы кадров атласа, добавив `BONUS_ATLAS_KEY` и `BONUS_ANIM_FRAMES` и изменив `BONUS_TEXTURES` на новые имена кадров (например `shield`, `speed_up`, `battery`, `score_300`, `anti_score_300` и т.д.). (изменён `js/phaser/entities/EntityRenderer.js`).
- Заменил подбор кадра на универсальную функцию `getBonusFrame()` которая возвращает имена `PREFIX_01..PREFIX_06` по `animFrame` вместо старой кастомной логики. (изменён `js/phaser/entities/EntityRenderer.js`).
- В `preload()` убрал загрузку старых per-bonus PNG и добавил `scene.load.multiatlas('bonus_atlas', assetUrl('assets/bonus_atlas_phaser.json'), assetUrl('assets/'))` для загрузки нового атласа. (изменён `js/phaser/entities/EntityRenderer.js`).
- Обновил рендеринг в рантайме и VFX сборки: все бонусные спрайты (мировые и collect VFX) теперь создаются из `bonus_atlas` с соответствующими frame-names; pool-creation использует `shield_01` как дефолт. (изменён `js/phaser/entities/entity-render-passes.js`).
- Удалил устаревшие кастомные определения фреймов и special-case для «широких» бонусов; размер визуально сохраняется через существующую логику `FRAME_SIZE = 64` и `setDisplaySize(...)`, что обеспечивает программный даунскейл 128→64. (см. `FRAME_SIZE` и использование `setDisplaySize` в обоих файлах).

### Testing
- Запущены автоматические проверки синтаксиса: `npm run check:syntax` — успешно ✅.
- Запущен модульный тест: `node --test scripts/entity-render-passes.test.mjs` — все тесты прошли ✅.
- Pre-commit hooks (`check:syntax`, `check:static-analysis`) выполнялись при фиксации изменений и прошли успешно ✅.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbe0d00b08326991ef66f72644195)