### PR TITLE
Hide Connect Wallet button in Telegram mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3427,6 +3427,11 @@ body.is-telegram #walletCorner {
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
+body.is-telegram #walletCorner #walletBtn,
+body.telegram-mini-app #walletCorner #walletBtn {
+  display: none !important;
+}
+
 body.is-telegram #playerMenuOverlay .pm-center #pmXBlock {
   width: 100%;
   margin-top: 8px;


### PR DESCRIPTION
### Motivation
- The Telegram runtime still showed the main-page "Connect Wallet" CTA but in Telegram versions this button must not be visible on the main screen.

### Description
- Add a CSS rule in `css/style.css` to hide `#walletBtn` inside `#walletCorner` for both `body.is-telegram` and `body.telegram-mini-app` by applying `display: none !important`.

### Testing
- Ran automated pre-commit checks `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c0c3d5248326850c01bb43cd088f)