### PR TITLE
Unify onboarding prompts to spotlight, refresh on auth, and scope onboarding cache to identity

### DIFF
--- a/js/features/onboarding/hooks.js
+++ b/js/features/onboarding/hooks.js
@@ -9,31 +9,11 @@ function hideMenuStartHook() {
   hook.textContent = '';
 }
 
-function showMenuStartHook(text) {
-  const hook = DOM.startHook;
-  if (!hook) return false;
-  hook.hidden = false;
-  hook.setAttribute('aria-hidden', 'false');
-  hook.textContent = String(text || '').trim();
-  return true;
-}
-
-function showGameOverPlayAgainHook(text) {
-  if (!text) return false;
-  return setGameOverPrompt({
-    title: String(text),
-    body: '',
-    cta: 'PLAY AGAIN'
-  }, { source: 'preview', runToken: null });
-}
-
 function clearGameOverOnboardingHook() {
   return setGameOverPrompt(null, { source: 'preview', runToken: null });
 }
 
 export {
   hideMenuStartHook,
-  showMenuStartHook,
-  showGameOverPlayAgainHook,
   clearGameOverOnboardingHook
 };

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -1,6 +1,6 @@
 import { fetchOnboardingState } from './onboarding-service.js';
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
-import { showMenuStartHook, hideMenuStartHook, showGameOverPlayAgainHook, clearGameOverOnboardingHook } from './hooks.js';
+import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
 import { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
 import { logger } from '../../logger.js';
@@ -215,19 +215,19 @@ function applyOnboardingUiState() {
   trackOnboardingStepEvent('onboarding_step_shown', { presentation: step, screen: currentScreen });
 
   if ((step === STEP.AUTH_START || step === STEP.AUTH_MENU) && currentScreen === 'menu') {
-    showMenuStartHook('Take the lead');
+    showAuthSpotlight({ selector: '#startBtn', text: 'Take the lead' });
     return;
   }
   if ((step === STEP.AUTH_RUN_1_DONE || step === STEP.AFTER_FIRST_RUN) && currentScreen === 'game-over') {
-    showGameOverPlayAgainHook('Run again. Get +100 silver');
+    showAuthSpotlight({ selector: '#restartBtn', text: 'Run again. Get +100 silver' });
     return;
   }
   if ((step === STEP.AUTH_RUN_2_DONE || step === STEP.AFTER_SECOND_RUN) && currentScreen === 'game-over') {
-    showGameOverPlayAgainHook('One more run. Get +100 gold');
+    showAuthSpotlight({ selector: '#restartBtn', text: 'One more run. Get +100 gold' });
     return;
   }
   if ((step === STEP.AUTH_RUN_3_DONE || step === STEP.AFTER_THIRD_RUN) && currentScreen === 'game-over') {
-    showGameOverPlayAgainHook('Connect X for more rewards');
+    showAuthSpotlight({ selector: '#shareResultBtn', text: 'Connect X for more rewards' });
     return;
   }
   const pendingGift = getPendingRadarGift();
@@ -285,3 +285,18 @@ async function initOnboardingFeature() {
 }
 
 export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen };
+function showAuthSpotlight({ selector, text }) {
+  return showSpotlight({
+    target: selector,
+    text,
+    showSkip: true,
+    onSkip: () => {
+      skippedSteps.add(resolveMappedStep(onboardingState.step));
+      trackOnboardingStepEvent('onboarding_step_skipped');
+    },
+    onTargetClick: () => {
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
+    },
+    step: resolveMappedStep(onboardingState.step)
+  }) || showSpotlightBySelector({ selector, text, showSkip: true });
+}

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -7,6 +7,7 @@ import { getTelegramInitData } from '../../auth-telegram.js';
 
 let onboardingStateInFlightPromise = null;
 let onboardingStateCache = null;
+let onboardingStateCacheIdentity = '';
 let hasLoggedMissingIdentity = false;
 
 function buildOnboardingStateUrl() {
@@ -31,10 +32,22 @@ function buildOnboardingAuthHeaders() {
 }
 
 async function fetchOnboardingState() {
+  const { headers, hasIdentity } = buildOnboardingAuthHeaders();
+  const identityKey = JSON.stringify({
+    primaryId: headers['X-Primary-Id'] || '',
+    wallet: headers['X-Wallet'] || '',
+    telegram: headers['X-Telegram-Init-Data'] || ''
+  });
+
+  if (onboardingStateCacheIdentity !== identityKey) {
+    onboardingStateCache = null;
+    onboardingStateInFlightPromise = null;
+    onboardingStateCacheIdentity = identityKey;
+  }
+
   if (onboardingStateCache) return onboardingStateCache;
   if (onboardingStateInFlightPromise) return onboardingStateInFlightPromise;
 
-  const { headers, hasIdentity } = buildOnboardingAuthHeaders();
   const shouldFetchRemote = hasIdentity;
   if (!shouldFetchRemote) {
     if (!hasLoggedMissingIdentity) {

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -432,6 +432,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     },
     onAuthAuthenticated: () => {
       updatePlayerAvatarVisibility();
+      refreshOnboardingState({ reason: 'auth_authenticated' }).catch(() => {});
       const hadWalletSessionBefore = _lastKnownWalletSession;
       const hasWalletNow = hasWalletAuthSession();
       _lastKnownWalletSession = hasWalletNow;


### PR DESCRIPTION
### Motivation
- Simplify onboarding UI hooks by moving start/game-over prompts to the shared spotlight flow to reduce duplicate DOM hook handling.
- Ensure onboarding state is fresh after authentication changes so the UI reflects the new user identity immediately.
- Prevent stale onboarding state from being reused across different authenticated identities by scoping the cache to the current identity.

### Description
- Removed the legacy `showMenuStartHook` and `showGameOverPlayAgainHook` implementations and their exports from `js/features/onboarding/hooks.js` and switched callers to a unified `showAuthSpotlight` function. 
- Added `showAuthSpotlight` to `js/features/onboarding/index.js` which delegates to `showSpotlight` (or falls back to `showSpotlightBySelector`) and wires skip/click tracking via `skippedSteps` and `trackOnboardingStepEvent`.
- Changed onboarding step usages to call `showAuthSpotlight` with appropriate selectors/texts instead of DOM hook helpers.
- Updated `js/features/onboarding/onboarding-service.js` to track an `onboardingStateCacheIdentity` key built from auth headers and to invalidate the cached state and in-flight promise when the identity changes.
- Triggered a refresh of onboarding state after authentication by calling `refreshOnboardingState({ reason: 'auth_authenticated' })` in `js/game/bootstrap.js` when `onAuthAuthenticated` fires.

### Testing
- Ran the existing automated test suite (unit and integration tests) and linters locally, and they completed successfully.
- Verified onboarding state fetch logic by simulating identity changes and confirmed cache invalidation and re-fetch occurred as expected in development runs.
- Performed a smoke run of the app to validate that start/restart/share spotlights appear and that analytics events are emitted when skipping or clicking; no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c5ee2394832689af9f32ff21b684)