### PR TITLE
Use timer icon for rides reset label

### DIFF
--- a/js/store/rides-service.js
+++ b/js/store/rides-service.js
@@ -160,7 +160,7 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
     if (ridesTimer) {
       if (limited && free < 3 && currentRides.resetInMs > 0) {
         appendRidesLabel(ridesTimer, {
-          iconPosition: '-56px -28px',
+          iconPosition: '-112px -28px',
           text: `Resets in ${currentRides.resetInFormatted}`
         });
         ridesTimer.style.display = '';


### PR DESCRIPTION
### Motivation
- Align the visual cue for rides reset with the text `Resets in ...` by replacing the bell icon with the timer icon from the icon atlas.

### Description
- Updated the `appendRidesLabel` call in `js/store/rides-service.js` to use the timer frame by changing `iconPosition` from `'-56px -28px'` to `'-112px -28px'` for the rides reset label.

### Testing
- Pre-commit automated checks ran and passed: `npm run check:syntax` and `npm run check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c1dba1ac8326818c91a42c84f9f3)