### PR TITLE
Center icon glyphs inside round audio/back buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1035,6 +1035,21 @@ body.start-launching #walletCorner {
 .game-audio-btn:active { transform: scale(0.88); }
 .game-audio-btn.muted { opacity: 0.35; border-color: rgba(255,255,255,.05); }
 
+
+/* Icon glyph centering for round nav buttons */
+.app-audio-btn,
+.game-audio-btn {
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.app-back-btn,
+.pm-back-btn {
+  font-family: "Inter", "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+}
+
 /* ===== GAME OVER ===== */
 #gameOver {
   display: none;


### PR DESCRIPTION
### Motivation
- Emoji and arrow glyphs inside circular audio and back buttons were rendering off-center on some platforms, so they need a consistent font fallback and normalized `line-height` to visually center them.

### Description
- Added CSS in `css/style.css` to apply an emoji-capable font stack and `line-height: 1` to `.app-audio-btn` and `.game-audio-btn`, and a symbol-friendly font stack with `line-height: 1` to `.app-back-btn` and `.pm-back-btn` to ensure glyphs are vertically centered.

### Testing
- Pre-commit hooks executed automated checks including `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00dbedb7ac8326afcfa32831839432)