### PR TITLE
Исправить затемнение кнопки кошелька при пропуске гостевого onboarding

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -196,23 +196,32 @@ function applyOnboardingUiState() {
   }
 
   if (runtimeMode === 'web_guest_first_visit') {
+    const completeGuestFirstVisit = ({ skipped = false } = {}) => {
+      writeWebGuestOnboardingSeen();
+      clearFirstRunWalletDimming();
+      if (skipped) {
+        hideSpotlight();
+        trackOnboardingStepEvent('onboarding_guest_skipped');
+        return;
+      }
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
+    };
+
     showSpotlight({
       target: '#startBtn',
       text: 'Start your first run',
       showSkip: true,
-      onSkip: () => {
-        writeWebGuestOnboardingSeen();
-        clearFirstRunWalletDimming();
-        hideSpotlight();
-        trackOnboardingStepEvent('onboarding_guest_skipped');
-      },
-      onTargetClick: () => {
-        writeWebGuestOnboardingSeen();
-        clearFirstRunWalletDimming();
-        trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
-      },
+      onSkip: () => completeGuestFirstVisit({ skipped: true }),
+      onTargetClick: () => completeGuestFirstVisit(),
       step: 'guest_start'
-    }) || showSpotlightBySelector({ selector: '#startBtn', text: 'Start your first run', showSkip: true });
+    }) || showSpotlight({
+      target: '#startBtn',
+      text: 'Start your first run',
+      showSkip: true,
+      onSkip: () => completeGuestFirstVisit({ skipped: true }),
+      onTargetClick: () => completeGuestFirstVisit(),
+      step: 'guest_start_fallback'
+    });
     return;
   }
 


### PR DESCRIPTION
### Motivation
- При первом визите в guest-режиме при пропуске onboarding кнопка `Connect Wallet` оставалась затемнённой из‑за класса `onboarding-first-run`, нужно вернуть стандартный вид без затемнения.

### Description
- Добавлен helper `completeGuestFirstVisit` в `js/features/onboarding/index.js`, который вызывает `writeWebGuestOnboardingSeen()` и `clearFirstRunWalletDimming()` и отправляет соответствующие аналитические события.
- Заменены inline-колбэки `onSkip`/`onTargetClick` в ветке `web_guest_first_visit` на вызов нового helper-а для основного и fallback-вызова `showSpotlight`, чтобы унифицировать поведение.
- Фоллбэк-показ `showSpotlight` теперь использует тот же набор колбэков и шаг `guest_start_fallback`, чтобы избежать рассинхронизации логики и оставить кнопку в нормальном состоянии после skip.

### Testing
- Выполнен `npm run -s build` и сборка прошла успешно.
- Статические проверки `check:syntax` и `check:static-analysis`, запуск которых произошёл в pre-commit, завершились успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cd8abe188326a52c9e3047a2c186)