### PR TITLE
Fix coin collect effect to use coin_atlas frames consistently

### DIFF
--- a/js/phaser/entities/EntityRenderer.js
+++ b/js/phaser/entities/EntityRenderer.js
@@ -341,6 +341,7 @@ class EntityRenderer {
     renderCollectAnimationsPass(this, {
       BONUS_TEXTURES,
       COIN_COLLECT_BURST_ANGLE_STEP,
+      COIN_ATLAS_KEY,
       clamp,
       parseRgbaColor,
     });

--- a/js/phaser/entities/entity-render-passes.js
+++ b/js/phaser/entities/entity-render-passes.js
@@ -129,10 +129,10 @@ function renderCollectAnimationsPass(renderer, deps) {
       ? (deps.BONUS_TEXTURES[bonusType] || 'shield')
       : deps.COIN_ATLAS_KEY;
     const coinPrefix = coinType === 'silver' ? 'silver_coin' : 'gold_coin';
-    const coinFrameName = `${coinPrefix}_01`;
+    const firstFrame = `${coinPrefix}_01`;
     const sprite = kind === 'bonus'
       ? renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, 'bonus_atlas', `${textureKey}_01`)
-      : renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, deps.COIN_ATLAS_KEY, coinFrameName);
+      : renderer.scene.add.sprite(Number(effect.x) || 0, Number(effect.y) || 0, deps.COIN_ATLAS_KEY, firstFrame);
     sprite.setDepth(22);
     sprite.setAlpha(0.98);
     sprite.setScale(kind === 'bonus' ? 0.9 : (coinType === 'silver' ? 0.72 : 0.8));
@@ -143,8 +143,8 @@ function renderCollectAnimationsPass(renderer, deps) {
       const lift = (isSilver ? 10 : 14) + Math.floor(Math.random() * 12);
       const burstDistance = isSilver ? 14 : 20;
       for (let index = 0; index < 6; index += 1) {
-        const burstFrameName = `${coinPrefix}_${String((index % 4) + 1).padStart(2, '0')}`;
-        const burstSprite = renderer.scene.add.sprite(sprite.x, sprite.y, deps.COIN_ATLAS_KEY, burstFrameName);
+        const burstFrame = `${coinPrefix}_${String((index % 4) + 1).padStart(2, '0')}`;
+        const burstSprite = renderer.scene.add.sprite(sprite.x, sprite.y, deps.COIN_ATLAS_KEY, burstFrame);
         burstSprite.setDepth(21);
         burstSprite.setAlpha(isSilver ? 0.72 : 0.9);
         burstSprite.setScale(isSilver ? 0.2 : 0.3);


### PR DESCRIPTION
### Motivation
- Phaser emitted warnings like `Texture "__DEFAULT" has no frame "silver_coin_01"` and the small coin collect mini-sprite stopped appearing because collect-effect frames were created without an explicit texture key.

### Description
- In `renderCollectAnimationsPass` the coin collect sprite now uses an explicit `firstFrame` and is created with `deps.COIN_ATLAS_KEY` via `add.sprite(x, y, deps.COIN_ATLAS_KEY, firstFrame)` to ensure the frame is resolved from the coin atlas.
- Burst particles for coins now compute `burstFrame` and are created via `add.sprite(..., deps.COIN_ATLAS_KEY, burstFrame)` so all burst frames come from `coin_atlas` as well.
- Visual motion/tween/lift/burst timing, easing, scale and alpha behavior are preserved and the `bonus` path remains unchanged.
- `EntityRenderer.renderCollectAnimations()` now injects `COIN_ATLAS_KEY` into `renderCollectAnimationsPass` so the pass always receives the atlas key via `deps`.

### Testing
- Pre-commit syntax check `npm run check:syntax` ran and passed.
- Static analysis guard `npm run check:static-analysis` ran and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011835eac083269395a64d2575801f)