### PR TITLE
Fix onboarding runtime modes for Telegram, Web Guest and Web Auth

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -5,7 +5,7 @@ import { hideSpotlight, showSpotlight } from './spotlight.js';
 import { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { trackAnalyticsEvent } from '../../analytics.js';
-import { hasAuthenticatedSession } from '../auth/index.js';
+import { hasAuthenticatedSession, isTelegramAuthMode, isTelegramMiniApp, getPrimaryAuthIdentifier } from '../auth/index.js';
 import { BACKEND_URL } from '../../config.js';
 import { requestJsonResult, REQUEST_PROFILE_STORE_WRITE } from '../../request.js';
 
@@ -29,7 +29,9 @@ let onboardingState = { ...DEFAULT_ONBOARDING_STATE };
 let currentScreen = 'menu';
 
 const COMPLETED_EVENT_KEY = 'ursas.onboarding.completed.event.v1';
+const GUEST_SKIP_KEY = 'ursas.onboarding.guest.skip.v1';
 const skippedSteps = new Set();
+let lastRuntimeMode = null;
 
 function trackOnboardingStepEvent(eventName, extra = {}) {
   trackAnalyticsEvent(eventName, {
@@ -51,23 +53,62 @@ function resolveMappedStep(step) {
   return Object.values(STEP).includes(normalized) ? normalized : 'unknown';
 }
 
-function shouldHideForGuest() {
-  return !hasAuthenticatedSession();
+function readGuestSkipState() {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem(GUEST_SKIP_KEY) === '1';
+}
+
+function writeGuestSkipState(skipped) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(GUEST_SKIP_KEY, skipped ? '1' : '0');
+}
+
+function resolveOnboardingRuntimeMode() {
+  const telegramMiniApp = isTelegramMiniApp();
+  const telegramInitData = String(window.Telegram?.WebApp?.initData || '').trim();
+  const telegramUser = window.Telegram?.WebApp?.initDataUnsafe?.user || null;
+  const hasAuthSession = hasAuthenticatedSession();
+
+  if (telegramMiniApp) {
+    if (hasAuthSession || isTelegramAuthMode() || getPrimaryAuthIdentifier()) return 'telegram_authenticated';
+    if (telegramInitData || telegramUser) return 'telegram_auth_pending';
+    return 'telegram_auth_failed';
+  }
+
+  return hasAuthSession ? 'web_authenticated' : 'web_guest';
 }
 
 function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) {
-  return showSpotlight({
-    target: selector,
-    text,
-    showSkip,
-    onSkip: () => {
-      skippedSteps.add(resolveMappedStep(onboardingState.step));
-      trackOnboardingStepEvent('onboarding_step_skipped');
-    },
-    onTargetClick: () => {
-      trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
+  const maxAttempts = 20;
+  let attempts = 0;
+
+  const render = () => {
+    attempts += 1;
+    const shown = showSpotlight({
+      target: selector,
+      text,
+      showSkip,
+      onSkip: () => {
+        skippedSteps.add(resolveMappedStep(onboardingState.step));
+        trackOnboardingStepEvent('onboarding_step_skipped');
+      },
+      onTargetClick: () => {
+        trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
+      }
+    });
+
+    if (shown || attempts >= maxAttempts) {
+      if (!shown) logger.warn('⚠️ onboarding spotlight target not found', { selector, attempts });
+      return shown;
     }
-  });
+
+    requestAnimationFrame(() => {
+      setTimeout(render, 50);
+    });
+    return false;
+  };
+
+  return render();
 }
 
 
@@ -117,11 +158,43 @@ function trackOnboardingCompletedOnce() {
 function applyOnboardingUiState() {
   hideAllOnboardingUi();
 
+  const runtimeMode = resolveOnboardingRuntimeMode();
+  if (lastRuntimeMode === 'web_guest' && runtimeMode === 'web_authenticated') {
+    writeGuestSkipState(false);
+  }
+  lastRuntimeMode = runtimeMode;
+
   const step = resolveMappedStep(onboardingState.step);
-  if (onboardingState.completed || step === STEP.COMPLETED || step === 'unknown' || shouldHideForGuest()) {
+  if (onboardingState.completed || step === STEP.COMPLETED) {
     trackOnboardingCompletedOnce();
     return;
   }
+
+  if (runtimeMode === 'telegram_auth_pending') return;
+  if (runtimeMode === 'telegram_auth_failed') {
+    logger.warn('⚠️ Telegram auth failed; onboarding waiting for auth retry');
+    return;
+  }
+
+  if (runtimeMode === 'web_guest') {
+    if (readGuestSkipState()) return;
+    showSpotlight({
+      target: '#startBtn',
+      text: 'Start your first run',
+      showSkip: true,
+      onSkip: () => {
+        writeGuestSkipState(true);
+        hideSpotlight();
+        trackOnboardingStepEvent('onboarding_guest_skipped');
+      },
+      onTargetClick: () => {
+        trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
+      }
+    }) || showSpotlightBySelector({ selector: '#startBtn', text: 'Start your first run', showSkip: true });
+    return;
+  }
+
+  if (step === 'unknown') return;
   if (skippedSteps.has(step)) return;
 
   trackOnboardingStepEvent('onboarding_step_shown', { presentation: step, screen: currentScreen });

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -2,7 +2,7 @@ import { buildBackendUrl } from '../../config.js';
 import { requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ, REQUEST_PROFILE_STORE_WRITE } from '../../request.js';
 import { logger } from '../../logger.js';
 import { normalizeOnboardingState } from './onboarding-state.js';
-import { getPrimaryAuthIdentifier, getSigningWalletAddress, isTelegramMiniApp } from '../auth/index.js';
+import { getPrimaryAuthIdentifier, getSigningWalletAddress } from '../auth/index.js';
 import { getTelegramInitData } from '../../auth-telegram.js';
 
 let onboardingStateInFlightPromise = null;
@@ -35,11 +35,11 @@ async function fetchOnboardingState() {
   if (onboardingStateInFlightPromise) return onboardingStateInFlightPromise;
 
   const { headers, hasIdentity } = buildOnboardingAuthHeaders();
-  const shouldFetchRemote = hasIdentity && isTelegramMiniApp();
+  const shouldFetchRemote = hasIdentity;
   if (!shouldFetchRemote) {
     if (!hasLoggedMissingIdentity) {
       hasLoggedMissingIdentity = true;
-      logger.info('🧭 onboarding state: skip remote fetch (telegram/user identity unavailable)');
+      logger.info('🧭 onboarding state: skip remote fetch (user identity unavailable)');
     }
     onboardingStateCache = null;
     return null;
@@ -85,7 +85,7 @@ async function postOnboardingEvent(eventName) {
     const { ok } = await requestJsonResult(buildOnboardingStateUrl().replace('/state', '/event'), {
       ...REQUEST_PROFILE_STORE_WRITE,
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildOnboardingAuthHeaders().headers,
       body: JSON.stringify({ event: normalizedEventName })
     });
     return Boolean(ok);


### PR DESCRIPTION
### Motivation
- Устранить глобальный guard, который скрывал весь onboarding для гостей и ломал Web Guest и Telegram flows во время Telegram auto-auth.
- Обеспечить явное различение runtime-модов onboarding для корректного отображения визуальных подсказок и сохранения поведения наград.

### Description
- Заменён глобальный `shouldHideForGuest()` на `resolveOnboardingRuntimeMode()` с режимами `telegram_authenticated`, `telegram_auth_pending`, `telegram_auth_failed`, `web_guest` и `web_authenticated` и логикой на основе `isTelegramMiniApp()`, `isTelegramAuthMode()`, `hasAuthenticatedSession()`, `getPrimaryAuthIdentifier()` и Telegram `initData`.
- Добавлен guest-specific fallback для `web_guest`: spotlight на `#startBtn` с текстом `Start your first run`, `Skip` и сохранением пропуска в `localStorage` под ключом `ursas.onboarding.guest.skip.v1`, при переходе в `web_authenticated` этот skip сбрасывается.
- Внедрена retry-механика для spotlight-целевых селекторов (`requestAnimationFrame` + `setTimeout`, `maxAttempts=20`) и логирование предупреждения, если элемент не найден, чтобы избежать молчалых провалов подсветки.
- В `onboarding-service` убрано ограничение на remote fetch только для Telegram; теперь remote состояние запрашивается при наличии любой идентификации, а запросы событий отправляются с построенными заголовками авторизации (включая `X-Telegram-Init-Data`, если есть).

### Testing
- Выполнена статическая проверка синтаксиса файлов: `node --check js/features/onboarding/index.js` и `node --check js/features/onboarding/onboarding-service.js`, оба пройдены успешно.
- Прогоны pre-commit автоматизированных проверок прошли успешно: `npm run check:syntax` и `npm run check:static-analysis`.
- Компоненты, затронувшие селекторы и localStorage, дополнительно покрыты runtime-предусмотрительностью (retry + проверки `typeof localStorage !== 'undefined'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b892d05483269eba41fcb9a9835f)