### PR TITLE
Finish radar gift onboarding flow

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -1,8 +1,62 @@
 const GIFT_INDICATOR_ID = 'onboardingGiftIndicator';
+const BOOSTS_ID = 'onboardingActiveRadarBoosts';
+
+function ensureStyles() {
+  if (document.getElementById('onboardingGiftIndicatorStyles')) return;
+  const style = document.createElement('style');
+  style.id = 'onboardingGiftIndicatorStyles';
+  style.textContent = `
+    #${GIFT_INDICATOR_ID}{position:fixed;top:90px;right:20px;z-index:9001;}
+    #${GIFT_INDICATOR_ID} .gift-btn{border:0;border-radius:999px;padding:8px 10px;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;font-weight:800;color:#111}
+    #${BOOSTS_ID}{position:fixed;top:130px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:6px}
+    #${BOOSTS_ID} .boost-pill{background:rgba(17,24,39,.9);border:1px solid rgba(251,191,36,.4);border-radius:999px;padding:4px 8px;font-size:11px;font-weight:700;color:#fde68a}
+    @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(251,191,36,.7)}70%{box-shadow:0 0 0 12px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}`;
+  document.head.appendChild(style);
+}
+
+function mountGiftIndicator({ onClick } = {}) {
+  ensureStyles();
+  unmountGiftIndicator();
+  const node = document.createElement('div');
+  node.id = GIFT_INDICATOR_ID;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'gift-btn';
+  btn.textContent = '🎁';
+  btn.title = 'Claim radar gift';
+  btn.addEventListener('click', () => onClick?.());
+  node.appendChild(btn);
+  document.body.appendChild(node);
+}
 
 function unmountGiftIndicator() {
   const node = document.getElementById(GIFT_INDICATOR_ID);
   if (node?.parentElement) node.parentElement.removeChild(node);
 }
 
-export { unmountGiftIndicator };
+function renderActiveBoostIndicators(activeBoosts = {}) {
+  const old = document.getElementById(BOOSTS_ID);
+  if (old?.parentElement) old.parentElement.removeChild(old);
+  const rows = [];
+  const now = Date.now();
+  for (const [key, label] of [['radar_obstacles_24h', '📡 Radar Obstacles'], ['radar_gold_24h', '🪙 Radar Gold']]) {
+    const boost = activeBoosts[key];
+    if (!boost?.active || !Number.isFinite(Number(boost.endsAt))) continue;
+    const remainingMs = Math.max(0, Number(boost.endsAt) - now);
+    if (remainingMs <= 0) continue;
+    const hours = Math.max(1, Math.ceil(remainingMs / 3600000));
+    rows.push(`${label}: ${hours}h`);
+  }
+  if (!rows.length) return;
+  const root = document.createElement('div');
+  root.id = BOOSTS_ID;
+  rows.forEach((text) => {
+    const pill = document.createElement('div');
+    pill.className = 'boost-pill';
+    pill.textContent = text;
+    root.appendChild(pill);
+  });
+  document.body.appendChild(root);
+}
+
+export { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators };

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -2,10 +2,13 @@ import { fetchOnboardingState } from './onboarding-service.js';
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
 import { showMenuStartHook, hideMenuStartHook, showGameOverPlayAgainHook, clearGameOverOnboardingHook } from './hooks.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
-import { unmountGiftIndicator } from './gift-indicator.js';
+import { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { trackAnalyticsEvent } from '../../analytics.js';
 import { hasAuthenticatedSession } from '../auth/index.js';
+import { BACKEND_URL } from '../../config.js';
+import { requestJsonResult, REQUEST_PROFILE_STORE_WRITE } from '../../request.js';
+
 
 const STEP = Object.freeze({
   AUTH_START: 'auth_start',
@@ -37,6 +40,7 @@ function hideAllOnboardingUi() {
   clearGameOverOnboardingHook();
   hideSpotlight();
   unmountGiftIndicator();
+  renderActiveBoostIndicators(onboardingState.activeBoosts || {});
 }
 
 function resolveMappedStep(step) {
@@ -64,6 +68,42 @@ function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) 
       target.click?.();
     }
   });
+}
+
+
+function getPendingRadarGift() {
+  const gifts = onboardingState.gifts || {};
+  if (gifts.radar_obstacles_24h?.unlocked && !gifts.radar_obstacles_24h?.claimed) return 'radar_obstacles_24h';
+  if (gifts.radar_gold_24h?.unlocked && !gifts.radar_gold_24h?.claimed) return 'radar_gold_24h';
+  return null;
+}
+
+async function claimOnboardingGift(reward) {
+  const url = `${String(BACKEND_URL || '').trim()}/api/onboarding/claim`;
+  const { ok } = await requestJsonResult(url, {
+    ...REQUEST_PROFILE_STORE_WRITE,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ reward })
+  });
+  if (ok) {
+    await refreshOnboardingState({ reason: 'onboarding_claim' });
+    window.dispatchEvent(new CustomEvent('ursas:onboarding-store-buy', { detail: { reward } }));
+  }
+}
+
+function applyRadarGiftStoreCard(giftKey) {
+  const map = { radar_obstacles_24h: '#store-radarobstacles-0', radar_gold_24h: '#store-radargold-0' };
+  const selector = map[giftKey];
+  if (!selector) return;
+  const card = document.querySelector(selector);
+  if (!card) return;
+  const priceEl = card.querySelector('.store-tier-price');
+  if (priceEl) priceEl.textContent = 'FREE 24H';
+  card.onclick = () => claimOnboardingGift(giftKey);
+  if (!skippedSteps.has(`gift_store_${giftKey}`)) {
+    showSpotlight({ target: selector, text: '', showSkip: true, onSkip: () => skippedSteps.add(`gift_store_${giftKey}`) });
+  }
 }
 
 function trackOnboardingCompletedOnce() {
@@ -102,6 +142,21 @@ function applyOnboardingUiState() {
     showGameOverPlayAgainHook('Connect X for more rewards');
     return;
   }
+  const pendingGift = getPendingRadarGift();
+  if (pendingGift && currentScreen === 'menu') {
+    const skippedGiftMenu = skippedSteps.has(`gift_menu_${pendingGift}`);
+    if (!skippedGiftMenu) {
+      showSpotlight({ target: '#storeBtn', text: 'Claim your free Radar', showSkip: true, onSkip: () => skippedSteps.add(`gift_menu_${pendingGift}`), onTargetClick: () => document.querySelector('#storeBtn')?.click?.() });
+    } else {
+      mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
+    }
+    return;
+  }
+  if (pendingGift && currentScreen === 'store') {
+    applyRadarGiftStoreCard(pendingGift);
+    return;
+  }
+
   if (step === STEP.STORE_INTRO && currentScreen === 'menu') {
     showSpotlightBySelector({ selector: '#storeBtn', text: 'Upgrade your runs', showSkip: true });
     return;

--- a/js/features/onboarding/onboarding-state.js
+++ b/js/features/onboarding/onboarding-state.js
@@ -3,15 +3,52 @@ const ONBOARDING_STORAGE_KEY = 'ursas.onboarding.state.v1';
 const DEFAULT_ONBOARDING_STATE = Object.freeze({
   step: 'unknown',
   completed: false,
-  updatedAt: 0
+  updatedAt: 0,
+  gifts: {
+    radar_obstacles_24h: { unlocked: false, claimed: false, skipped: false },
+    radar_gold_24h: { unlocked: false, claimed: false, skipped: false }
+  },
+  activeBoosts: {
+    radar_obstacles_24h: { active: false, endsAt: 0 },
+    radar_gold_24h: { active: false, endsAt: 0 }
+  }
 });
+
+function normalizeGiftState(input) {
+  return {
+    unlocked: Boolean(input?.unlocked),
+    claimed: Boolean(input?.claimed),
+    skipped: Boolean(input?.skipped)
+  };
+}
+
+function normalizeBoostState(input) {
+  return {
+    active: Boolean(input?.active),
+    endsAt: Number.isFinite(Number(input?.endsAt)) ? Number(input.endsAt) : 0
+  };
+}
 
 function normalizeOnboardingState(input) {
   if (!input || typeof input !== 'object') return { ...DEFAULT_ONBOARDING_STATE };
   const step = typeof input.step === 'string' && input.step.trim() ? input.step.trim() : DEFAULT_ONBOARDING_STATE.step;
   const completed = Boolean(input.completed);
   const updatedAt = Number.isFinite(Number(input.updatedAt)) ? Number(input.updatedAt) : Date.now();
-  return { step, completed, updatedAt };
+  const giftsInput = input.gifts || input.rewards || {};
+  const boostsInput = input.activeBoosts || input.active_boosts || input.effects || {};
+  return {
+    step,
+    completed,
+    updatedAt,
+    gifts: {
+      radar_obstacles_24h: normalizeGiftState(giftsInput.radar_obstacles_24h || giftsInput.radarObstacles24h || giftsInput.radarObstacles),
+      radar_gold_24h: normalizeGiftState(giftsInput.radar_gold_24h || giftsInput.radarGold24h || giftsInput.radarGold)
+    },
+    activeBoosts: {
+      radar_obstacles_24h: normalizeBoostState(boostsInput.radar_obstacles_24h || boostsInput.radarObstacles24h || boostsInput.radarObstacles),
+      radar_gold_24h: normalizeBoostState(boostsInput.radar_gold_24h || boostsInput.radarGold24h || boostsInput.radarGold)
+    }
+  };
 }
 
 function readCachedOnboardingState(storage = window?.localStorage) {


### PR DESCRIPTION
### Motivation
- Complete the radar gift onboarding UX so backend-provided radar gifts survive reload, can be skipped without being lost, and are claimable from the Store.
- Surface active 24h radar boosts on the main menu with a compact hours-only indicator that rounds up and hides after expiry.

### Description
- Extend onboarding state normalization to persist `gifts` and `activeBoosts` (keys: `radar_obstacles_24h`, `radar_gold_24h`) and add tolerant mapping for backend field variants in `js/features/onboarding/onboarding-state.js`.
- Add a small gift UI and boost pills in `js/features/onboarding/gift-indicator.js` with `mountGiftIndicator`, `unmountGiftIndicator`, and `renderActiveBoostIndicators` that show remaining time in hours (rounded up, minimum 1h) and auto-hide expired boosts.
- Update onboarding flow in `js/features/onboarding/index.js` to: detect pending radar gifts, show a `#storeBtn` spotlight on menu with text `Claim your free Radar` (Skip allowed), when skipped show a glowing gift icon under coins (gift persists until claimed), and navigate to Store when the gift icon is clicked or Store is opened manually.
- Implement Store-side handling to highlight the gift tier cards (`#store-radarobstacles-0`, `#store-radargold-0`), replace the price label with `FREE 24H`, and wire clicks to claim the gift via POST `/api/onboarding/claim` with payload `{ reward: "radar_obstacles_24h" }` or `{ reward: "radar_gold_24h" }` using existing `requestJsonResult` + `REQUEST_PROFILE_STORE_WRITE` semantics; successful claim triggers a refresh and dispatches `ursas:onboarding-store-buy` so existing store hooks continue to work.
- Preserve skip behavior inside Store (hide spotlight but keep `FREE 24H` label) and ensure the gift state is cached in localStorage so the gift survives reloads until claimed.

### Testing
- Pre-commit syntax checks were run via `npm run check:syntax` and passed.
- Static analysis checks were run via `npm run check:static-analysis` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010548b90c832692e681437deccaa2)