### PR TITLE
Fix Phaser atlas loading for bonus and obstacles

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -195,8 +195,8 @@ class EntityRenderer {
       });
     });
     scene.load.atlas(COIN_ATLAS_KEY, assetUrl('assets/coin_atlas.webp'), assetUrl('assets/coin_atlas_phaser.json'));
-    scene.load.atlas(BONUS_ATLAS_KEY, assetUrl('assets/bonus_atlas.webp'), assetUrl('assets/bonus_atlas_phaser.json'));
-    scene.load.atlas('obstacles_atlas', assetUrl('assets/obstacles_atlas.webp'), assetUrl('assets/obstacles_atlas_phaser.json'));
+    scene.load.multiatlas(BONUS_ATLAS_KEY, assetUrl('assets/bonus_atlas_phaser.json'), assetUrl('assets/'));
+    scene.load.multiatlas('obstacles_atlas', assetUrl('assets/obstacles_atlas_phaser.json'), assetUrl('assets/'));
     // Visual upgrade textures are generated procedurally at runtime in
     // ensureVisualUpgradeTextures(), so no static asset preload is required.
   }


### PR DESCRIPTION
### Motivation
- Multiatlas-formatted JSON for bonuses and obstacles was being loaded with `scene.load.atlas`, so Phaser did not register frames like `bull_01` and `shield_01`, causing runtime missing-frame errors.

### Description
- Updated `js/phaser/entities/EntityRenderer.js` to load `bonus_atlas` and `obstacles_atlas` with `scene.load.multiatlas(..., assetUrl('assets/'))` while keeping `coin_atlas` on `scene.load.atlas(...)`, and did not change texture keys or frame names.

### Testing
- Pre-commit automated checks ran during the change (`npm run check:syntax` and `npm run check:static-analysis`) and both checks passed.
- Local static validation confirmed the modified file and checks; runtime browser verification of Phaser frame errors was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d9f4eb448326b18bb2f1bbe69a5c)