### PR TITLE
Implement deterministic onboarding step orchestration

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -1,39 +1,8 @@
 const GIFT_INDICATOR_ID = 'onboardingGiftIndicator';
 
-function findCoinsAnchor() {
-  const gold = document.getElementById('goldVal');
-  if (gold?.parentElement) return gold.parentElement;
-  return document.querySelector('.coins-row') || null;
-}
-
 function unmountGiftIndicator() {
   const node = document.getElementById(GIFT_INDICATOR_ID);
   if (node?.parentElement) node.parentElement.removeChild(node);
 }
 
-function mountGiftIndicator({ label = '🎁 Radar gift', onClick } = {}) {
-  if (typeof document === 'undefined') return false;
-  const anchor = findCoinsAnchor();
-  if (!anchor) return false;
-
-  let btn = document.getElementById(GIFT_INDICATOR_ID);
-  if (!btn) {
-    btn = document.createElement('button');
-    btn.type = 'button';
-    btn.id = GIFT_INDICATOR_ID;
-    btn.className = 'ui-btn ui-btn--ghost onboarding-gift-indicator';
-    btn.style.marginTop = '6px';
-    btn.style.display = 'inline-flex';
-    btn.style.alignItems = 'center';
-    btn.style.gap = '6px';
-    anchor.parentElement?.appendChild(btn);
-  }
-
-  btn.textContent = String(label);
-  btn.onclick = () => {
-    if (typeof onClick === 'function') onClick();
-  };
-  return true;
-}
-
-export { mountGiftIndicator, unmountGiftIndicator };
+export { unmountGiftIndicator };

--- a/js/features/onboarding/hooks.js
+++ b/js/features/onboarding/hooks.js
@@ -27,8 +27,13 @@ function showGameOverPlayAgainHook(text) {
   }, { source: 'preview', runToken: null });
 }
 
+function clearGameOverOnboardingHook() {
+  return setGameOverPrompt(null, { source: 'preview', runToken: null });
+}
+
 export {
   hideMenuStartHook,
   showMenuStartHook,
-  showGameOverPlayAgainHook
+  showGameOverPlayAgainHook,
+  clearGameOverOnboardingHook
 };

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -1,30 +1,29 @@
 import { fetchOnboardingState } from './onboarding-service.js';
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
-import { showMenuStartHook, hideMenuStartHook, showGameOverPlayAgainHook } from './hooks.js';
-import { mountGiftIndicator, unmountGiftIndicator } from './gift-indicator.js';
-import { showStore } from '../../ui.js';
+import { showMenuStartHook, hideMenuStartHook, showGameOverPlayAgainHook, clearGameOverOnboardingHook } from './hooks.js';
+import { hideSpotlight, showSpotlight } from './spotlight.js';
+import { unmountGiftIndicator } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { trackAnalyticsEvent } from '../../analytics.js';
+import { hasAuthenticatedSession } from '../auth/index.js';
+
+const STEP = Object.freeze({
+  AUTH_START: 'auth_start',
+  AUTH_MENU: 'auth_menu',
+  AFTER_FIRST_RUN: 'after_first_run',
+  AFTER_SECOND_RUN: 'after_second_run',
+  AFTER_THIRD_RUN: 'after_third_run',
+  STORE_INTRO: 'store_intro',
+  STORE_RIDE_PACK: 'store_ride_pack',
+  STORE_BACK: 'store_back',
+  COMPLETED: 'completed'
+});
 
 let onboardingState = { ...DEFAULT_ONBOARDING_STATE };
-
+let currentScreen = 'menu';
 
 const COMPLETED_EVENT_KEY = 'ursas.onboarding.completed.event.v1';
-
-function trackOnboardingCompletedOnce() {
-  if (!onboardingState.completed) return;
-  if (typeof sessionStorage === 'undefined') return;
-  if (sessionStorage.getItem(COMPLETED_EVENT_KEY) === '1') return;
-  trackOnboardingStepEvent('onboarding_completed', {
-    onboarding_step: String(onboardingState.step || 'completed')
-  });
-  sessionStorage.setItem(COMPLETED_EVENT_KEY, '1');
-}
-
-function getOnboardingStateSnapshot() {
-  return { ...onboardingState };
-}
-
+const skippedSteps = new Set();
 
 function trackOnboardingStepEvent(eventName, extra = {}) {
   trackAnalyticsEvent(eventName, {
@@ -33,79 +32,113 @@ function trackOnboardingStepEvent(eventName, extra = {}) {
   });
 }
 
-function resolveUiActionByStep(step) {
-  const normalizedStep = String(step || '').toLowerCase();
-  if (normalizedStep.includes('auth_menu') || normalizedStep.includes('start') || normalizedStep === 'step_1') {
-    return { type: 'menu_hook', text: 'Take the lead' };
-  }
-  if (normalizedStep.includes('after_first_run') || normalizedStep === 'step_2') {
-    return { type: 'game_over_hook', text: 'Run again. Get +100 silver' };
-  }
-  if (normalizedStep.includes('after_second_run') || normalizedStep === 'step_3') {
-    return { type: 'game_over_hook', text: 'One more run. Get +100 gold' };
-  }
-  if (normalizedStep.includes('after_third_run') || normalizedStep === 'step_4') {
-    return { type: 'game_over_hook', text: 'Connect X for more rewards' };
-  }
-  if (normalizedStep.includes('radar') || normalizedStep.includes('gift') || normalizedStep === 'step_5') {
-    return { type: 'radar_gift' };
-  }
-  return { type: 'none' };
+function hideAllOnboardingUi() {
+  hideMenuStartHook();
+  clearGameOverOnboardingHook();
+  hideSpotlight();
+  unmountGiftIndicator();
+}
+
+function resolveMappedStep(step) {
+  const normalized = String(step || '').trim().toLowerCase();
+  return Object.values(STEP).includes(normalized) ? normalized : 'unknown';
+}
+
+function shouldHideForGuest() {
+  return !hasAuthenticatedSession();
+}
+
+function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) {
+  const target = document.querySelector(selector);
+  if (!target) return false;
+  return showSpotlight({
+    target,
+    text,
+    showSkip,
+    onSkip: () => {
+      skippedSteps.add(resolveMappedStep(onboardingState.step));
+      trackOnboardingStepEvent('onboarding_step_skipped');
+    },
+    onTargetClick: () => {
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
+      target.click?.();
+    }
+  });
+}
+
+function trackOnboardingCompletedOnce() {
+  if (!onboardingState.completed) return;
+  if (typeof sessionStorage === 'undefined') return;
+  if (sessionStorage.getItem(COMPLETED_EVENT_KEY) === '1') return;
+  trackOnboardingStepEvent('onboarding_completed', { onboarding_step: String(onboardingState.step || STEP.COMPLETED) });
+  sessionStorage.setItem(COMPLETED_EVENT_KEY, '1');
 }
 
 function applyOnboardingUiState() {
-  const action = resolveUiActionByStep(onboardingState.step);
-  if (onboardingState.completed || action.type === 'none') {
-    hideMenuStartHook();
-    unmountGiftIndicator();
+  hideAllOnboardingUi();
+
+  const step = resolveMappedStep(onboardingState.step);
+  if (onboardingState.completed || step === STEP.COMPLETED || step === 'unknown' || shouldHideForGuest()) {
     trackOnboardingCompletedOnce();
     return;
   }
+  if (skippedSteps.has(step)) return;
 
-  trackOnboardingStepEvent('onboarding_step_shown', {
-    presentation: action.type
-  });
+  trackOnboardingStepEvent('onboarding_step_shown', { presentation: step, screen: currentScreen });
 
-  if (action.type === 'menu_hook') {
-    unmountGiftIndicator();
-    showMenuStartHook(action.text);
+  if ((step === STEP.AUTH_START || step === STEP.AUTH_MENU) && currentScreen === 'menu') {
+    showMenuStartHook('Take the lead');
     return;
   }
-
-
-  if (action.type === 'radar_gift') {
-    hideMenuStartHook();
-    mountGiftIndicator({
-      label: '🎁 FREE RADAR',
-      onClick: () => {
-        trackOnboardingStepEvent('onboarding_step_clicked', { target: 'gift_indicator' });
-        trackOnboardingStepEvent('radar_gift_prompt_shown', { source: 'gift_indicator_click' });
-        showStore();
-      }
-    });
+  if (step === STEP.AFTER_FIRST_RUN && currentScreen === 'game-over') {
+    showGameOverPlayAgainHook('Run again. Get +100 silver');
     return;
   }
-
-  hideMenuStartHook();
-  if (action.type === 'game_over_hook') {
-    showGameOverPlayAgainHook(action.text);
+  if (step === STEP.AFTER_SECOND_RUN && currentScreen === 'game-over') {
+    showGameOverPlayAgainHook('One more run. Get +100 gold');
+    return;
   }
+  if (step === STEP.AFTER_THIRD_RUN && currentScreen === 'game-over') {
+    showGameOverPlayAgainHook('Connect X for more rewards');
+    return;
+  }
+  if (step === STEP.STORE_INTRO && currentScreen === 'menu') {
+    showSpotlightBySelector({ selector: '#storeBtn', text: 'Upgrade your runs', showSkip: true });
+    return;
+  }
+  if (step === STEP.STORE_RIDE_PACK && currentScreen === 'store') {
+    showSpotlightBySelector({ selector: '#store-ride-pack-3, #store-rides_pack', text: '', showSkip: true });
+    return;
+  }
+  if (step === STEP.STORE_BACK) {
+    if (currentScreen === 'store') {
+      showSpotlightBySelector({ selector: '#storeBackBtn', text: '', showSkip: true });
+      return;
+    }
+    if (currentScreen === 'menu') {
+      showSpotlightBySelector({ selector: '#startBtn', text: 'You’re ready. Start again.', showSkip: false });
+    }
+  }
+}
+
+async function refreshOnboardingState({ reason = 'manual' } = {}) {
+  const remote = await fetchOnboardingState();
+  if (remote) onboardingState = writeCachedOnboardingState(remote);
+  applyOnboardingUiState();
+  logger.info('🧭 Onboarding refreshed', { reason, step: onboardingState.step, completed: onboardingState.completed, screen: currentScreen });
+  return { ...onboardingState };
+}
+
+function applyOnboardingForScreen(screen) {
+  currentScreen = String(screen || currentScreen || 'menu');
+  applyOnboardingUiState();
 }
 
 async function initOnboardingFeature() {
   onboardingState = readCachedOnboardingState();
-  const remote = await fetchOnboardingState();
-  if (remote) {
-    onboardingState = writeCachedOnboardingState(remote);
-  }
-
-  applyOnboardingUiState();
-
-  logger.info('🧭 Onboarding initialized', {
-    step: onboardingState.step,
-    completed: onboardingState.completed
-  });
-  return getOnboardingStateSnapshot();
+  await refreshOnboardingState({ reason: 'init' });
+  logger.info('🧭 Onboarding initialized', { step: onboardingState.step, completed: onboardingState.completed });
+  return { ...onboardingState };
 }
 
-export { initOnboardingFeature };
+export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen };

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -15,7 +15,7 @@ import { trackAnalyticsEvent } from '../analytics.js';
 import { initAiMode } from '../ai-mode.js';
 import { shouldShowFirstRunHint } from './onboarding-hints.js';
 import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } from '../features/player-menu/index.js';
-import { initOnboardingFeature } from '../features/onboarding/index.js';
+import { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen } from '../features/onboarding/index.js';
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { identifyPostHogUser, resetPostHogUser } from '../integrations/posthog/index.js';
 import { trackTelegramEvent } from '../telegram-analytics.js';
@@ -282,7 +282,9 @@ function bindUiEventHandlers({ startGame, restartFromGameOver, goToMainMenu, sho
     'toggle-music': toggleMusicMute,
     'show-store': () => {
       trackTelegramEvent('upload_opened');
-      return showStore();
+      const result = showStore();
+      refreshOnboardingState({ reason: 'store_open_click' }).catch(() => {});
+      return result;
     },
     'start-game': wrappedStartGame
   };
@@ -306,6 +308,7 @@ function bindUiEventHandlers({ startGame, restartFromGameOver, goToMainMenu, sho
           onConnected: () => {
             invalidateProfileCache();
             updateGameOverShareButton();
+            refreshOnboardingState({ reason: 'share_connect_x' }).catch(() => {});
           }
         });
         return;
@@ -324,6 +327,7 @@ function bindUiEventHandlers({ startGame, restartFromGameOver, goToMainMenu, sho
             invalidateProfileCache();
             updateGameOverShareButton();
             refreshPlayerStats({ refreshLeaderboard: true }).catch(() => {});
+            refreshOnboardingState({ reason: 'share_confirmed' }).catch(() => {});
           }
         });
       } finally {
@@ -474,6 +478,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
   logger.info('🔐 Authenticating...');
   await initAuth();
   await initOnboardingFeature();
+  refreshOnboardingState({ reason: 'auth' }).catch(() => {});
   updateStartHook().catch(() => {});
   syncFirstRunOnboardingUiState();
 
@@ -519,10 +524,19 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
 
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
     const screen = event.detail?.screen;
+    applyOnboardingForScreen(screen);
     if (screen === 'game-over') {
       invalidateProfileCache();
       updateGameOverShareButton().catch(() => {});
+      refreshOnboardingState({ reason: 'run_finished' }).catch(() => {});
     }
+    if (screen === 'store') {
+      refreshOnboardingState({ reason: 'store_open' }).catch(() => {});
+    }
+  });
+
+  window.addEventListener('ursas:onboarding-store-buy', () => {
+    refreshOnboardingState({ reason: 'store_buy' }).catch(() => {});
   });
 
   initializeMetaMaskIntegration({

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -438,6 +438,12 @@ export function createUpgradesService({
         const silverEl = document.getElementById('walletSilver');
         if (goldEl) goldEl.textContent = playerBalance.gold;
         if (silverEl) silverEl.textContent = playerBalance.silver;
+
+        if (typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('ursas:onboarding-store-buy', {
+            detail: { upgradeKey: key, tier, timestamp: Date.now() }
+          }));
+        }
       } else {
         const serverError = data && data.error ? data.error : 'Purchase failed';
         const isConflict = isAlreadyPurchasedError(serverError);


### PR DESCRIPTION
### Motivation
- The previous onboarding used fragile `step.includes(...)` checks and produced non-deterministic overlays that diverged from backend onboarding state.
- The frontend must follow explicit backend `currentStep` values, avoid showing guest overlays, and resume/refresh reliably after auth, runs, share/X connect, and store interactions.
- The change centralizes hiding/cleanup of onboarding UI and introduces per-step skip memory so users can skip spotlights without altering backend progress.

### Description
- Replace fuzzy branching with an explicit `STEP` map and deterministic orchestrator in `js/features/onboarding/index.js`, adding `refreshOnboardingState`, `applyOnboardingForScreen`, skip handling, guest gating, and consolidated `hideAllOnboardingUi` logic.
- Map backend steps to concrete UI actions: `auth_start`/`auth_menu` → menu start hook (`Take the lead`), `after_first_run` → game-over replay hook (`Run again. Get +100 silver`), `after_second_run` → game-over replay hook (`One more run. Get +100 gold`), `after_third_run` → game-over replay hook (`Connect X for more rewards`), `store_intro` → spotlight `#storeBtn` (`Upgrade your runs`, includes Skip), `store_ride_pack` → in-store spotlight targeting `#store-ride-pack-3` (fallback to `#store-rides_pack`, Skip, no text), `store_back` → spotlight `#storeBackBtn` in-store then `#startBtn` on menu with `You’re ready. Start again.`, and `completed` → hide all onboarding UI.
- Add `clearGameOverOnboardingHook` to `js/features/onboarding/hooks.js` and simplify gift indicator to only export `unmountGiftIndicator` to satisfy static analysis and central cleanup.
- Wire lifecycle refreshes and screen-aware application in `js/game/bootstrap.js` so onboarding state is re-fetched after auth, run finished (game-over), share/X connect, store open/click, and on a store purchase event, and call `applyOnboardingForScreen` on `SCREEN_CHANGED_EVENT`.
- Emit a `ursas:onboarding-store-buy` custom event from `js/store/upgrades-service.js` after successful purchase so the frontend refreshes onboarding state immediately after buys.

### Testing
- Ran `npm run -s lint` and pre-commit quality checks, with `check:syntax` succeeding and static analysis (`check:static-analysis`) passing.
- Static analysis guardrails (unused exports / module thresholds) passed after gift indicator simplification.
- No other unit tests were modified; integration of onboarding refresh hooks was validated by running the lint/static checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0102fe44c48326addffdd8a9b02ac9)