### PR TITLE
Replace rides reset icon with timer atlas sprite

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
     </div>
     <div id="ridesInfo" aria-hidden="true">
       <span id="ridesText" style="font-family: 'Orbitron', sans-serif; font-size: 13px; font-weight: 600; color: rgba(255,255,255,.8);"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span> 3 rides</span>
-      <span id="ridesTimer" style="font-family: 'Orbitron', sans-serif; font-size: 11px; color: #fbbf24; display: none;"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -28px"></span> Resets in 0h 0m</span>
+      <span id="ridesTimer" style="font-family: 'Orbitron', sans-serif; font-size: 11px; color: #fbbf24; display: none;"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px -28px"></span> Resets in 0h 0m</span>
     </div>
   </div>
 


### PR DESCRIPTION
### Motivation
- Поменять иконку индикатора сброса езд (`ridesTimer`) на главной странице на `timer` из атласа иконок.

### Description
- В `index.html` изменён inline `background-position` для `#ridesTimer` с `-56px -28px` на `-112px -28px`, чтобы использовать спрайт `timer` из атласа.

### Testing
- Запущены pre-commit проверки: `npm run check:syntax` и `npm run check:static-analysis`, обе проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0097d998f883269f63bd6c6b141ef0)