### PR TITLE
Fix icon atlas mappings and replace broken coin/share icons (store, player menu, leaderboard)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2878,9 +2878,12 @@ footer a:hover { color: #e0b0ff; }
 }
 
 .pm-share-gold-icon {
+  display: inline-block;
   width: 16px;
   height: 16px;
   vertical-align: middle;
+  background-size: 80px auto;
+  background-position: -32px -48px;
 }
 
 .pm-streak {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <title>URSASS TUBE</title>
-  <link rel="icon" type="image/png" href="img/favicon.svg">
+  <link rel="icon" type="image/png" href="/assets/icon_atlas.webp">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -395,7 +395,7 @@
     <!-- === GOLD: Spin Alert (2-tier) === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:0px -56px"></span> Spin Alert — warns before coin rings</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -28px"></span> Spin Alert — warns before coin rings</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-gold" aria-hidden="true"></span> GOLD</span>
       </div>
       <div class="store-tiers">
@@ -413,7 +413,7 @@
     <!-- === GOLD: Rides pack === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> Rides — pack of rides</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px -84px"></span> Rides — pack of rides</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-gold" aria-hidden="true"></span> GOLD</span>
       </div>
       <button class="store-single-buy ui-btn ui-btn--secondary ui-btn--sm" id="store-rides_pack" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <span class="icon-atlas icon-coin-gold-sm" aria-hidden="true"></span> 70
@@ -423,7 +423,7 @@
     <!-- === SILVER: X2 Score duration === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -56px"></span> Score — X2 multiplier duration</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span> Score — X2 multiplier duration</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -445,7 +445,7 @@
     <!-- === SILVER: Score +300 multiplier === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span> Score +300 — bonus multiplier</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:0px -56px"></span> Score +300 — bonus multiplier</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -467,7 +467,7 @@
     <!-- === SILVER: Score +500 multiplier === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span> Score +500 — bonus multiplier</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:0px -56px"></span> Score +500 — bonus multiplier</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -489,7 +489,7 @@
     <!-- === SILVER: Score -300 penalty reduction === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -56px"></span> Score −300 — penalty reduction</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -56px"></span> Score −300 — penalty reduction</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -511,7 +511,7 @@
     <!-- === SILVER: Score -500 penalty reduction === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -56px"></span> Score −500 — penalty reduction</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -56px"></span> Score −500 — penalty reduction</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -533,7 +533,7 @@
     <!-- === SILVER: Invert score === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -84px"></span> Invert — bonus score multiplier</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -28px"></span> Invert — bonus score multiplier</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -555,7 +555,7 @@
     <!-- === SILVER: Speed Up === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px -56px"></span> Speed Up — speed boost multiplier</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -56px"></span> Speed Up — speed boost multiplier</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">
@@ -621,7 +621,7 @@
     <!-- === SILVER: Spin cooldown === -->
     <div class="store-item">
       <div class="store-item-header">
-        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -28px"></span> Spin — cooldown reduction</span>
+        <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> Spin — cooldown reduction</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-silver" aria-hidden="true"></span> SILVER</span>
       </div>
       <div class="store-tiers">

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -68,7 +68,7 @@ async function updateGameOverShareButton() {
   } else if (profile?.canShareToday) {
     shareBtn.classList.add('is-share-rewarded');
     const gold = profile.goldRewardToday || 20;
-    shareBtn.innerHTML = `SHARE +${gold} <img src="img/icon_gold.svg" alt="gold" class="pm-share-gold-icon">`;
+    shareBtn.innerHTML = `SHARE +${gold} <span class="icon-atlas pm-share-gold-icon" role="img" aria-label="gold"></span>`;
   } else {
     shareBtn.classList.add('is-share');
     shareBtn.textContent = 'SHARE RESULT';

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -167,7 +167,7 @@ function updateShareButtonState(profile) {
   if (profile.canShareToday) {
     btn.classList.add('is-share-rewarded');
     const gold = profile.goldRewardToday || 20;
-    btn.innerHTML = `SHARE +${gold} <img src="img/icon_gold.svg" alt="gold" class="pm-share-gold-icon">`;
+    btn.innerHTML = `SHARE +${gold} <span class="icon-atlas pm-share-gold-icon" role="img" aria-label="gold"></span>`;
   } else {
     btn.classList.add('is-share');
     btn.innerHTML = 'SHARE RESULT';

--- a/js/store/rides-service.js
+++ b/js/store/rides-service.js
@@ -149,7 +149,7 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
 
     if (ridesText) {
       appendRidesLabel(ridesText, {
-        iconPosition: '-84px -28px',
+        iconPosition: '-112px -84px',
         text: limited ? `${total ?? '∞'} ride${total === 1 ? '' : 's'}` : 'Unlimited rides'
       });
       if (limited && paid > 0) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,7 +3,7 @@ import { DOM, gameState, player } from './state.js';
 import { syncAllAudioUI } from './audio.js';
 import { getAuthStateSnapshot, hasWalletAuthSession, hasAuthenticatedSession } from './features/auth/index.js';
 import { applyStoreDefaultLockState, loadPlayerUpgrades, updateStoreUI, setActiveStoreTab, closeDonationModal, isStoreAvailable, isUnauthRuntimeMode, getStoreStateSnapshot } from './features/store/index.js';
-import { createElement, createIconAtlas, clearNode } from './dom-render.js';
+import { createElement, clearNode } from './dom-render.js';
 import { showStoreScreen, hideStoreScreen } from './screens.js';
 import { logger } from './logger.js';
 import { notifyWarn } from './notifier.js';
@@ -186,16 +186,7 @@ function createLeaderboardRow(entry, idx, { isMe = false, isDimmed = false, rank
 
   const scoreEl = document.createElement('span');
   scoreEl.className = 'lb-score';
-  scoreEl.append(
-    createIconAtlas({
-      width: 16,
-      height: 16,
-      backgroundSize: '80px auto',
-      backgroundPosition: '-64px -16px',
-      marginRight: 4
-    }),
-    document.createTextNode(score.toLocaleString())
-  );
+  scoreEl.textContent = score.toLocaleString();
 
   row.append(rank, wallet, scoreEl);
   return row;


### PR DESCRIPTION
### Motivation
- Align UI icon usage with the `public/assets/icon_atlas.webp` + `public/assets/icon_atlas_map.json` atlas so app shows the correct frames for store and player UI icons. 
- Replace broken standalone images (gold coin) with atlas-backed icons and remove redundant atlas usage (score icon) to fix missing icons and visual mismatches.

### Description
- Updated HTML store markup in `index.html` to use correct `background-position` values for upgrade item icons (ticket, lightning, rotate, refresh, minus, plus, cross, bell) and adjusted the rides pack and Spin/Score icon frames to match the atlas frames.
- Switched the rides counter runtime icon in `js/store/rides-service.js` to the `ticket` atlas frame by changing the `iconPosition` used by `appendRidesLabel`.
- Removed the small icon next to leaderboard score entries by simplifying the leaderboard score element in `js/ui.js` to show only the numeric score.
- Replaced broken share reward `<img>` usage with an atlas-backed span in both `js/player-menu/controller.js` and `js/game/bootstrap.js`, and added atlas-based styling for `.pm-share-gold-icon` in `css/style.css` (background-size / background-position tuned to atlas).
- Pointed the page favicon link in `index.html` to the bundled atlas asset so a valid image is served by the app.

### Testing
- Ran the app build with `npm run build` and the production bundle was generated successfully (Vite build completed). 
- Pre-commit quality checks executed during commit, including `check:syntax` and `check:static-analysis`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0087c7382883269e7ce519f8d04562)