### PR TITLE
Удалить фиолетовый center particle burst при старте Spin

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -1,9 +1,7 @@
 import { gameState, player, inputQueue, coins, getLaneCooldown } from './state.js';
 import { CONFIG } from './config.js';
 import { audioManager } from './audio.js';
-import { spawnParticles } from './particles.js';
 import { collectCoin } from './physics.js';
-import { getViewportCenter } from './game/projection.js';
 import { showBonusText } from './ui.js';
 
 /* ===== INPUT HANDLERS ===== */
@@ -105,8 +103,6 @@ function triggerSpin() {
 
   player.isSpin = true;
   audioManager.playSFX('spin');
-  const { x, y } = getViewportCenter();
-  spawnParticles(x, y, 'rgba(200, 100, 255, 1)', 25, 10);
 }
 
 export { initInputHandlers };


### PR DESCRIPTION
### Motivation
- Убрать визуальный фиолетовый burst в центре экрана при активации `triggerSpin()` без изменения логики самого Spin и не трогая общий particle helper.

### Description
- Удалён вызов `spawnParticles(...)` и получение центра экрана `getViewportCenter()` из `triggerSpin()` в `js/input.js`, и также удалены теперь неиспользуемые импорты `spawnParticles` и `getViewportCenter`, при этом сохранены `gameState.spinActive`, `gameState.spinProgress`, `player.isSpin` и `audioManager.playSFX('spin')`; файл `js/particles.js` не изменялся.

### Testing
- Запущены статические и синтаксические проверки и линтер через `npm run lint`, все проверки и pre-commit хуки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0094ca1f6483269205c62f44c51f6b)