### PR TITLE
Refactor web guest onboarding spotlight handlers and remove wallet dimming styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -183,17 +183,6 @@ body {
   box-shadow: 0 0 12px rgba(255, 100, 100, .15);
 }
 
-body.onboarding-first-run .wallet-btn-corner:not(.connected) {
-  opacity: .55;
-  border-color: rgba(140, 80, 255, .2);
-  background: rgba(255, 255, 255, .04);
-  box-shadow: none;
-}
-
-body.onboarding-first-run .wallet-btn-corner:not(.connected):hover {
-  transform: none;
-  box-shadow: 0 0 10px rgba(140, 80, 255, .1);
-}
 
 .wallet-info {
   display: none;

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -196,23 +196,32 @@ function applyOnboardingUiState() {
   }
 
   if (runtimeMode === 'web_guest_first_visit') {
+    const completeGuestFirstVisit = ({ skipped = false } = {}) => {
+      writeWebGuestOnboardingSeen();
+      clearFirstRunWalletDimming();
+      if (skipped) {
+        hideSpotlight();
+        trackOnboardingStepEvent('onboarding_guest_skipped');
+        return;
+      }
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
+    };
+
     showSpotlight({
       target: '#startBtn',
       text: 'Start your first run',
       showSkip: true,
-      onSkip: () => {
-        writeWebGuestOnboardingSeen();
-        clearFirstRunWalletDimming();
-        hideSpotlight();
-        trackOnboardingStepEvent('onboarding_guest_skipped');
-      },
-      onTargetClick: () => {
-        writeWebGuestOnboardingSeen();
-        clearFirstRunWalletDimming();
-        trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
-      },
+      onSkip: () => completeGuestFirstVisit({ skipped: true }),
+      onTargetClick: () => completeGuestFirstVisit(),
       step: 'guest_start'
-    }) || showSpotlightBySelector({ selector: '#startBtn', text: 'Start your first run', showSkip: true });
+    }) || showSpotlight({
+      target: '#startBtn',
+      text: 'Start your first run',
+      showSkip: true,
+      onSkip: () => completeGuestFirstVisit({ skipped: true }),
+      onTargetClick: () => completeGuestFirstVisit(),
+      step: 'guest_start_fallback'
+    });
     return;
   }
 


### PR DESCRIPTION
### Motivation

- Simplify and centralize the behavior for the web-guest-first-visit onboarding spotlight to avoid duplicated callback logic. 
- Stop visually dimming the corner wallet button during the onboarding first run to keep consistent UI affordance.

### Description

- Introduce a `completeGuestFirstVisit` helper in `js/features/onboarding/index.js` to consolidate the actions performed when the guest onboarding is completed or skipped. 
- Update `showSpotlight` calls for the `web_guest_first_visit` runtime mode to use the new helper for both `onSkip` and `onTargetClick` and add a fallback `showSpotlight` with a distinct `step` of `guest_start_fallback`. 
- Remove CSS rules that dimmed the corner wallet button during the first-run onboarding by deleting the `.onboarding-first-run .wallet-btn-corner:not(.connected)` and its `:hover` rules from `css/style.css`.

### Testing

- Built the frontend locally with `npm run build` and verified the bundle completed without errors. 
- Ran linting with `npm run lint` and resolved reported issues; lint completed successfully. 
- Executed the frontend unit tests with `npm test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cd8abe188326a52c9e3047a2c186)