### PR TITLE
Fix leaderboard URL construction for relative backend paths

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -171,14 +171,18 @@ async function signMessage(message) {
   }
 }
 
-
+function buildBackendApiUrl(pathname) {
+  const safePath = String(pathname || '').startsWith('/') ? String(pathname) : `/${String(pathname || '')}`;
+  const origin = (typeof window !== 'undefined' && window.location?.origin) ? window.location.origin : 'http://localhost';
+  return new URL(`${String(BACKEND_URL || '').trim()}${safePath}`, origin);
+}
 async function loadAndDisplayLeaderboard(options = {}) {
   const runToken = options?.runToken ?? null;
   const { userWallet = '' } = getAuthStateSnapshot();
   showLeaderboardSkeletons();
   try {
     const normalizedWallet = String(userWallet || '').trim();
-    const leaderboardUrl = new URL(`${BACKEND_URL}/api/leaderboard/top`);
+    const leaderboardUrl = buildBackendApiUrl('/api/leaderboard/top');
     if (normalizedWallet) {
       leaderboardUrl.searchParams.set('wallet', normalizedWallet);
       leaderboardUrl.searchParams.set('v', '2');
@@ -197,7 +201,7 @@ async function loadAndDisplayLeaderboard(options = {}) {
         insightsReason = null;
       } else if (normalizedWallet) {
         try {
-          const insightsUrl = new URL(`${BACKEND_URL}/api/leaderboard/insights`);
+          const insightsUrl = buildBackendApiUrl('/api/leaderboard/insights');
           insightsUrl.searchParams.set('wallet', normalizedWallet);
           const insightsResult = await requestJsonResult(insightsUrl.toString(), REQUEST_PROFILE_LEADERBOARD_READ);
           if (insightsResult.ok) {


### PR DESCRIPTION
### Motivation
- Prevent runtime `TypeError: Failed to construct 'URL': Invalid URL` when `BACKEND_URL` is configured as a relative path (e.g. `/api`).
- Ensure leaderboard network calls build valid absolute URLs in browser contexts that require a base origin.

### Description
- Added `buildBackendApiUrl(pathname)` helper in `js/api.js` which composes a safe path and constructs a `URL` using `window.location.origin` with a fallback to `http://localhost`.
- Replaced direct `new URL(`${BACKEND_URL}/...`)` usage for the leaderboard `top` and `insights` endpoints with the new helper.
- The change preserves behavior for absolute `BACKEND_URL` values and improves robustness for relative backend paths.

### Testing
- Ran the full request test suite with `npm run test:request`, which completed successfully (`86` tests passed, `0` failed).
- Pre-commit checks executed during the change included `npm run check:syntax` and `npm run check:static-analysis`, and both passed.
- All automated request/static-analysis checks passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00ba7be9ec83269f73309a62aebf69)