### PR TITLE
Stop preloading atlas metadata as images

### DIFF
--- a/js/assets.js
+++ b/js/assets.js
@@ -11,11 +11,8 @@ class AssetManager {
   static getCriticalManifest() {
     return [
       ['coin_atlas', 'assets/coin_atlas.webp'],
-      ['coin_atlas_meta', 'assets/coin_atlas_phaser.json'],
       ['bonus_atlas', 'assets/bonus_atlas.webp'],
-      ['bonus_atlas_meta', 'assets/bonus_atlas_phaser.json'],
       ['obstacles_atlas', 'assets/obstacles_atlas.webp'],
-      ['obstacles_atlas_meta', 'assets/obstacles_atlas_phaser.json'],
       ['character_back_idle', 'assets/character_back_idle.png'],
       ['character_left_idle', 'assets/character_left_idle.png'],
       ['character_right_idle', 'assets/character_right_idle.png'],

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -168,9 +168,9 @@ function createGameSessionController({
   function areAllAssetsReady() {
     if (!assetManager.isReady()) return false;
     const criticalAssets = [
-      'coin_atlas', 'coin_atlas_meta',
-      'bonus_atlas', 'bonus_atlas_meta',
-      'obstacles_atlas', 'obstacles_atlas_meta',
+      'coin_atlas',
+      'bonus_atlas',
+      'obstacles_atlas',
       'character_back_idle', 'character_left_idle', 'character_right_idle',
       'character_left_swipe', 'character_right_swipe', 'character_spin'
     ];


### PR DESCRIPTION
### Motivation
- Atlas JSON files (for example `assets/coin_atlas_phaser.json`) were being fetched by the generic image loader and produced console errors even though Phaser loads these descriptors via `scene.load.atlas` / `scene.load.multiatlas`.

### Description
- Removed `*_atlas_meta` entries from `AssetManager.getCriticalManifest()` in `js/assets.js` and updated `areAllAssetsReady()` in `js/game/session.js` to require only the actual image atlas keys (`coin_atlas`, `bonus_atlas`, `obstacles_atlas`).

### Testing
- Ran pre-commit static checks including `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008bdaf0dc8326bc2ebcf76867448e)