### PR TITLE
Mark guest onboarding as seen on first presentation

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -196,8 +196,12 @@ function applyOnboardingUiState() {
   }
 
   if (runtimeMode === 'web_guest_first_visit') {
+    // Mark guest onboarding as seen immediately after first presentation so it
+    // does not reappear on subsequent visits if the player leaves without
+    // explicitly clicking Start/Skip.
+    writeWebGuestOnboardingSeen();
+
     const completeGuestFirstVisit = ({ skipped = false } = {}) => {
-      writeWebGuestOnboardingSeen();
       clearFirstRunWalletDimming();
       if (skipped) {
         hideSpotlight();


### PR DESCRIPTION
### Motivation
- Prevent the guest onboarding "first visit" spotlight from reappearing on subsequent web visits when a player leaves or reloads the page before clicking Start/Skip by persisting the seen flag as soon as the spotlight is shown.

### Description
- Call `writeWebGuestOnboardingSeen()` immediately when `runtimeMode === 'web_guest_first_visit'` in `js/features/onboarding/index.js`, moving the persisted flag out of the `completeGuestFirstVisit` callback so `ursas.webGuestOnboarding.seen.v1` is set on first presentation.

### Testing
- Pre-commit automated checks ran successfully (including `check:syntax` and `check:static-analysis`) and `node --check js/features/onboarding/index.js` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0202f43b3883269f2b37398b0e18ed)