### PR TITLE
Integrate Store onboarding continuation with stable 3-rides target

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@
         <span class="store-item-name"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-112px -84px"></span> Rides — pack of rides</span>
         <span class="store-item-currency"><span class="icon-atlas icon-coin-gold" aria-hidden="true"></span> GOLD</span>
       </div>
-      <button class="store-single-buy ui-btn ui-btn--secondary ui-btn--sm" id="store-rides_pack" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <span class="icon-atlas icon-coin-gold-sm" aria-hidden="true"></span> 70
+      <button class="store-single-buy ui-btn ui-btn--secondary ui-btn--sm" id="store-ride-pack-3" data-upgrade-key="rides_pack" data-upgrade-tier="0"> + 3 rides — <span class="icon-atlas icon-coin-gold-sm" aria-hidden="true"></span> 70
       </button>
     </div>
 

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -107,7 +107,7 @@ function applyOnboardingUiState() {
     return;
   }
   if (step === STEP.STORE_RIDE_PACK && currentScreen === 'store') {
-    showSpotlightBySelector({ selector: '#store-ride-pack-3, #store-rides_pack', text: '', showSkip: true });
+    showSpotlightBySelector({ selector: '#store-ride-pack-3', text: '', showSkip: true });
     return;
   }
   if (step === STEP.STORE_BACK) {

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -1,5 +1,5 @@
 import { BACKEND_URL } from '../../config.js';
-import { requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ } from '../../request.js';
+import { requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ, REQUEST_PROFILE_STORE_WRITE } from '../../request.js';
 import { logger } from '../../logger.js';
 import { normalizeOnboardingState } from './onboarding-state.js';
 
@@ -19,4 +19,22 @@ async function fetchOnboardingState() {
   }
 }
 
-export { fetchOnboardingState };
+async function postOnboardingEvent(eventName) {
+  const normalizedEventName = String(eventName || '').trim();
+  if (!normalizedEventName) return false;
+
+  try {
+    const { ok } = await requestJsonResult(buildOnboardingStateUrl().replace('/state', '/event'), {
+      ...REQUEST_PROFILE_STORE_WRITE,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: normalizedEventName })
+    });
+    return Boolean(ok);
+  } catch (error) {
+    logger.warn('⚠️ onboarding event post failed', { event: normalizedEventName, error });
+    return false;
+  }
+}
+
+export { fetchOnboardingState, postOnboardingEvent };

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -6,6 +6,8 @@ import { renderStoreCurrencyButton } from './rides-service.js';
 import { notifyError, notifyWarn } from '../notifier.js';
 import { updateAiAccessFromBackendPayload } from '../ai-mode.js';
 import { trackUpgradePurchaseAnalytics } from './store-analytics.js';
+import { postOnboardingEvent } from '../features/onboarding/onboarding-service.js';
+import { refreshOnboardingState } from '../features/onboarding/index.js';
 import {
   parseNumericLevel,
   parseSpinAlertLevel,
@@ -303,7 +305,7 @@ export function createUpgradesService({
     }
 
 
-    const ridesBtn = document.getElementById('store-rides_pack');
+    const ridesBtn = document.getElementById('store-ride-pack-3');
     if (ridesBtn) {
       ridesBtn.classList.remove('purchased');
       ridesBtn.style.opacity = '';
@@ -443,6 +445,10 @@ export function createUpgradesService({
           window.dispatchEvent(new CustomEvent('ursas:onboarding-store-buy', {
             detail: { upgradeKey: key, tier, timestamp: Date.now() }
           }));
+        }
+        if (key === 'rides_pack') {
+          await postOnboardingEvent('ride_pack_bought');
+          await refreshOnboardingState({ reason: 'ride_pack_bought' });
         }
       } else {
         const serverError = data && data.error ? data.error : 'Purchase failed';

--- a/js/ui.js
+++ b/js/ui.js
@@ -8,6 +8,7 @@ import { showStoreScreen, hideStoreScreen } from './screens.js';
 import { logger } from './logger.js';
 import { notifyWarn } from './notifier.js';
 import { trackAnalyticsEvent } from './analytics.js';
+import { refreshOnboardingState } from './features/onboarding/index.js';
 
 const uiTextCache = {
   distance: '',
@@ -70,6 +71,7 @@ function showStore() {
   trackAnalyticsEvent('store_opened', {
     coins_gold: Number(gameState?.goldCoins || 0)
   });
+  refreshOnboardingState({ reason: 'store_open_manual' }).catch(() => {});
 }
 
 function hideStore() {


### PR DESCRIPTION
### Motivation
- The Store onboarding step must reliably highlight the existing "+3 rides" pack and progress automatically after purchase, and it must resume if the player opens the Store manually.

### Description
- Add a stable DOM id for the 3-rides button: set `id="store-ride-pack-3"` in `index.html` so onboarding can target it reliably.
- Update Store rendering to bind the rides CTA to `#store-ride-pack-3` and keep the purchase handler `buyUpgrade('rides_pack', 0)` intact in `js/store/upgrades-service.js`.
- Change onboarding spotlight mapping to target only `#store-ride-pack-3` for the `store_ride_pack` step with empty instructional text and `showSkip: true` in `js/features/onboarding/index.js` so the spotlight darkens and highlights the pack without extra text.
- Add `postOnboardingEvent(eventName)` in `js/features/onboarding/onboarding-service.js` to POST onboarding events to `/api/onboarding/event` and export it for use by the client.
- On successful `rides_pack` purchase, send `ride_pack_bought` via `postOnboardingEvent(...)` and call `refreshOnboardingState(...)` to ensure onboarding advances and remains completed after reload in `js/store/upgrades-service.js`.
- Trigger `refreshOnboardingState({ reason: 'store_open_manual' })` when the Store is opened manually so Store-related onboarding resumes immediately in `js/ui.js`.

### Testing
- Ran `npm run check:syntax`, which completed successfully and validated updated modules.
- Pre-commit checks executed during the commit ran `npm run check:syntax` and `npm run check:static-analysis`, both of which passed.
- An attempt to run `npm run check-syntax` (without the colon) failed due to a missing script name, but this was replaced by the correct `npm run check:syntax` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0104621d5c8326a506830a02ed608e)