### PR TITLE
Invalidate onboarding-state cache on auth identity change and refresh on auth

### DIFF
--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -7,6 +7,7 @@ import { getTelegramInitData } from '../../auth-telegram.js';
 
 let onboardingStateInFlightPromise = null;
 let onboardingStateCache = null;
+let onboardingStateCacheIdentity = '';
 let hasLoggedMissingIdentity = false;
 
 function buildOnboardingStateUrl() {
@@ -31,10 +32,22 @@ function buildOnboardingAuthHeaders() {
 }
 
 async function fetchOnboardingState() {
+  const { headers, hasIdentity } = buildOnboardingAuthHeaders();
+  const identityKey = JSON.stringify({
+    primaryId: headers['X-Primary-Id'] || '',
+    wallet: headers['X-Wallet'] || '',
+    telegram: headers['X-Telegram-Init-Data'] || ''
+  });
+
+  if (onboardingStateCacheIdentity !== identityKey) {
+    onboardingStateCache = null;
+    onboardingStateInFlightPromise = null;
+    onboardingStateCacheIdentity = identityKey;
+  }
+
   if (onboardingStateCache) return onboardingStateCache;
   if (onboardingStateInFlightPromise) return onboardingStateInFlightPromise;
 
-  const { headers, hasIdentity } = buildOnboardingAuthHeaders();
   const shouldFetchRemote = hasIdentity;
   if (!shouldFetchRemote) {
     if (!hasLoggedMissingIdentity) {

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -432,6 +432,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     },
     onAuthAuthenticated: () => {
       updatePlayerAvatarVisibility();
+      refreshOnboardingState({ reason: 'auth_authenticated' }).catch(() => {});
       const hadWalletSessionBefore = _lastKnownWalletSession;
       const hasWalletNow = hasWalletAuthSession();
       _lastKnownWalletSession = hasWalletNow;


### PR DESCRIPTION
### Motivation
- Ensure the onboarding state is not reused across different authenticated identities so the UI doesn't show stale onboarding data.
- Prompt an immediate onboarding state refresh when a user authenticates so the client can update onboarding-dependent UI right away.

### Description
- Add `onboardingStateCacheIdentity` and compute an `identityKey` from auth headers to detect identity changes and clear `onboardingStateCache` and `onboardingStateInFlightPromise` when they differ in `fetchOnboardingState`.
- Move the call to `buildOnboardingAuthHeaders` earlier in `fetchOnboardingState` and use its values to build the identity key used for cache invalidation.
- Preserve existing remote-fetch guards and error handling while ensuring the cache is invalidated when identity changes.
- Call `refreshOnboardingState({ reason: 'auth_authenticated' })` from the `onAuthAuthenticated` handler in `js/game/bootstrap.js` to trigger an immediate refresh after authentication.

### Testing
- Ran unit tests via `npm test`, and the test suite completed successfully.
- Ran linter via `npm run lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c5ee2394832689af9f32ff21b684)