### PR TITLE
Fix bonus atlas frame registration and coin collect effect atlas usage

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -41,6 +41,8 @@ const OBSTACLE_TEXTURES = { fence: 'fence', rock1: 'rock', rock2: 'rock', bull: 
 const OBSTACLE_ANIM_FRAMES = 6;
 const OBSTACLE_FRAME_SIZE = 128;
 const OBSTACLE_ATLAS_ROWS = ['tree', 'rock', 'spikes', 'hole', 'fence', 'cactus', 'bull', 'bricks', 'bottles'];
+const BONUS_FRAME_SIZE = 128;
+const BONUS_ATLAS_ROWS = ['shield', 'battery', 'score_500', 'score_300', 'anti_score_500', 'anti_score_300', 'magnet', 'invert_controls', 'speed_up', 'speed_down', 'x2'];
 const FRAME_SIZE = 64;
 const PLAYER_FRAME_SIZE = 128;
 const BONUS_ATLAS_KEY = 'bonus_atlas';
@@ -189,6 +191,17 @@ function ensureObstacleAtlasFrames(scene) {
     }
   });
 }
+function ensureBonusAtlasFrames(scene) {
+  const texture = scene?.textures?.get(BONUS_ATLAS_KEY);
+  if (!texture || texture.has('x2_06')) return;
+  BONUS_ATLAS_ROWS.forEach((prefix, row) => {
+    for (let col = 0; col < BONUS_ANIM_FRAMES; col += 1) {
+      const frameName = `${prefix}_${String(col + 1).padStart(2, '0')}`;
+      if (texture.has(frameName)) continue;
+      texture.add(frameName, 0, col * BONUS_FRAME_SIZE, row * BONUS_FRAME_SIZE, BONUS_FRAME_SIZE, BONUS_FRAME_SIZE);
+    }
+  });
+}
 function getBonusFrame(item) {
   const bonusPrefix = BONUS_TEXTURES[item.type] || BONUS_TEXTURES[BONUS_TYPES.SHIELD];
   const frameNumber = ((Number(item.animFrame) || 0) % BONUS_ANIM_FRAMES) + 1;
@@ -208,7 +221,7 @@ class EntityRenderer {
       });
     });
     scene.load.atlas(COIN_ATLAS_KEY, assetUrl('assets/coin_atlas.webp'), assetUrl('assets/coin_atlas_phaser.json'));
-    scene.load.multiatlas(BONUS_ATLAS_KEY, assetUrl('assets/bonus_atlas_phaser.json'), assetUrl('assets/'));
+    scene.load.image(BONUS_ATLAS_KEY, assetUrl('assets/bonus_atlas.webp'));
     scene.load.image('obstacles_atlas', assetUrl('assets/obstacles_atlas.webp'));
     // Visual upgrade textures are generated procedurally at runtime in
     // ensureVisualUpgradeTextures(), so no static asset preload is required.
@@ -242,6 +255,7 @@ class EntityRenderer {
   create() {
     ensureVisualUpgradeTextures(this.scene);
     ensureObstacleAtlasFrames(this.scene);
+    ensureBonusAtlasFrames(this.scene);
     this.root = this.scene.add.container(0, 0).setDepth(14);
     this.objectLayer = this.scene.add.container(0, 0).setDepth(14);
     this.playerLayer = this.scene.add.container(0, 0).setDepth(15);

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -127,10 +127,12 @@ function renderCollectAnimationsPass(renderer, deps) {
 
     const textureKey = kind === 'bonus'
       ? (deps.BONUS_TEXTURES[bonusType] || 'shield')
-      : (coinType === 'silver' ? 'coins_silver' : 'coins_gold');
+      : deps.COIN_ATLAS_KEY;
+    const coinPrefix = coinType === 'silver' ? 'silver_coin' : 'gold_coin';
+    const coinFrameName = `${coinPrefix}_01`;
     const sprite = kind === 'bonus'
       ? renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, 'bonus_atlas', `${textureKey}_01`)
-      : renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, textureKey, 0);
+      : renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, deps.COIN_ATLAS_KEY, coinFrameName);
     sprite.setDepth(22);
     sprite.setAlpha(0.98);
     sprite.setScale(kind === 'bonus' ? 0.9 : (coinType === 'silver' ? 0.72 : 0.8));
@@ -141,7 +143,8 @@ function renderCollectAnimationsPass(renderer, deps) {
       const lift = (isSilver ? 10 : 14) + Math.floor(Math.random() * 12);
       const burstDistance = isSilver ? 14 : 20;
       for (let index = 0; index < 6; index += 1) {
-        const burstSprite = renderer.scene.add.sprite(sprite.x, sprite.y, textureKey, (index + 1) % 4);
+        const frameName = `${coinPrefix}_${String(((index % 4) + 1)).padStart(2, '0')}`;
+        const burstSprite = renderer.scene.add.sprite(sprite.x, sprite.y, deps.COIN_ATLAS_KEY, frameName);
         burstSprite.setDepth(21);
         burstSprite.setAlpha(isSilver ? 0.72 : 0.9);
         burstSprite.setScale(isSilver ? 0.2 : 0.3);


### PR DESCRIPTION
### Motivation
- Bonus sprites and collect-effect coins sometimes rendered as a preview of the whole atlas or lacked named frames because `multiatlas` loading was unreliable for `bonus_atlas` and frames were not registered at runtime.
- The coin collect effect still used legacy texture keys (`coins_silver` / `coins_gold`) so burst/collect sprites were incorrect after atlas changes.

### Description
- Load `bonus_atlas` as a single image (`scene.load.image`) and add `BONUS_ATLAS_ROWS` / `BONUS_FRAME_SIZE` constants in `js/phaser/entities/EntityRenderer.js` to support manual frame registration.
- Add `ensureBonusAtlasFrames(scene)` to register named frames (`shield_01..06`, `battery_01..06`, `score_300_01..06`, `score_500_01..06`, `anti_score_300_01..06`, `anti_score_500_01..06`, `magnet_01..06`, `invert_controls_01..06`, `speed_up_01..06`, `speed_down_01..06`, `x2_01..06`) from the known 128x128 grid and call it from `EntityRenderer.create()` before creating sprite pools.
- Update `js/phaser/entities/entity-render-passes.js` in `renderCollectAnimationsPass` to stop using `coins_silver`/`coins_gold` and instead create collect-effect sprites from `deps.COIN_ATLAS_KEY` with frame names `silver_coin_01..04` and `gold_coin_01..04`, including burst sprites; bonus-effect sprite creation still uses `bonus_atlas` with the registered frame names.
- Changes are limited to `js/phaser/entities/EntityRenderer.js` and `js/phaser/entities/entity-render-passes.js` and do not modify gameplay, scoring, collisions, player sprites, or backend code.

### Testing
- Automated syntax checks (`scripts/check-syntax.mjs`) ran and passed successfully.
- Static analysis guardrails (`scripts/check-static-analysis.mjs`) ran and passed successfully.
- Pre-commit quality checks completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010fda4df0832692a7266099839faf)