### PR TITLE
Fix icon atlas public asset path in manifest

### DIFF
--- a/js/assets.js
+++ b/js/assets.js
@@ -19,7 +19,7 @@ class AssetManager {
       ['character_left_swipe', 'assets/character_left_swipe.png'],
       ['character_right_swipe', 'assets/character_right_swipe.png'],
       ['character_spin', 'assets/character_spin.png'],
-      ['icon_atlas', 'img/icon_atlas.webp']
+      ['icon_atlas', '/img/icon_atlas.webp']
     ];
   }
 


### PR DESCRIPTION
### Motivation
- Asset path guardrails flagged a missing public asset for `img/icon_atlas.webp`, so the manifest must reference the asset under the `public/` URL space.

### Description
- Updated `AssetManager.getCriticalManifest()` in `js/assets.js` to reference `icon_atlas` as `/img/icon_atlas.webp` so it resolves to `public/img/icon_atlas.webp`.

### Testing
- Ran `npm run check:asset-paths`, `npm run check:static-analysis`, and `npm run check:unused-code`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0106d96ac8832686ba23ee5c33981b)