### PR TITLE
Fix Phaser atlas preload: use `scene.load.atlas` for obstacles and bonuses

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -195,16 +195,8 @@ class EntityRenderer {
       });
     });
     scene.load.atlas(COIN_ATLAS_KEY, assetUrl('assets/coin_atlas.webp'), assetUrl('assets/coin_atlas_phaser.json'));
-    scene.load.multiatlas(
-      BONUS_ATLAS_KEY,
-      assetUrl('assets/bonus_atlas_phaser.json'),
-      assetUrl('assets/'),
-    );
-    scene.load.multiatlas(
-      'obstacles_atlas',
-      assetUrl('assets/obstacles_atlas_phaser.json'),
-      assetUrl('assets/'),
-    );
+    scene.load.atlas(BONUS_ATLAS_KEY, assetUrl('assets/bonus_atlas.webp'), assetUrl('assets/bonus_atlas_phaser.json'));
+    scene.load.atlas('obstacles_atlas', assetUrl('assets/obstacles_atlas.webp'), assetUrl('assets/obstacles_atlas_phaser.json'));
     // Visual upgrade textures are generated procedurally at runtime in
     // ensureVisualUpgradeTextures(), so no static asset preload is required.
   }


### PR DESCRIPTION
### Motivation
- Obstacle and bonus sprites were sometimes rendered as the whole atlas preview instead of individual frames because the atlas metadata was being loaded with the wrong loader type.
- The intent is to ensure frame lookups like `fence_01` / `tree_02` resolve correctly to single-frame textures rather than falling back to the base image.

### Description
- Replaced `scene.load.multiatlas(...)` calls with `scene.load.atlas(...)` for `bonus_atlas` and `obstacles_atlas` in `js/phaser/entities/EntityRenderer.js` to match the provided atlas format and image files.
- Kept existing frame naming and selection logic unchanged so frame references like `<name>_01..._06` continue to work.
- No gameplay logic was modified; this change only affects asset preload wiring.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Pre-commit automated checks (`check:syntax`, `check:static-analysis`, etc.) ran as part of the commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0094bad66c8326b4767536159fe016)