### PR TITLE
Fix onboarding spotlight named exports

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -40,7 +40,7 @@ function getViewportRect() {
   };
 }
 
-function hideSpotlight() {
+export function hideSpotlight() {
   if (rafId) {
     cancelAnimationFrame(rafId);
     rafId = null;
@@ -54,7 +54,7 @@ function hideSpotlight() {
   spotlightRoot.innerHTML = '';
 }
 
-function showSpotlight({ target, text = '', showSkip = true, onSkip, onTargetClick } = {}) {
+export function showSpotlight({ target, text = '', showSkip = true, onSkip, onTargetClick } = {}) {
   const root = ensureSpotlightRoot();
   if (!root || !target) return false;
 


### PR DESCRIPTION
### Motivation
- Resolve a Vite/Rollup build error where `js/features/onboarding/index.js` expected `hideSpotlight`/`showSpotlight` to be named exports from the spotlight module, causing the build to fail.

### Description
- Exported `hideSpotlight` and `showSpotlight` as named exports in `js/features/onboarding/spotlight.js` so imports in the onboarding feature resolve correctly.

### Testing
- Ran `npm run build` (which invokes `vite build`) successfully, and the pre-commit static checks `check:syntax` and `check:static-analysis` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010a1e97808326bbcdb77fccef8a9a)