### PR TITLE
Refresh onboarding after successful authentication

### DIFF
--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -432,6 +432,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     },
     onAuthAuthenticated: () => {
       updatePlayerAvatarVisibility();
+      refreshOnboardingState({ reason: 'auth_authenticated' }).catch(() => {});
       const hadWalletSessionBefore = _lastKnownWalletSession;
       const hasWalletNow = hasWalletAuthSession();
       _lastKnownWalletSession = hasWalletNow;


### PR DESCRIPTION
### Motivation
- Ensure onboarding UI (spotlight/mask/hooks/skip) is applied immediately when a user authenticates (wallet or Telegram) because first-time authenticated users previously saw no onboarding flow.

### Description
- Add `refreshOnboardingState({ reason: 'auth_authenticated' }).catch(() => {})` to the `onAuthAuthenticated` callback in `js/game/bootstrap.js` so onboarding state is fetched and applied right after auth completes.

### Testing
- Ran `node scripts/onboarding-hints.test.mjs` and it passed. 
- Ran `node scripts/check-syntax.mjs` and pre-commit `check:static-analysis` during commit and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c5ee2394832689af9f32ff21b684)