### PR TITLE
Fix frontend API base URL resolution for production

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -3,7 +3,7 @@ import { logger } from './logger.js';
 import { runRefreshPlayerStats } from './player-stats.js';
 // @ts-check
 
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, buildBackendUrl } from './config.js';
 import { request, requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ, REQUEST_PROFILE_AUTH_WRITE } from './request.js';
 import { DOM, getGameplayProgressSnapshot } from './state.js';
 import { WC } from './walletconnect.js';
@@ -172,9 +172,7 @@ async function signMessage(message) {
 }
 
 function buildBackendApiUrl(pathname) {
-  const safePath = String(pathname || '').startsWith('/') ? String(pathname) : `/${String(pathname || '')}`;
-  const origin = (typeof window !== 'undefined' && window.location?.origin) ? window.location.origin : 'http://localhost';
-  return new URL(`${String(BACKEND_URL || '').trim()}${safePath}`, origin);
+  return new URL(buildBackendUrl(pathname));
 }
 async function loadAndDisplayLeaderboard(options = {}) {
   const runToken = options?.runToken ?? null;

--- a/js/config.js
+++ b/js/config.js
@@ -4,24 +4,34 @@ function stripTrailingSlashes(value) {
   return String(value || '').replace(/\/+$/, '');
 }
 
-const explicitBackendUrl = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_BACKEND_URL)
-  ? stripTrailingSlashes(String(import.meta.env.VITE_BACKEND_URL).trim())
+function getEnvString(key) {
+  if (typeof import.meta === 'undefined' || !import.meta.env) return '';
+  const value = import.meta.env[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+const explicitBackendUrl = stripTrailingSlashes(
+  getEnvString('VITE_API_BASE_URL') || getEnvString('VITE_BACKEND_URL')
+);
+
+
+const sameOriginBackendUrl = typeof window !== 'undefined' && window.location?.origin
+  ? stripTrailingSlashes(window.location.origin)
   : '';
 
-const isUrsassTubeFrontendHost = (() => {
+const isLocalDevHost = (() => {
   if (typeof window === 'undefined' || !window.location?.hostname) return false;
-  return /(^|\.)ursasstube\.fun$/i.test(window.location.hostname);
+  const host = String(window.location.hostname).toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0';
 })();
 
-const sameOriginBackendUrl =
-  typeof window !== 'undefined' && window.location?.origin
-    ? stripTrailingSlashes(window.location.origin)
-    : '';
-
 const BACKEND_URL = explicitBackendUrl
-  || (isUrsassTubeFrontendHost && sameOriginBackendUrl
-    ? sameOriginBackendUrl
-    : 'https://api.ursasstube.fun');
+  || (isLocalDevHost && sameOriginBackendUrl ? sameOriginBackendUrl : 'https://api.ursasstube.fun');
+
+function buildBackendUrl(pathname) {
+  const safePath = String(pathname || '').startsWith('/') ? String(pathname) : `/${String(pathname || '')}`;
+  return `${BACKEND_URL}${safePath}`;
+}
 
 if (!/^https?:\/\//i.test(BACKEND_URL)) {
   logger.warn(`⚠️ BACKEND_URL is not absolute: ${BACKEND_URL}`);
@@ -104,4 +114,4 @@ const BONUS_TYPES = {
   SCORE_MINUS_500: "score_minus_500"
 };
 
-export { BACKEND_URL, WC_PROJECT_ID, CONFIG, BONUS_TYPES };
+export { BACKEND_URL, buildBackendUrl, WC_PROJECT_ID, CONFIG, BONUS_TYPES };

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -1,11 +1,10 @@
-import { BACKEND_URL } from '../../config.js';
+import { buildBackendUrl } from '../../config.js';
 import { requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ, REQUEST_PROFILE_STORE_WRITE } from '../../request.js';
 import { logger } from '../../logger.js';
 import { normalizeOnboardingState } from './onboarding-state.js';
 
 function buildOnboardingStateUrl() {
-  const origin = (typeof window !== 'undefined' && window.location?.origin) ? window.location.origin : 'http://localhost';
-  return new URL(`${String(BACKEND_URL || '').trim()}/api/onboarding/state`, origin).toString();
+  return buildBackendUrl('/api/onboarding/state');
 }
 
 async function fetchOnboardingState() {

--- a/js/perf.js
+++ b/js/perf.js
@@ -1,4 +1,4 @@
-import { BACKEND_URL } from './config.js';
+import { buildBackendUrl } from './config.js';
 import { request } from './request.js';
 import { gameState } from './state.js';
 import { logger } from './logger.js';
@@ -98,7 +98,7 @@ class PerformanceMonitor {
   async measurePing() {
     try {
       const start = performance.now();
-      await request(`${BACKEND_URL}/health`, { method: 'GET', cache: 'no-store' });
+      await request(buildBackendUrl('/health'), { method: 'GET', cache: 'no-store' });
       this.currentPing = Math.round(performance.now() - start);
       this.updatePingUI();
     } catch (e) {


### PR DESCRIPTION
### Motivation
- Prevent the frontend from calling same-origin endpoints on the public host (e.g. `https://www.ursasstube.fun/health` and `https://www.ursasstube.fun/api/...`) by restoring a centralized, environment-driven API base URL resolver. 
- Ensure production uses the configured backend host via `VITE_API_BASE_URL` while still allowing a safe same-origin fallback for local development only.

### Description
- Added `getEnvString()` and changed env priority to use `VITE_API_BASE_URL` with legacy fallback `VITE_BACKEND_URL` in `js/config.js`. 
- Removed production same-origin fallback for `*.ursasstube.fun`, and restricted same-origin fallback to local dev hosts (`localhost`, `127.0.0.1`, `0.0.0.0`). 
- Introduced and exported `buildBackendUrl(path)` from `js/config.js` and replaced inline same-origin URL construction with this helper. 
- Updated call sites to use the centralized resolver: `buildBackendApiUrl()` in `js/api.js`, ping in `js/perf.js` (`/health`), and onboarding endpoints in `js/features/onboarding/onboarding-service.js`.

### Testing
- `npm run build` completed successfully and the production build artifacts were produced without errors. 
- Pre-commit automated checks passed, including `check:syntax` and `check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01157c7eb48326a364c2f7abfc815f)