### PR TITLE
Normalize Shield Start button label capitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
       </div>
       <div class="store-tiers">
         <div class="store-tier" id="store-shield-0" data-upgrade-key="shield" data-upgrade-tier="0">
-          <div class="store-tier-label">start shield</div>
+          <div class="store-tier-label">Start shield</div>
           <div class="store-tier-price"><span class="icon-atlas icon-coin-gold-sm" aria-hidden="true"></span> 400</div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Ensure consistent UI copy style in the store by capitalizing the word `Start` in the Shield Start purchase button label.

### Description
- Replace `start shield` with `Start shield` in `index.html` for the Shield Start store tier label.

### Testing
- Pre-commit hooks executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f3d7e0c08326ac285aecf42978b5)