### PR TITLE
Fix radar gift spotlight duplicate Store click

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -146,7 +146,7 @@ function applyOnboardingUiState() {
   if (pendingGift && currentScreen === 'menu') {
     const skippedGiftMenu = skippedSteps.has(`gift_menu_${pendingGift}`);
     if (!skippedGiftMenu) {
-      showSpotlight({ target: '#storeBtn', text: 'Claim your free Radar', showSkip: true, onSkip: () => skippedSteps.add(`gift_menu_${pendingGift}`), onTargetClick: () => document.querySelector('#storeBtn')?.click?.() });
+      showSpotlight({ target: '#storeBtn', text: 'Claim your free Radar', showSkip: true, onSkip: () => skippedSteps.add(`gift_menu_${pendingGift}`), onTargetClick: () => { trackOnboardingStepEvent('onboarding_step_clicked', { target: '#storeBtn', flow: 'radar_gift_menu' }); } });
     } else {
       mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
     }


### PR DESCRIPTION
### Motivation
- `showSpotlight` internally dispatches a native click on the highlighted target, while the radar gift flow also called `document.querySelector('#storeBtn')?.click?.()` in `onTargetClick`, causing duplicate Store openings and duplicated handlers.

### Description
- Replace the radar gift menu `onTargetClick` in `js/features/onboarding/index.js` with an analytics-only callback: `onTargetClick: () => { trackOnboardingStepEvent('onboarding_step_clicked', { target: '#storeBtn', flow: 'radar_gift_menu' }); }`, leaving the spotlight's default click dispatch and the `mountGiftIndicator` behavior unchanged.

### Testing
- Pre-commit automated checks ran (including `check:syntax` and `check:static-analysis`) as part of the commit workflow and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010d9a89f083268b4f824e4c354ca5)