### PR TITLE
Fix onboarding frontend/backend contract mismatches

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -13,6 +13,9 @@ import { requestJsonResult, REQUEST_PROFILE_STORE_WRITE } from '../../request.js
 const STEP = Object.freeze({
   AUTH_START: 'auth_start',
   AUTH_MENU: 'auth_menu',
+  AUTH_RUN_1_DONE: 'auth_run_1_done',
+  AUTH_RUN_2_DONE: 'auth_run_2_done',
+  AUTH_RUN_3_DONE: 'auth_run_3_done',
   AFTER_FIRST_RUN: 'after_first_run',
   AFTER_SECOND_RUN: 'after_second_run',
   AFTER_THIRD_RUN: 'after_third_run',
@@ -53,10 +56,8 @@ function shouldHideForGuest() {
 }
 
 function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) {
-  const target = document.querySelector(selector);
-  if (!target) return false;
   return showSpotlight({
-    target,
+    target: selector,
     text,
     showSkip,
     onSkip: () => {
@@ -65,7 +66,6 @@ function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) 
     },
     onTargetClick: () => {
       trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
-      target.click?.();
     }
   });
 }
@@ -130,15 +130,15 @@ function applyOnboardingUiState() {
     showMenuStartHook('Take the lead');
     return;
   }
-  if (step === STEP.AFTER_FIRST_RUN && currentScreen === 'game-over') {
+  if ((step === STEP.AUTH_RUN_1_DONE || step === STEP.AFTER_FIRST_RUN) && currentScreen === 'game-over') {
     showGameOverPlayAgainHook('Run again. Get +100 silver');
     return;
   }
-  if (step === STEP.AFTER_SECOND_RUN && currentScreen === 'game-over') {
+  if ((step === STEP.AUTH_RUN_2_DONE || step === STEP.AFTER_SECOND_RUN) && currentScreen === 'game-over') {
     showGameOverPlayAgainHook('One more run. Get +100 gold');
     return;
   }
-  if (step === STEP.AFTER_THIRD_RUN && currentScreen === 'game-over') {
+  if ((step === STEP.AUTH_RUN_3_DONE || step === STEP.AFTER_THIRD_RUN) && currentScreen === 'game-over') {
     showGameOverPlayAgainHook('Connect X for more rewards');
     return;
   }

--- a/js/features/onboarding/onboarding-state.js
+++ b/js/features/onboarding/onboarding-state.js
@@ -29,9 +29,29 @@ function normalizeBoostState(input) {
   };
 }
 
+function toTimestamp(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const asNumber = Number(value);
+    if (Number.isFinite(asNumber)) return asNumber;
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+function normalizeBackendBoost(untilValue, fallbackInput) {
+  const endsAt = toTimestamp(untilValue) || toTimestamp(fallbackInput?.endsAt);
+  return {
+    active: endsAt > Date.now(),
+    endsAt
+  };
+}
+
 function normalizeOnboardingState(input) {
   if (!input || typeof input !== 'object') return { ...DEFAULT_ONBOARDING_STATE };
-  const step = typeof input.step === 'string' && input.step.trim() ? input.step.trim() : DEFAULT_ONBOARDING_STATE.step;
+  const rawStep = input.step ?? input.currentStep;
+  const step = typeof rawStep === 'string' && rawStep.trim() ? rawStep.trim() : DEFAULT_ONBOARDING_STATE.step;
   const completed = Boolean(input.completed);
   const updatedAt = Number.isFinite(Number(input.updatedAt)) ? Number(input.updatedAt) : Date.now();
   const giftsInput = input.gifts || input.rewards || {};
@@ -45,8 +65,14 @@ function normalizeOnboardingState(input) {
       radar_gold_24h: normalizeGiftState(giftsInput.radar_gold_24h || giftsInput.radarGold24h || giftsInput.radarGold)
     },
     activeBoosts: {
-      radar_obstacles_24h: normalizeBoostState(boostsInput.radar_obstacles_24h || boostsInput.radarObstacles24h || boostsInput.radarObstacles),
-      radar_gold_24h: normalizeBoostState(boostsInput.radar_gold_24h || boostsInput.radarGold24h || boostsInput.radarGold)
+      radar_obstacles_24h: normalizeBackendBoost(
+        boostsInput.radarObstaclesUntil,
+        boostsInput.radar_obstacles_24h || boostsInput.radarObstacles24h || boostsInput.radarObstacles
+      ),
+      radar_gold_24h: normalizeBackendBoost(
+        boostsInput.radarGoldUntil,
+        boostsInput.radar_gold_24h || boostsInput.radarGold24h || boostsInput.radarGold
+      )
     }
   };
 }

--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -58,7 +58,7 @@ function showSpotlight({ target, text = '', showSkip = true, onSkip, onTargetCli
   const root = ensureSpotlightRoot();
   if (!root || !target) return false;
 
-  const targetElement = document.querySelector(target);
+  const targetElement = typeof target === 'string' ? document.querySelector(target) : target;
   if (!targetElement) return false;
 
   hideSpotlight();


### PR DESCRIPTION
### Motivation
- Backend and frontend used different onboarding contracts which caused missing steps, querySelector errors, incorrect boost/gift rendering, and double-clicks from spotlight interactions.
- Normalize incoming backend payload shapes and make spotlight target handling robust to prevent runtime errors and mismatches.

### Description
- Normalize onboarding state by reading `currentStep` as a fallback to `step` and keep `step` as the frontend canonical value via `normalizeOnboardingState` (`js/features/onboarding/onboarding-state.js`).
- Parse backend boost shapes by supporting `activeBoosts.radarObstaclesUntil` and `activeBoosts.radarGoldUntil`, converting numeric or date-string timestamps into `{ active, endsAt }` with `active` only true when `endsAt > Date.now()` (added `toTimestamp` and `normalizeBackendBoost`).
- Add explicit backend run-step constants (`auth_run_1_done`, `auth_run_2_done`, `auth_run_3_done`) and map them (together with legacy `after_*` names) to the correct game-over hooks and messages (`js/features/onboarding/index.js`).
- Fix spotlight APIs: `showSpotlightBySelector()` now passes the selector string to `showSpotlight()` instead of a DOM element, `showSpotlight()` accepts either a selector string or an `HTMLElement`, and duplicate click forwarding was removed so the spotlight dispatches the native click while `onTargetClick` is reserved for analytics/side-effects (`js/features/onboarding/spotlight.js`, `js/features/onboarding/index.js`).

### Testing
- Ran repository static analysis and syntax checks via project hooks which completed successfully (`check-syntax` and `check-static-analysis`).
- Ran lint/quality pre-commit checks (`npm run -s lint` / repo quality checks) which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010817f84083268e4e52ffbda7e656)