### PR TITLE
Fix wallet button dimming after guest onboarding skip

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -76,6 +76,11 @@ function writeWebGuestOnboardingSeen() {
   storage.setItem(WEB_GUEST_ONBOARDING_SEEN_KEY, '1');
 }
 
+function clearFirstRunWalletDimming() {
+  if (typeof document === 'undefined') return;
+  document.body.classList.remove('onboarding-first-run');
+}
+
 function resolveOnboardingRuntimeMode() {
   const telegramMiniApp = isTelegramMiniApp();
   const telegramInitData = String(window.Telegram?.WebApp?.initData || '').trim();
@@ -197,11 +202,13 @@ function applyOnboardingUiState() {
       showSkip: true,
       onSkip: () => {
         writeWebGuestOnboardingSeen();
+        clearFirstRunWalletDimming();
         hideSpotlight();
         trackOnboardingStepEvent('onboarding_guest_skipped');
       },
       onTargetClick: () => {
         writeWebGuestOnboardingSeen();
+        clearFirstRunWalletDimming();
         trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
       },
       step: 'guest_start'


### PR DESCRIPTION
### Motivation
- Guest onboarding's Skip/Start buttons left the UI in a first-run state so the `Connect Wallet` control remained visually dimmed due to the `onboarding-first-run` class on `<body>`.

### Description
- Add `clearFirstRunWalletDimming()` in `js/features/onboarding/index.js` and call it from the web guest onboarding spotlight callbacks (`onSkip` and `onTargetClick`) so the `onboarding-first-run` class is removed immediately.

### Testing
- Ran build and checks: `npm run -s build` completed successfully and pre-commit static checks (`check:syntax`, `check:static-analysis`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c4ffc6688326aee6f4fb29af58d8)