### PR TITLE
Fix icon atlas asset reference to public path

### DIFF
--- a/js/assets.js
+++ b/js/assets.js
@@ -19,7 +19,7 @@ class AssetManager {
       ['character_left_swipe', 'assets/character_left_swipe.png'],
       ['character_right_swipe', 'assets/character_right_swipe.png'],
       ['character_spin', 'assets/character_spin.png'],
-      ['icon_atlas', '/img/icon_atlas.webp']
+      ['icon_atlas', 'assets/icon_atlas.webp']
     ];
   }
 


### PR DESCRIPTION
### Motivation
- Fix a runtime/public-path mismatch that caused `check:asset-paths` to report a missing public asset for `icon_atlas` because `/img/icon_atlas.webp` did not resolve under `public/`.

### Description
- Change the `icon_atlas` entry in `getCriticalManifest` inside `js/assets.js` from `/img/icon_atlas.webp` to `assets/icon_atlas.webp` so it points to the actual `public/assets/icon_atlas.webp` file.

### Testing
- Ran `npm run check:asset-paths` which now passes, and pre-commit checks ran `npm run check:syntax` and `npm run check:static-analysis` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010b80ee7c832689b37f27efa9c07f)