### PR TITLE
Fix wallet auth CORS via same-origin API proxy

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,15 @@
 import { logger } from './logger.js';
 /* ===== CONFIG ===== */
-const BACKEND_URL = "https://api.ursasstube.fun";
+const explicitBackendUrl = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_BACKEND_URL)
+  ? String(import.meta.env.VITE_BACKEND_URL).trim()
+  : '';
+
+const isUrsassTubeFrontendHost = (() => {
+  if (typeof window === 'undefined' || !window.location?.hostname) return false;
+  return /(^|\.)ursasstube\.fun$/i.test(window.location.hostname);
+})();
+
+const BACKEND_URL = explicitBackendUrl || (isUrsassTubeFrontendHost ? '/api' : 'https://api.ursasstube.fun');
 logger.info(`🔗 Backend URL: ${BACKEND_URL}`);
 
 // WalletConnect v2 Project ID — get yours at https://cloud.walletconnect.com

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "rewrites": [
+    { "source": "/api/:path*", "destination": "https://api.ursasstube.fun/api/:path*" },
     { "source": "/privacy", "destination": "/privacy.html" },
     { "source": "/terms", "destination": "/terms.html" }
   ]


### PR DESCRIPTION
### Motivation
- Browser CORS errors occurred when frontend at `https://www.ursasstube.fun` called the backend at `https://api.ursasstube.fun`, causing wallet auth flows to be blocked by missing CORS headers.
- The goal is to make frontend API calls same-origin so failures surface as ordinary API errors instead of being blocked by the browser.

### Description
- Added a Vercel rewrite in `vercel.json` to proxy `/api/:path*` requests to `https://api.ursasstube.fun/api/:path*` so frontend can call `/api/*` on the same origin.
- Updated `js/config.js` to resolve backend URL by preferring `VITE_BACKEND_URL` when set, otherwise using `'/api'` on `*.ursasstube.fun` hosts, and falling back to `https://api.ursasstube.fun`.
- Kept an informational log of the resolved `BACKEND_URL` to aid debugging in different deploy environments.

### Testing
- Ran the request/integration test suite (`npm run test:request`) and all tests passed (86/86 green).
- Pre-commit checks including `check:syntax` and `check:static-analysis` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0095c6b1f08326a449e0f34ee23c72)