### PR TITLE
Use coin atlas for Phaser coin rendering

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -42,6 +42,7 @@ const OBSTACLE_ANIM_FRAMES = 6;
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
 const BONUS_ATLAS_KEY = 'bonus_atlas';
+const COIN_ATLAS_KEY = 'coin_atlas';
 const BONUS_ANIM_FRAMES = 6;
 function assetUrl(path) {
   const normalizedBase = BASE_URL.endsWith('/') ? BASE_URL : `${BASE_URL}/`;
@@ -180,6 +181,11 @@ function getBonusFrame(item) {
   const frameNumber = ((Number(item.animFrame) || 0) % BONUS_ANIM_FRAMES) + 1;
   return `${bonusPrefix}_${String(frameNumber).padStart(2, '0')}`;
 }
+function getCoinFrame(item) {
+  const prefix = item?.type === 'gold' || item?.type === 'gold_spin' ? 'gold_coin' : 'silver_coin';
+  const frameNumber = ((Number(item?.animFrame) || 0) % 4) + 1;
+  return `${prefix}_${String(frameNumber).padStart(2, '0')}`;
+}
 class EntityRenderer {
   static preload(scene) {
     Object.values(PLAYER_TEXTURES).forEach((key) => {
@@ -188,12 +194,7 @@ class EntityRenderer {
         frameHeight: PLAYER_FRAME_SIZE,
       });
     });
-    ['coins_gold', 'coins_silver'].forEach((key) => {
-      scene.load.spritesheet(key, assetUrl(`assets/${key}.png`), {
-        frameWidth: FRAME_SIZE,
-        frameHeight: FRAME_SIZE,
-      });
-    });
+    scene.load.atlas(COIN_ATLAS_KEY, assetUrl('assets/coin_atlas.webp'), assetUrl('assets/coin_atlas_phaser.json'));
     scene.load.multiatlas(
       BONUS_ATLAS_KEY,
       assetUrl('assets/bonus_atlas_phaser.json'),
@@ -370,6 +371,8 @@ class EntityRenderer {
       projectLane,
       projectPolar,
       getBonusFrame,
+      getCoinFrame,
+      COIN_ATLAS_KEY,
     });
   }
   renderSpinTargets() {

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -240,7 +240,7 @@ function renderObjectsPass(renderer, deps) {
       ? renderer.scene.add.image(0, 0, 'shadow_contact_ellipse_01')
       : renderer.scene.add.ellipse(0, 0, 44, 14, 0x000000, 0.18)
   ));
-  renderer.ensurePoolSize(renderer.coinSprites, coinCount, () => renderer.scene.add.sprite(0, 0, 'coins_silver', 0));
+  renderer.ensurePoolSize(renderer.coinSprites, coinCount, () => renderer.scene.add.sprite(0, 0, deps.COIN_ATLAS_KEY, 'silver_coin_01'));
   renderer.ensurePoolSize(renderer.coinShadowSprites, coinCount, () => (
     hasShadowTexture
       ? renderer.scene.add.image(0, 0, 'shadow_contact_ellipse_01')
@@ -348,15 +348,15 @@ function renderObjectsPass(renderer, deps) {
     } else {
       const sprite = renderer.coinSprites[coinIndex++];
       const shadow = renderer.coinShadowSprites[coinShadowIndex++];
-      const textureKey = item.type === 'gold' || item.type === 'gold_spin' ? 'coins_gold' : 'coins_silver';
-      const size = Math.max(18, deps.FRAME_SIZE * projection.scale * (textureKey === 'coins_gold' ? 1 : 0.95));
+      const isGoldCoin = item.type === 'gold' || item.type === 'gold_spin';
+      const size = Math.max(18, deps.FRAME_SIZE * projection.scale * (isGoldCoin ? 1 : 0.95));
       shadow
         .setPosition(projection.x, projection.y + size * 0.42)
         .setDisplaySize(size * 0.82, size * 0.24)
         .setAlpha((0.14 + projection.scale * 0.18) * curveOcclusion)
         .setVisible(true);
       renderer.objectLayer.add(shadow);
-      sprite.setTexture(textureKey, (item.animFrame || 0) % 4);
+      sprite.setTexture(deps.COIN_ATLAS_KEY, deps.getCoinFrame(item));
       sprite.setPosition(projection.x, projection.y);
       sprite.setDisplaySize(size, size);
       sprite.setAlpha((item.spinOnly ? 0.78 : 1) * curveOcclusion);


### PR DESCRIPTION
### Motivation
- Replace separate gold/silver spritesheets with a single coin atlas so Phaser rendering uses `public/assets/coin_atlas.webp` + `public/assets/coin_atlas_phaser.json` for coin frames.

### Description
- Added `COIN_ATLAS_KEY` and a helper `getCoinFrame(item)` to map coin `type` and `animFrame` to atlas frame names (`silver_coin_01..04`, `gold_coin_01..04`).
- Switched preload to `scene.load.atlas(COIN_ATLAS_KEY, assetUrl('assets/coin_atlas.webp'), assetUrl('assets/coin_atlas_phaser.json'))` in `EntityRenderer.preload`.
- Updated `renderObjectsPass` to create pooled coin sprites from the coin atlas and call `sprite.setTexture(deps.COIN_ATLAS_KEY, deps.getCoinFrame(item))` when rendering coins, preserving existing sizing and alpha logic for gold vs silver.
- Passed `getCoinFrame` and `COIN_ATLAS_KEY` into the `renderObjectsPass` dependency object from `EntityRenderer`.

### Testing
- Ran `node scripts/check-syntax.mjs`, which completed successfully.
- Pre-commit checks ran `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd5adf9c88326b5eaf2c1265dcc34)