### PR TITLE
Refresh player stats for Telegram users on return to main menu

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -9,7 +9,7 @@ import { DOM, getGameplayProgressSnapshot } from './state.js';
 import { WC } from './walletconnect.js';
 import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGameOverLeaderboardNotice, setGameOverPrompt } from './ui.js';
 import { validatePlayerInsights, getRankBucket } from './game/leaderboard-insights.js';
-import { isTelegramAuthMode, hasWalletAuthSession, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot, isTelegramMiniApp } from './features/auth/index.js';
+import { isTelegramAuthMode, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot, isTelegramMiniApp } from './features/auth/index.js';
 import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './features/store/index.js';
 
 const SAVE_RESULT_STATUS = Object.freeze({
@@ -127,7 +127,7 @@ async function refreshPlayerStats(options = {}) {
 
   const { refreshLeaderboard = false, leaderboardCooldownMs = 5000 } = options || {};
   refreshPlayerStatsInFlight = runRefreshPlayerStats({
-    hasWalletAuthSession,
+    hasAuthenticatedSession,
     getPrimaryAuthIdentifier,
     resetWalletPlayerUI,
     fetchMyProfile,

--- a/js/player-stats.js
+++ b/js/player-stats.js
@@ -27,7 +27,7 @@ function applyWalletProfile(profile) {
 }
 
 async function runRefreshPlayerStats({
-  hasWalletAuthSession,
+  hasAuthenticatedSession,
   getPrimaryAuthIdentifier,
   resetWalletPlayerUI,
   fetchMyProfile,
@@ -38,7 +38,7 @@ async function runRefreshPlayerStats({
   setLastLeaderboardRefreshAt
 }) {
   const primaryId = getPrimaryAuthIdentifier();
-  if (!hasWalletAuthSession() || !primaryId) {
+  if (!hasAuthenticatedSession() || !primaryId) {
     try {
       DOM.walletInfo?.classList.remove('visible');
       resetWalletPlayerUI();


### PR DESCRIPTION
### Motivation
- Telegram-authenticated users did not have their rank/score/coins refreshed when returning to the main menu because the refresh guard required a wallet-only session.

### Description
- Replaced wallet-only guard with authenticated-session guard by changing `hasWalletAuthSession` → `hasAuthenticatedSession` in `runRefreshPlayerStats` (file `js/player-stats.js`).
- Updated `js/api.js` to import `hasAuthenticatedSession` and pass it into `runRefreshPlayerStats` when calling `refreshPlayerStats`.
- Updated the guard inside `runRefreshPlayerStats` to call `hasAuthenticatedSession()` before applying profile UI updates and leaderboard refresh.
- Removed the now-unused `hasWalletAuthSession` import from `js/api.js` to satisfy static analysis.

### Testing
- Ran `npm run -s check:syntax`, which completed successfully.
- Pre-commit static analysis (`check:static-analysis`) ran automatically and passed.
- Changes were committed after the checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00dba67b388326bdbccaf6d69b5554)