### PR TITLE
Use mystery sprite from icon_atlas as favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,30 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <title>URSASS TUBE</title>
-  <link rel="icon" type="image/png" href="/assets/icon_atlas.webp">
+  <link rel="icon" type="image/webp" href="/assets/icon_atlas.webp">
+  <script>
+    (() => {
+      const atlas = new Image();
+      atlas.src = "/assets/icon_atlas.webp";
+      atlas.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 64;
+        canvas.height = 64;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        ctx.drawImage(atlas, 0, 192, 64, 64, 0, 0, 64, 64);
+        const href = canvas.toDataURL("image/png");
+        let link = document.querySelector('link[rel="icon"]');
+        if (!link) {
+          link = document.createElement("link");
+          link.rel = "icon";
+          document.head.appendChild(link);
+        }
+        link.type = "image/png";
+        link.href = href;
+      };
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">


### PR DESCRIPTION
### Motivation
- Provide a proper favicon by extracting the `mystery` sprite from the existing atlas so the app favicon matches UI assets.

### Description
- Replace the static favicon reference in `index.html` and set the link `type` to `image/webp` while keeping the atlas as source via `href="/assets/icon_atlas.webp"`.
- Inject a small runtime script in `index.html` that loads `/assets/icon_atlas.webp`, draws the `mystery` frame (`x=0, y=192, w=64, h=64`) onto a `canvas`, converts it to a PNG data URL, and sets it as the page `link[rel="icon"]`.
- Gracefully no-op if `canvas` context is unavailable so page load remains safe and no asset-pipeline changes are required.

### Testing
- Pre-commit automated checks ran and passed: `npm run check:syntax` (syntax checks) and `npm run check:static-analysis` (static analysis).
- The added runtime logic is included in `index.html` and does not break existing build checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008c5c925c83268a22efab7862c340)