### PR TITLE
Add missing WalletConnect favicon asset under public/img

### DIFF
--- a/public/img/favicon.svg
+++ b/public/img/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="URSAS favicon">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#7f5cff"/>
+      <stop offset="1" stop-color="#45d4ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0f1020"/>
+  <circle cx="32" cy="32" r="20" fill="url(#g)"/>
+  <path d="M22 24v14c0 7 4 12 10 12s10-5 10-12V24h-6v14c0 3-1 6-4 6s-4-3-4-6V24z" fill="#0f1020"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Fix the CI `check:asset-paths` failure caused by `js/walletconnect.js` referencing `/img/favicon.svg` which was missing from `public/`.

### Description
- Add the file `public/img/favicon.svg` (an inline SVG favicon) so the `/img/favicon.svg` reference resolves to an existing public asset.

### Testing
- Ran `node scripts/check-public-asset-paths.mjs` which now passes, and pre-commit hooks executed `check:syntax` and `check:static-analysis` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fa5d92fc83268de0cf7a7b672fb2)