### PR TITLE
Fix obstacles_atlas loading and register obstacle frames explicitly

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -39,6 +39,8 @@ const BONUS_TEXTURES = {
 };
 const OBSTACLE_TEXTURES = { fence: 'fence', rock1: 'rock', rock2: 'rock', bull: 'bull', wall_brick: 'bricks', wall_kactus: 'cactus', tree: 'tree', pit: 'hole', spikes: 'spikes', bottles: 'bottles' };
 const OBSTACLE_ANIM_FRAMES = 6;
+const OBSTACLE_FRAME_SIZE = 128;
+const OBSTACLE_ATLAS_ROWS = ['tree', 'rock', 'spikes', 'hole', 'fence', 'cactus', 'bull', 'bricks', 'bottles'];
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
 const BONUS_ATLAS_KEY = 'bonus_atlas';
@@ -176,6 +178,17 @@ function projectPolar(angle, z, viewport, tube, radiusFactor = 0.65) {
     curveOcclusion,
   };
 }
+function ensureObstacleAtlasFrames(scene) {
+  const texture = scene?.textures?.get('obstacles_atlas');
+  if (!texture || texture.has('hole_06')) return;
+  OBSTACLE_ATLAS_ROWS.forEach((prefix, row) => {
+    for (let col = 0; col < OBSTACLE_ANIM_FRAMES; col += 1) {
+      const frameName = `${prefix}_${String(col + 1).padStart(2, '0')}`;
+      if (texture.has(frameName)) continue;
+      texture.add(frameName, 0, col * OBSTACLE_FRAME_SIZE, row * OBSTACLE_FRAME_SIZE, OBSTACLE_FRAME_SIZE, OBSTACLE_FRAME_SIZE);
+    }
+  });
+}
 function getBonusFrame(item) {
   const bonusPrefix = BONUS_TEXTURES[item.type] || BONUS_TEXTURES[BONUS_TYPES.SHIELD];
   const frameNumber = ((Number(item.animFrame) || 0) % BONUS_ANIM_FRAMES) + 1;
@@ -196,7 +209,7 @@ class EntityRenderer {
     });
     scene.load.atlas(COIN_ATLAS_KEY, assetUrl('assets/coin_atlas.webp'), assetUrl('assets/coin_atlas_phaser.json'));
     scene.load.multiatlas(BONUS_ATLAS_KEY, assetUrl('assets/bonus_atlas_phaser.json'), assetUrl('assets/'));
-    scene.load.multiatlas('obstacles_atlas', assetUrl('assets/obstacles_atlas_phaser.json'), assetUrl('assets/'));
+    scene.load.image('obstacles_atlas', assetUrl('assets/obstacles_atlas.webp'));
     // Visual upgrade textures are generated procedurally at runtime in
     // ensureVisualUpgradeTextures(), so no static asset preload is required.
   }
@@ -224,9 +237,11 @@ class EntityRenderer {
     this.playerEyesGlow = null;
     this.collectEffectSeenIds = new Set();
     this.collectEffectSprites = new Set();
+    this.missingObstacleFrameWarned = false;
   }
   create() {
     ensureVisualUpgradeTextures(this.scene);
+    ensureObstacleAtlasFrames(this.scene);
     this.root = this.scene.add.container(0, 0).setDepth(14);
     this.objectLayer = this.scene.add.container(0, 0).setDepth(14);
     this.playerLayer = this.scene.add.container(0, 0).setDepth(15);

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -313,7 +313,13 @@ function renderObjectsPass(renderer, deps) {
       obstacleLayer.add(shadow);
       const obstacleFrame = ((Number(item.animFrame) || 0) % 6) + 1;
       const obstacleFrameName = `${textureKey}_${String(obstacleFrame).padStart(2, '0')}`;
-      sprite.setTexture('obstacles_atlas', obstacleFrameName);
+      const obstacleTexture = renderer.scene.textures.get('obstacles_atlas');
+      if (obstacleTexture?.has(obstacleFrameName)) {
+        sprite.setTexture('obstacles_atlas', obstacleFrameName);
+      } else if (!renderer.missingObstacleFrameWarned) {
+        console.warn(`[EntityRenderer] Missing obstacle frame in obstacles_atlas: ${obstacleFrameName}`);
+        renderer.missingObstacleFrameWarned = true;
+      }
       sprite.setPosition(projection.x, projection.y);
       sprite.setDisplaySize(size, size);
       const radarAlpha = radarPreviewActive ? (0.84 + 0.16 * radarPulse) : 1;


### PR DESCRIPTION
### Motivation
- Исправить проблему с отсутствующими named frames (например `hole_06`, `bottles_01`) у `obstacles_atlas`, из-за которой Phaser рендерил весь атлас вместо отдельных кадров. 
- Не менять логику игрового баланса, коллизий, спавна или бэкенд-части — правки ограничены только загрузкой/регистрацией кадров атласа.

### Description
- Заменил загрузку `obstacles_atlas` из `multiatlas` на прямую загрузку изображения через `scene.load.image('obstacles_atlas', assetUrl('assets/obstacles_atlas.webp'))` в `EntityRenderer.preload`.
- Добавил константы `OBSTACLE_FRAME_SIZE = 128` и `OBSTACLE_ATLAS_ROWS = ['tree','rock','spikes','hole','fence','cactus','bull','bricks','bottles']` и функцию `ensureObstacleAtlasFrames(scene)` для явной регистрации фреймов 6x по строкам/столбцам сетки `128x128` в текстуру через `texture.add(...)`.
- Вызвал `ensureObstacleAtlasFrames(this.scene)` в `EntityRenderer.create()` сразу после `ensureVisualUpgradeTextures(this.scene)` и до создания пулов/использования спрайтов.
- Добавил безопасную проверку перед `setTexture` в `renderObjectsPass` и одноразовый `console.warn` (`renderer.missingObstacleFrameWarned`) если фрейм всё ещё отсутствует, чтобы не ломать игру при редкой ошибке кадра.
- Изменённые файлы: `js/phaser/entities/EntityRenderer.js`, `js/phaser/entities/entity-render-passes.js`.

### Testing
- Запущены pre-commit проверки синтаксиса через `npm run check:syntax`, которые прошли успешно.
- Выполнена статическая проверка через `npm run check:static-analysis`, которая прошла успешно.
- Код собран и линтеры / статический-анализ не выявили регрессий после правок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0103c502bc8326a6b46beb106be6ac)