### PR TITLE
Use icon atlas slices for UI coin icons and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <title>URSASS TUBE</title>
-  <link rel="icon" type="image/png" href="img/favicon.png">
+  <link rel="icon" type="image/png" href="img/favicon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -39,8 +39,8 @@
     <span class="tg-account-badge" id="tgAccountBadge" hidden></span>
   </div>
   <div class="wallet-info" id="walletInfo">
-    <div class="wallet-info-row"><img src="img/icon_gold.png"> <span class="val-gold" id="walletGold">0</span></div>
-    <div class="wallet-info-row"><img src="img/icon_silver.png"> <span class="val-silver" id="walletSilver">0</span></div>
+    <div class="wallet-info-row"><img src="img/icon_gold.svg"> <span class="val-gold" id="walletGold">0</span></div>
+    <div class="wallet-info-row"><img src="img/icon_silver.svg"> <span class="val-silver" id="walletSilver">0</span></div>
   </div>
 </div>
 
@@ -71,11 +71,11 @@
       <div id="uiBottomCenter">
         <div class="coins-row">
           <div class="coin">
-            <img src="img/icon_gold.png" style="width: 24px; height: 24px; vertical-align: middle;">
+            <img src="img/icon_gold.svg" style="width: 24px; height: 24px; vertical-align: middle;">
             <span class="count" id="goldVal">0</span>
           </div>
           <div class="coin">
-            <img src="img/icon_silver.png" style="width: 24px; height: 24px; vertical-align: middle;">
+            <img src="img/icon_silver.svg" style="width: 24px; height: 24px; vertical-align: middle;">
             <span class="count" id="silverVal">0</span>
           </div>
         </div>
@@ -187,8 +187,8 @@
 
   <div class="go-stats" aria-label="Collected coins">
     <div class="go-stat-row go-stat-row-coins">
-      <span class="go-coins-pill go-coins-pill-gold"><img src="img/icon_gold.png" style="width: 24px; height: 24px; vertical-align: middle;"> <span id="goGold">0</span></span>
-      <span class="go-coins-pill go-coins-pill-silver"><img src="img/icon_silver.png" style="width: 24px; height: 24px; vertical-align: middle;"> <span id="goSilver">0</span></span>
+      <span class="go-coins-pill go-coins-pill-gold"><img src="img/icon_gold.svg" style="width: 24px; height: 24px; vertical-align: middle;"> <span id="goGold">0</span></span>
+      <span class="go-coins-pill go-coins-pill-silver"><img src="img/icon_silver.svg" style="width: 24px; height: 24px; vertical-align: middle;"> <span id="goSilver">0</span></span>
     </div>
   </div>
 
@@ -293,8 +293,8 @@
             <thead>
               <tr>
                 <th scope="col">Type</th>
-                <th scope="col"><img src="img/icon_gold.png" alt="Gold"></th>
-                <th scope="col"><img src="img/icon_silver.png" alt="Silver"></th>
+                <th scope="col"><img src="img/icon_gold.svg" alt="Gold"></th>
+                <th scope="col"><img src="img/icon_silver.svg" alt="Silver"></th>
               </tr>
             </thead>
             <tbody id="pmHistoryBody">
@@ -324,11 +324,11 @@
     <div class="store-title"><span class="store-title-icon" aria-hidden="true">🛒</span> STORE</div>
     <div class="store-coins">
       <div class="store-coin-display">
-        <img src="img/icon_gold.png">
+        <img src="img/icon_gold.svg">
         <span class="store-gold-val" id="storeGoldVal">0</span>
       </div>
       <div class="store-coin-display">
-        <img src="img/icon_silver.png">
+        <img src="img/icon_silver.svg">
         <span class="store-silver-val" id="storeSilverVal">0</span>
       </div>
     </div>
@@ -346,12 +346,12 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield Start — start every rides with shield bonus</span>
-        <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
+        <span class="store-item-currency"><img src="img/icon_gold.svg"> GOLD</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-shield-0" data-upgrade-key="shield" data-upgrade-tier="0">
           <div class="store-tier-label">start shield</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 400</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 400</div>
         </div>
       </div>
     </div>
@@ -360,16 +360,16 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span> Shield Stack — increase max shields</span>
-        <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
+        <span class="store-item-currency"><img src="img/icon_gold.svg"> GOLD</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-shieldcapacity-0" data-upgrade-key="shield_capacity" data-upgrade-tier="0">
           <div class="store-tier-label">2 shields</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 2,000</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 2,000</div>
         </div>
         <div class="store-tier" id="store-shieldcapacity-1" data-upgrade-key="shield_capacity" data-upgrade-tier="1">
           <div class="store-tier-label">3 shields</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 5,000</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 5,000</div>
         </div>
       </div>
     </div>
@@ -378,16 +378,16 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px 0px"></span> Radar — choose your detection module</span>
-        <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
+        <span class="store-item-currency"><img src="img/icon_gold.svg"> GOLD</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-radarobstacles-0" data-upgrade-key="radar_obstacles" data-upgrade-tier="0">
           <div class="store-tier-label">Radar Obstacles</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 2,000</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 2,000</div>
         </div>
         <div class="store-tier" id="store-radargold-0" data-upgrade-key="radar_gold" data-upgrade-tier="0">
           <div class="store-tier-label">Radar Gold</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 3,000</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 3,000</div>
         </div>
       </div>
     </div>
@@ -396,16 +396,16 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:0px -56px"></span> Spin Alert — warns before coin rings</span>
-        <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
+        <span class="store-item-currency"><img src="img/icon_gold.svg"> GOLD</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-spinalert-0" data-upgrade-key="spin_alert" data-upgrade-tier="0">
           <div class="store-tier-label"> Alert</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 1,000</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 1,000</div>
         </div>
         <div class="store-tier" id="store-spinalert-1" data-upgrade-key="spin_alert" data-upgrade-tier="1">
           <div class="store-tier-label"> Perfect</div>
-          <div class="store-tier-price"><img src="img/icon_gold.png" style="width: 12px; vertical-align: middle;"> 3,000</div>
+          <div class="store-tier-price"><img src="img/icon_gold.svg" style="width: 12px; vertical-align: middle;"> 3,000</div>
         </div>
       </div>
     </div>
@@ -414,9 +414,9 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> Rides — pack of rides</span>
-        <span class="store-item-currency"><img src="img/icon_gold.png"> GOLD</span>
+        <span class="store-item-currency"><img src="img/icon_gold.svg"> GOLD</span>
       </div>
-      <button class="store-single-buy ui-btn ui-btn--secondary ui-btn--sm" id="store-rides_pack" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <img src="img/icon_gold.png" style="width: 14px; height: 14px; vertical-align: middle;"> 70
+      <button class="store-single-buy ui-btn ui-btn--secondary ui-btn--sm" id="store-rides_pack" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <img src="img/icon_gold.svg" style="width: 14px; height: 14px; vertical-align: middle;"> 70
       </button>
     </div>
 
@@ -424,20 +424,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -56px"></span> Score — X2 multiplier duration</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-x2-0" data-upgrade-key="x2_duration" data-upgrade-tier="0">
           <div class="store-tier-label">+5s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-x2-1" data-upgrade-key="x2_duration" data-upgrade-tier="1">
           <div class="store-tier-label">+5s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-x2-2" data-upgrade-key="x2_duration" data-upgrade-tier="2">
           <div class="store-tier-label">+5s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -446,20 +446,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span> Score +300 — bonus multiplier</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-scoreplus300-0" data-upgrade-key="score_plus_300_mult" data-upgrade-tier="0">
           <div class="store-tier-label">x1.5</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-scoreplus300-1" data-upgrade-key="score_plus_300_mult" data-upgrade-tier="1">
           <div class="store-tier-label">x1.7</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-scoreplus300-2" data-upgrade-key="score_plus_300_mult" data-upgrade-tier="2">
           <div class="store-tier-label">x2.0</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -468,20 +468,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span> Score +500 — bonus multiplier</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-scoreplus500-0" data-upgrade-key="score_plus_500_mult" data-upgrade-tier="0">
           <div class="store-tier-label">x1.5</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-scoreplus500-1" data-upgrade-key="score_plus_500_mult" data-upgrade-tier="1">
           <div class="store-tier-label">x1.7</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-scoreplus500-2" data-upgrade-key="score_plus_500_mult" data-upgrade-tier="2">
           <div class="store-tier-label">x2.0</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -490,20 +490,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -56px"></span> Score −300 — penalty reduction</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-scoreminus300-0" data-upgrade-key="score_minus_300_mult" data-upgrade-tier="0">
           <div class="store-tier-label">x0.9</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-scoreminus300-1" data-upgrade-key="score_minus_300_mult" data-upgrade-tier="1">
           <div class="store-tier-label">x0.7</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-scoreminus300-2" data-upgrade-key="score_minus_300_mult" data-upgrade-tier="2">
           <div class="store-tier-label">x0.5</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -512,20 +512,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -56px"></span> Score −500 — penalty reduction</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-scoreminus500-0" data-upgrade-key="score_minus_500_mult" data-upgrade-tier="0">
           <div class="store-tier-label">x0.9</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-scoreminus500-1" data-upgrade-key="score_minus_500_mult" data-upgrade-tier="1">
           <div class="store-tier-label">x0.7</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-scoreminus500-2" data-upgrade-key="score_minus_500_mult" data-upgrade-tier="2">
           <div class="store-tier-label">x0.5</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -534,20 +534,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -84px"></span> Invert — bonus score multiplier</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-invert-0" data-upgrade-key="invert_score" data-upgrade-tier="0">
           <div class="store-tier-label">x1.5</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-invert-1" data-upgrade-key="invert_score" data-upgrade-tier="1">
           <div class="store-tier-label">x1.7</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-invert-2" data-upgrade-key="invert_score" data-upgrade-tier="2">
           <div class="store-tier-label">x2.0</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -556,20 +556,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px -56px"></span> Speed Up — speed boost multiplier</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-speedup-0" data-upgrade-key="speed_up_mult" data-upgrade-tier="0">
           <div class="store-tier-label">x2</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-speedup-1" data-upgrade-key="speed_up_mult" data-upgrade-tier="1">
           <div class="store-tier-label">x3</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-speedup-2" data-upgrade-key="speed_up_mult" data-upgrade-tier="2">
           <div class="store-tier-label">x4</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -578,20 +578,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:0px -28px"></span> Speed Down — slow boost multiplier</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-speeddown-0" data-upgrade-key="speed_down_mult" data-upgrade-tier="0">
           <div class="store-tier-label">x2</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-speeddown-1" data-upgrade-key="speed_down_mult" data-upgrade-tier="1">
           <div class="store-tier-label">x3</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-speeddown-2" data-upgrade-key="speed_down_mult" data-upgrade-tier="2">
           <div class="store-tier-label">x4</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -600,20 +600,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px 0px"></span> Magnet — magnet duration</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-magnet-0" data-upgrade-key="magnet_duration" data-upgrade-tier="0">
           <div class="store-tier-label">+5s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-magnet-1" data-upgrade-key="magnet_duration" data-upgrade-tier="1">
           <div class="store-tier-label">+5s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-magnet-2" data-upgrade-key="magnet_duration" data-upgrade-tier="2">
           <div class="store-tier-label">+5s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>
@@ -622,20 +622,20 @@
     <div class="store-item">
       <div class="store-item-header">
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -28px"></span> Spin — cooldown reduction</span>
-        <span class="store-item-currency"><img src="img/icon_silver.png"> SILVER</span>
+        <span class="store-item-currency"><img src="img/icon_silver.svg"> SILVER</span>
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-spincooldown-0" data-upgrade-key="spin_cooldown" data-upgrade-tier="0">
           <div class="store-tier-label">-6s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 300</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 300</div>
         </div>
         <div class="store-tier" id="store-spincooldown-1" data-upgrade-key="spin_cooldown" data-upgrade-tier="1">
           <div class="store-tier-label">-12s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 2,400</div>
         </div>
         <div class="store-tier" id="store-spincooldown-2" data-upgrade-key="spin_cooldown" data-upgrade-tier="2">
           <div class="store-tier-label">-20s</div>
-          <div class="store-tier-price"><img src="img/icon_silver.png" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
+          <div class="store-tier-price"><img src="img/icon_silver.svg" style="width:20px;height:20px;vertical-align:middle"> 8,000</div>
         </div>
       </div>
     </div>

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -37,13 +37,13 @@ function createWalletInfoRow({ iconNode, valueId, valueClass, defaultValue }) {
 function renderWalletStats(infoRoot) {
   infoRoot.append(
     createWalletInfoRow({
-      iconNode: createImageIcon({ src: 'img/icon_gold.png' }),
+      iconNode: createImageIcon({ src: 'img/icon_gold.svg' }),
       valueId: 'walletGold',
       valueClass: 'val-gold',
       defaultValue: '0'
     }),
     createWalletInfoRow({
-      iconNode: createImageIcon({ src: 'img/icon_silver.png' }),
+      iconNode: createImageIcon({ src: 'img/icon_silver.svg' }),
       valueId: 'walletSilver',
       valueClass: 'val-silver',
       defaultValue: '0'

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -68,7 +68,7 @@ async function updateGameOverShareButton() {
   } else if (profile?.canShareToday) {
     shareBtn.classList.add('is-share-rewarded');
     const gold = profile.goldRewardToday || 20;
-    shareBtn.innerHTML = `SHARE +${gold} <img src="img/icon_gold.png" alt="gold" class="pm-share-gold-icon">`;
+    shareBtn.innerHTML = `SHARE +${gold} <img src="img/icon_gold.svg" alt="gold" class="pm-share-gold-icon">`;
   } else {
     shareBtn.classList.add('is-share');
     shareBtn.textContent = 'SHARE RESULT';

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -167,7 +167,7 @@ function updateShareButtonState(profile) {
   if (profile.canShareToday) {
     btn.classList.add('is-share-rewarded');
     const gold = profile.goldRewardToday || 20;
-    btn.innerHTML = `SHARE +${gold} <img src="img/icon_gold.png" alt="gold" class="pm-share-gold-icon">`;
+    btn.innerHTML = `SHARE +${gold} <img src="img/icon_gold.svg" alt="gold" class="pm-share-gold-icon">`;
   } else {
     btn.classList.add('is-share');
     btn.innerHTML = 'SHARE RESULT';

--- a/js/store/donation-ui.js
+++ b/js/store/donation-ui.js
@@ -55,13 +55,13 @@ function renderDonationReward(target, reward = {}) {
 
   target.append(
     createDonationRewardToken({
-      iconSrc: 'img/icon_gold.png',
+      iconSrc: 'img/icon_gold.svg',
       amount: gold,
       alt: 'Gold'
     }),
     document.createTextNode(' · '),
     createDonationRewardToken({
-      iconSrc: 'img/icon_silver.png',
+      iconSrc: 'img/icon_silver.svg',
       amount: silver,
       alt: 'Silver'
     })

--- a/js/store/rides-service.js
+++ b/js/store/rides-service.js
@@ -51,7 +51,7 @@ export function renderStoreCurrencyButton(target, { prefixIconPosition = null, l
   target.append(document.createTextNode(`${label} — `));
   target.append(
     createImageIcon({
-      src: 'img/icon_gold.png',
+      src: 'img/icon_gold.svg',
       width: 14,
       height: 14,
       verticalAlign: 'middle'

--- a/js/walletconnect.js
+++ b/js/walletconnect.js
@@ -36,7 +36,7 @@ const WC = {
           name: 'URSASS TUBE',
           description: 'URSASS TUBE Game',
           url: window.location.origin,
-          icons: [window.location.origin + '/img/favicon.png']
+          icons: [window.location.origin + '/img/favicon.svg']
         }
       });
 

--- a/public/img/favicon.svg
+++ b/public/img/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <image href="/assets/icon_atlas.webp" x="0" y="-192" width="320" height="256"/>
+</svg>

--- a/public/img/icon_gold.svg
+++ b/public/img/icon_gold.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <image href="/assets/icon_atlas.webp" x="-128" y="-192" width="320" height="256"/>
+</svg>

--- a/public/img/icon_silver.svg
+++ b/public/img/icon_silver.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <image href="/assets/icon_atlas.webp" x="-64" y="-192" width="320" height="256"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Centralize UI coin artwork on the shared atlas (`public/assets/icon_atlas.webp`) so the same source art is used across the game and web UI.  
- Use the atlas `mystery` frame as the site favicon to keep visuals consistent and avoid duplicate standalone PNGs.

### Description
- Added atlas-backed SVG slice assets: `public/img/icon_gold.svg`, `public/img/icon_silver.svg`, and `public/img/favicon.svg`, each embedding `public/assets/icon_atlas.webp` and positioned to the respective frame in the atlas.  
- Replaced PNG icon references with the new SVGs in the markup and code, including `index.html` and JS modules `js/auth-ui.js`, `js/game/bootstrap.js`, `js/player-menu/controller.js`, `js/store/donation-ui.js`, `js/store/rides-service.js`, and `js/walletconnect.js`.  
- Updated site favicon link in `index.html` to `img/favicon.svg` and updated WalletConnect metadata to reference the new favicon SVG.  
- Kept existing UI markup patterns (image tags, small inline sizes) so runtime behavior remains unchanged while source art is centralized.

### Testing
- Ran the repository pre-commit checks (`check:syntax` and `check:static-analysis`) which completed successfully.  
- Executed `npm run check:asset-paths` which reported unrelated missing assets in `js/assets.js` (existing in the repo) but did not indicate failures caused by these changes.  
- Verified that created SVG files are present at `public/img/icon_gold.svg`, `public/img/icon_silver.svg`, and `public/img/favicon.svg` and that source references in code were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd64948c0832692725246eb7f4ba1)