### PR TITLE
Gate onboarding/state on Telegram identity, add auth headers and dedupe requests

### DIFF
--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -2,20 +2,79 @@ import { buildBackendUrl } from '../../config.js';
 import { requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ, REQUEST_PROFILE_STORE_WRITE } from '../../request.js';
 import { logger } from '../../logger.js';
 import { normalizeOnboardingState } from './onboarding-state.js';
+import { getPrimaryAuthIdentifier, getSigningWalletAddress, isTelegramMiniApp } from '../auth/index.js';
+import { getTelegramInitData } from '../../auth-telegram.js';
+
+let onboardingStateInFlightPromise = null;
+let onboardingStateCache = null;
+let hasLoggedMissingIdentity = false;
 
 function buildOnboardingStateUrl() {
   return buildBackendUrl('/api/onboarding/state');
 }
 
+function buildOnboardingAuthHeaders() {
+  const headers = { 'Content-Type': 'application/json' };
+  const primaryId = getPrimaryAuthIdentifier();
+  const wallet = getSigningWalletAddress();
+  const telegramInitData = getTelegramInitData();
+
+  if (primaryId) {
+    headers['X-Primary-Id'] = String(primaryId);
+    if (wallet) headers['X-Wallet'] = String(wallet);
+  }
+  if (telegramInitData) {
+    headers['X-Telegram-Init-Data'] = telegramInitData;
+  }
+
+  return { headers, hasIdentity: Boolean(primaryId || telegramInitData) };
+}
+
 async function fetchOnboardingState() {
-  try {
-    const { ok, data } = await requestJsonResult(buildOnboardingStateUrl(), REQUEST_PROFILE_LEADERBOARD_READ);
-    if (!ok) return null;
-    return normalizeOnboardingState(data?.onboarding || data);
-  } catch (error) {
-    logger.warn('⚠️ onboarding state fetch failed', error);
+  if (onboardingStateCache) return onboardingStateCache;
+  if (onboardingStateInFlightPromise) return onboardingStateInFlightPromise;
+
+  const { headers, hasIdentity } = buildOnboardingAuthHeaders();
+  const shouldFetchRemote = hasIdentity && isTelegramMiniApp();
+  if (!shouldFetchRemote) {
+    if (!hasLoggedMissingIdentity) {
+      hasLoggedMissingIdentity = true;
+      logger.info('🧭 onboarding state: skip remote fetch (telegram/user identity unavailable)');
+    }
+    onboardingStateCache = null;
     return null;
   }
+
+  onboardingStateInFlightPromise = (async () => {
+    try {
+      const { ok, status, data } = await requestJsonResult(buildOnboardingStateUrl(), {
+        ...REQUEST_PROFILE_LEADERBOARD_READ,
+        retries: 0,
+        headers
+      });
+
+      if (!ok) {
+        if (status === 400) {
+          logger.info('🧭 onboarding state: backend returned 400, using local fallback');
+          onboardingStateCache = null;
+          return null;
+        }
+        return null;
+      }
+
+      const normalizedState = normalizeOnboardingState(data?.onboarding || data);
+      onboardingStateCache = normalizedState;
+      return normalizedState;
+    } catch (_error) {
+      logger.info('🧭 onboarding state fetch failed, using local fallback');
+      onboardingStateCache = null;
+      return null;
+    } finally {
+      onboardingStateInFlightPromise = null;
+    }
+  })();
+
+  return onboardingStateInFlightPromise;
 }
 
 async function postOnboardingEvent(eventName) {


### PR DESCRIPTION
### Motivation
- Prevent noisy 400 errors from `/api/onboarding/state` when no Telegram/user identity is available and avoid doing the network call outside Telegram context.
- Reuse existing auth helpers so backend receives the same identity headers the app already uses elsewhere.
- Ensure a single boot cycle cannot trigger duplicate onboarding GETs that happen concurrently.

### Description
- Use existing helpers `getPrimaryAuthIdentifier`, `getSigningWalletAddress`, and `getTelegramInitData` to build identity headers (`X-Primary-Id`, `X-Wallet`, `X-Telegram-Init-Data`).
- Gate remote fetch: only call `/api/onboarding/state` when identity is present and `isTelegramMiniApp()` is true, otherwise return local fallback (`null`) and emit a single info log.
- Add in-flight promise deduplication and a simple success cache so repeated `fetchOnboardingState` calls return the same promise/result and avoid duplicate GETs.
- Disable retries for onboarding read requests (`retries: 0`) and treat HTTP 400 as a soft failure that falls back to local state with an informational log instead of noisy warnings or retries.

### Testing
- Ran `node --check js/features/onboarding/onboarding-service.js` to validate syntax of the modified module (success).
- Ran project syntax checks via `scripts/check-syntax.mjs` (pre-commit check suite) and those checks passed for the changed file.
- Ran `scripts/check-static-analysis.mjs` which reported an existing unrelated static-analysis violation (`js/api.js` exceeds configured max lines) that is not caused by these changes (failure unrelated to onboarding changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011ad80d848326982897feba609ad1)