### PR TITLE
Invalidate onboarding cache on auth transitions and refresh state on connect/disconnect

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -1,4 +1,4 @@
-import { fetchOnboardingState } from './onboarding-service.js';
+import { fetchOnboardingState, resetOnboardingStateCache } from './onboarding-service.js';
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
 import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
@@ -285,6 +285,9 @@ function applyOnboardingUiState() {
 }
 
 async function refreshOnboardingState({ reason = 'manual' } = {}) {
+  if (String(reason || '').startsWith('auth_')) {
+    resetOnboardingStateCache({ clearIdentity: true });
+  }
   const remote = await fetchOnboardingState();
   if (remote) onboardingState = writeCachedOnboardingState(remote);
   applyOnboardingUiState();

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -10,6 +10,12 @@ let onboardingStateCache = null;
 let onboardingStateCacheIdentity = '';
 let hasLoggedMissingIdentity = false;
 
+function resetOnboardingStateCache({ clearIdentity = true } = {}) {
+  onboardingStateCache = null;
+  onboardingStateInFlightPromise = null;
+  if (clearIdentity) onboardingStateCacheIdentity = '';
+}
+
 function buildOnboardingStateUrl() {
   return buildBackendUrl('/api/onboarding/state');
 }
@@ -40,8 +46,7 @@ async function fetchOnboardingState() {
   });
 
   if (onboardingStateCacheIdentity !== identityKey) {
-    onboardingStateCache = null;
-    onboardingStateInFlightPromise = null;
+    resetOnboardingStateCache({ clearIdentity: false });
     onboardingStateCacheIdentity = identityKey;
   }
 
@@ -54,7 +59,7 @@ async function fetchOnboardingState() {
       hasLoggedMissingIdentity = true;
       logger.info('🧭 onboarding state: skip remote fetch (user identity unavailable)');
     }
-    onboardingStateCache = null;
+    resetOnboardingStateCache({ clearIdentity: false });
     return null;
   }
 
@@ -69,7 +74,7 @@ async function fetchOnboardingState() {
       if (!ok) {
         if (status === 400) {
           logger.info('🧭 onboarding state: backend returned 400, using local fallback');
-          onboardingStateCache = null;
+          resetOnboardingStateCache({ clearIdentity: false });
           return null;
         }
         return null;
@@ -80,7 +85,7 @@ async function fetchOnboardingState() {
       return normalizedState;
     } catch (_error) {
       logger.info('🧭 onboarding state fetch failed, using local fallback');
-      onboardingStateCache = null;
+      resetOnboardingStateCache({ clearIdentity: false });
       return null;
     } finally {
       onboardingStateInFlightPromise = null;
@@ -108,4 +113,4 @@ async function postOnboardingEvent(eventName) {
   }
 }
 
-export { fetchOnboardingState, postOnboardingEvent };
+export { fetchOnboardingState, postOnboardingEvent, resetOnboardingStateCache };

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -429,10 +429,11 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
       updatePlayerAvatarVisibility();
       resetAuthenticatedUiState();
       updateStartHook().catch(() => {});
+      refreshOnboardingState({ reason: 'auth_disconnected' }).catch(() => {});
     },
     onAuthAuthenticated: () => {
       updatePlayerAvatarVisibility();
-      refreshOnboardingState({ reason: 'auth_authenticated' }).catch(() => {});
+      refreshOnboardingState({ reason: 'auth_connected' }).catch(() => {});
       const hadWalletSessionBefore = _lastKnownWalletSession;
       const hasWalletNow = hasWalletAuthSession();
       _lastKnownWalletSession = hasWalletNow;


### PR DESCRIPTION
### Motivation
- Backend onboarding state now depends on authenticated gameplay history, so frontend must not reuse stale anonymous onboarding after auth changes. 
- Wallet connect and Telegram auto-auth must trigger an immediate onboarding refresh so authorized onboarding UI appears without delay. 
- Guest onboarding state must remain independent (guest skip/seen must not affect authorized onboarding). 

### Description
- Added `resetOnboardingStateCache()` in `js/features/onboarding/onboarding-service.js` to clear cached onboarding state, any in-flight promise, and optionally the identity cache key. 
- Replaced direct cache clears with the new helper and exported it as `resetOnboardingStateCache`. 
- Changed `refreshOnboardingState()` in `js/features/onboarding/index.js` to call `resetOnboardingStateCache({ clearIdentity: true })` when `reason` starts with `auth_`, forcing a fresh backend fetch on auth transitions. 
- Updated auth callbacks in `js/game/bootstrap.js` to call `refreshOnboardingState({ reason: 'auth_connected' })` on successful auth and `refreshOnboardingState({ reason: 'auth_disconnected' })` on logout/disconnect. 

### Testing
- Ran `npm run -s test -- scripts/onboarding-hints.test.mjs` and tests passed. 
- Pre-commit checks executed during the commit (`check:syntax` and `check:static-analysis`) passed successfully. 
- Verified changes compile and unit tests in the run did not fail (all relevant automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020ecb1e00832689f0dadf3a912e75)