### PR TITLE
Hide Connect Wallet button on Telegram preload screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3200,6 +3200,11 @@ body.telegram-mini-app .pm-mobile-connect-row {
 .app-nav-btn { width: 40px; height: 40px; min-width: 40px; min-height: 40px; border-radius: 50%; }
 .stars,.stars2 { animation: none !important; }
 body.loading-ui #walletCorner, body.loading-ui #playerCorner { opacity: 0; pointer-events: none; }
+body.is-telegram.preload-active #walletCorner,
+body.telegram-mini-app.preload-active #walletCorner {
+  opacity: 0;
+  pointer-events: none;
+}
 #rulesScreen { padding-top: calc(env(safe-area-inset-top, 0px) + 64px); }
 #gameStart .start-audio-nav {
   position: fixed;

--- a/js/game.js
+++ b/js/game.js
@@ -185,6 +185,7 @@ function ensureLoadingOverlay() {
     const progressFill = overlay.querySelector('[data-role=\"progress-fill\"]');
     const progressValue = overlay.querySelector('[data-role=\"progress-value\"]');
     if (progressFill && progressValue) {
+      document.body?.classList.add('preload-active');
       loadingOverlayElements = { overlay, progressFill, progressValue };
       return loadingOverlayElements;
     }
@@ -247,6 +248,7 @@ function ensureLoadingOverlay() {
 
   overlay.append(title, subtitle, progressWrap, progressValue);
   DOM.gameContent?.appendChild(overlay);
+  document.body?.classList.add('preload-active');
   loadingOverlayElements = { overlay, progressFill, progressValue };
   return loadingOverlayElements;
 }
@@ -261,6 +263,7 @@ function renderLoadingOverlay(progressValue) {
 function hideLoadingOverlay() {
   loadingOverlayElements?.overlay?.remove();
   loadingOverlayElements = null;
+  document.body?.classList.remove('preload-active');
 }
 
 const loopController = createGameLoopController({


### PR DESCRIPTION
### Motivation
- Prevent the Telegram Mini App's top-right `Connect Wallet` UI from being visible while the preload overlay is shown. 
- Provide a stable DOM hook for preload state so UI can be scoped safely for Telegram-specific behavior.

### Description
- Add a `preload-active` lifecycle class on `<body>` in the preload overlay flow by updating `ensureLoadingOverlay` and `hideLoadingOverlay` in `js/game.js`. 
- Add Telegram-scoped CSS rules in `css/style.css` (`body.is-telegram.preload-active #walletCorner` and `body.telegram-mini-app.preload-active #walletCorner`) to hide `#walletCorner` while the preload overlay is active. 
- Changes are limited to `js/game.js` and `css/style.css` and do not alter other auth or wallet flows.

### Testing
- Ran pre-commit automated checks which executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed. 
- Project static analysis and syntax guardrails passed during the commit hook (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d9dff3888326b1ef7b25ad56065f)