### PR TITLE
Fix absolute BACKEND_URL resolution to avoid invalid URL errors

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,7 +1,11 @@
 import { logger } from './logger.js';
 /* ===== CONFIG ===== */
+function stripTrailingSlashes(value) {
+  return String(value || '').replace(/\/+$/, '');
+}
+
 const explicitBackendUrl = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_BACKEND_URL)
-  ? String(import.meta.env.VITE_BACKEND_URL).trim()
+  ? stripTrailingSlashes(String(import.meta.env.VITE_BACKEND_URL).trim())
   : '';
 
 const isUrsassTubeFrontendHost = (() => {
@@ -9,7 +13,19 @@ const isUrsassTubeFrontendHost = (() => {
   return /(^|\.)ursasstube\.fun$/i.test(window.location.hostname);
 })();
 
-const BACKEND_URL = explicitBackendUrl || (isUrsassTubeFrontendHost ? '/api' : 'https://api.ursasstube.fun');
+const sameOriginBackendUrl =
+  typeof window !== 'undefined' && window.location?.origin
+    ? stripTrailingSlashes(window.location.origin)
+    : '';
+
+const BACKEND_URL = explicitBackendUrl
+  || (isUrsassTubeFrontendHost && sameOriginBackendUrl
+    ? sameOriginBackendUrl
+    : 'https://api.ursasstube.fun');
+
+if (!/^https?:\/\//i.test(BACKEND_URL)) {
+  logger.warn(`⚠️ BACKEND_URL is not absolute: ${BACKEND_URL}`);
+}
 logger.info(`🔗 Backend URL: ${BACKEND_URL}`);
 
 // WalletConnect v2 Project ID — get yours at https://cloud.walletconnect.com


### PR DESCRIPTION
### Motivation
- Production calls using `new URL(...)` were failing because `BACKEND_URL` could be `'/api'`, which is not an absolute base and caused `TypeError: Failed to construct 'URL'` when building leaderboard URLs.
- The goal is to ensure the frontend always composes absolute backend origins so existing API patterns like `${BACKEND_URL}/api/...` keep working and Vercel rewrites continue to apply.

### Description
- Changed `js/config.js` to normalize and prefer an explicit `VITE_BACKEND_URL` with trailing slashes removed via a new `stripTrailingSlashes` helper.
- When no env override is present and the host matches `ursasstube.fun`, the code now uses `window.location.origin` (normalized) instead of `'/api'` so `/api/*` requests become absolute origins like `https://ursasstube.fun`.
- Added a warning log if the resulting `BACKEND_URL` does not look like an absolute `http(s)` URL, and left all backend routes untouched.
- No changes were required in `js/api.js` because existing call patterns (e.g. `${BACKEND_URL}/api/leaderboard/top`) now resolve correctly with the updated `BACKEND_URL`.

### Testing
- Ran the project's syntax checks via `scripts/check-syntax.mjs`, which reported all files OK.
- Ran static analysis via `scripts/check-static-analysis.mjs`, which passed without issues.
- Pre-commit quality checks completed successfully before the change was recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00bee38d8083268c30c340a12e9783)