### PR TITLE
Refine guest onboarding flow: rename storage key, add dismiss-on-wallet-connect, improve logging and flow handling

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -29,9 +29,10 @@ let onboardingState = { ...DEFAULT_ONBOARDING_STATE };
 let currentScreen = 'menu';
 
 const COMPLETED_EVENT_KEY = 'ursas.onboarding.completed.event.v1';
-const WEB_GUEST_ONBOARDING_SEEN_KEY = 'ursas.webGuestOnboarding.seen.v1';
+const WEB_GUEST_ONBOARDING_DISMISSED_KEY = 'ursas.guest.onboarding.dismissed.v1';
 const skippedSteps = new Set();
 let lastRuntimeMode = null;
+let guestOnboardingSpotlightActive = false;
 
 function trackOnboardingStepEvent(eventName, extra = {}) {
   trackAnalyticsEvent(eventName, {
@@ -64,16 +65,16 @@ function getGuestOnboardingStorage() {
   return null;
 }
 
-function readWebGuestOnboardingSeen() {
+function readWebGuestOnboardingDismissed() {
   const storage = getGuestOnboardingStorage();
   if (!storage) return false;
-  return storage.getItem(WEB_GUEST_ONBOARDING_SEEN_KEY) === '1';
+  return storage.getItem(WEB_GUEST_ONBOARDING_DISMISSED_KEY) === '1';
 }
 
-function writeWebGuestOnboardingSeen() {
+function writeWebGuestOnboardingDismissed() {
   const storage = getGuestOnboardingStorage();
   if (!storage) return;
-  storage.setItem(WEB_GUEST_ONBOARDING_SEEN_KEY, '1');
+  storage.setItem(WEB_GUEST_ONBOARDING_DISMISSED_KEY, '1');
 }
 
 function logOnboardingDiagnostic(event, extra = {}) {
@@ -83,7 +84,7 @@ function logOnboardingDiagnostic(event, extra = {}) {
     currentScreen,
     step: resolveMappedStep(onboardingState.step),
     completed: Boolean(onboardingState.completed),
-    guestSeen: readWebGuestOnboardingSeen(),
+    guestDismissed: readWebGuestOnboardingDismissed(),
     ...extra
   });
 }
@@ -106,7 +107,7 @@ function resolveOnboardingRuntimeMode() {
   }
 
   if (hasAuthSession) return 'web_authenticated';
-  if (!readWebGuestOnboardingSeen()) return 'web_guest_first_visit';
+  if (!readWebGuestOnboardingDismissed()) return 'web_guest_onboarding';
   return 'web_guest';
 }
 
@@ -196,56 +197,73 @@ function applyOnboardingUiState() {
   const runtimeMode = resolveOnboardingRuntimeMode();
   lastRuntimeMode = runtimeMode;
 
-  const step = resolveMappedStep(onboardingState.step);
-  if (onboardingState.completed || step === STEP.COMPLETED) {
-    trackOnboardingCompletedOnce();
-    return;
-  }
-
   if (runtimeMode === 'telegram_auth_pending') return;
   if (runtimeMode === 'telegram_auth_failed') {
     logger.warn('⚠️ Telegram auth failed; onboarding waiting for auth retry');
     return;
   }
 
-  if (runtimeMode === 'web_guest_first_visit') {
-    const completeGuestFirstVisit = ({ skipped = false } = {}) => {
+  if (runtimeMode === 'web_guest_onboarding') {
+    logOnboardingDiagnostic('show_guest_onboarding');
+    const completeGuestOnboarding = ({ skipped = false } = {}) => {
       clearFirstRunWalletDimming();
-      writeWebGuestOnboardingSeen();
+      writeWebGuestOnboardingDismissed();
       if (skipped) {
         hideSpotlight();
         trackOnboardingStepEvent('onboarding_guest_skipped');
-        logOnboardingDiagnostic('guest_first_visit_skip', { selector: '#startBtn' });
+        logOnboardingDiagnostic('guest_onboarding_skip', { selector: '#startBtn' });
         return;
       }
-      trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest' });
-      logOnboardingDiagnostic('guest_first_visit_click', { selector: '#startBtn' });
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: '#startBtn', flow: 'web_guest_onboarding' });
+      logOnboardingDiagnostic('guest_onboarding_click', { selector: '#startBtn' });
     };
 
     const renderGuestSpotlight = (attempt = 1) => showSpotlight({
       target: '#startBtn',
       text: 'Start your first run',
       showSkip: true,
-      onSkip: () => completeGuestFirstVisit({ skipped: true }),
-      onTargetClick: () => completeGuestFirstVisit(),
+      onSkip: () => completeGuestOnboarding({ skipped: true }),
+      onTargetClick: () => completeGuestOnboarding(),
       step: attempt > 1 ? 'guest_start_retry' : 'guest_start'
     });
     const shown = renderGuestSpotlight(1);
-    logOnboardingDiagnostic('guest_first_visit_spotlight', { selector: '#startBtn', showSpotlightResult: shown });
+    guestOnboardingSpotlightActive = shown;
+    logOnboardingDiagnostic('guest_onboarding_spotlight', { selector: '#startBtn', showSpotlightResult: shown });
     if (!shown) {
       let retries = 0;
       const retry = () => {
         retries += 1;
         const retryShown = renderGuestSpotlight(retries + 1);
-        logOnboardingDiagnostic('guest_first_visit_retry', { selector: '#startBtn', retries, showSpotlightResult: retryShown });
+        if (retryShown) guestOnboardingSpotlightActive = true;
+        logOnboardingDiagnostic('guest_onboarding_retry', { selector: '#startBtn', retries, showSpotlightResult: retryShown });
         if (!retryShown && retries < 10) requestAnimationFrame(() => setTimeout(retry, 50));
+        if (!retryShown && retries >= 10) logger.warn('⚠️ guest onboarding spotlight target not found', { selector: '#startBtn', retries });
       };
       requestAnimationFrame(() => setTimeout(retry, 50));
     }
     return;
   }
 
-  if (step === 'unknown') return;
+  const step = resolveMappedStep(onboardingState.step);
+
+  if (onboardingState.completed || step === STEP.COMPLETED) {
+    logOnboardingDiagnostic('return_completed');
+    trackOnboardingCompletedOnce();
+    return;
+  }
+
+  if (runtimeMode === 'web_guest') {
+    logOnboardingDiagnostic('return_web_guest_dismissed');
+    guestOnboardingSpotlightActive = false;
+    return;
+  }
+
+  guestOnboardingSpotlightActive = false;
+
+  if (step === 'unknown') {
+    logOnboardingDiagnostic('return_unknown_step');
+    return;
+  }
   if (skippedSteps.has(step)) return;
 
   trackOnboardingStepEvent('onboarding_step_shown', { presentation: step, screen: currentScreen });
@@ -324,7 +342,7 @@ async function initOnboardingFeature() {
   return { ...onboardingState };
 }
 
-export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen };
+export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect };
 function showAuthSpotlight({ selector, text }) {
   return showSpotlight({
     target: selector,
@@ -339,4 +357,12 @@ function showAuthSpotlight({ selector, text }) {
     },
     step: resolveMappedStep(onboardingState.step)
   }) || showSpotlightBySelector({ selector, text, showSkip: true });
+}
+
+
+function dismissGuestOnboardingOnWalletConnect() {
+  if (lastRuntimeMode !== 'web_guest_onboarding') return;
+  if (!guestOnboardingSpotlightActive) return;
+  writeWebGuestOnboardingDismissed();
+  logOnboardingDiagnostic('guest_onboarding_wallet_connect_dismissed');
 }

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -15,7 +15,7 @@ import { trackAnalyticsEvent } from '../analytics.js';
 import { initAiMode } from '../ai-mode.js';
 import { shouldShowFirstRunHint } from './onboarding-hints.js';
 import { initPlayerMenu, openPlayerMenu, isPlayerMenuOpen, refreshPlayerMenu } from '../features/player-menu/index.js';
-import { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen } from '../features/onboarding/index.js';
+import { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect } from '../features/onboarding/index.js';
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { identifyPostHogUser, resetPostHogUser } from '../integrations/posthog/index.js';
 import { trackTelegramEvent } from '../telegram-analytics.js';
@@ -432,6 +432,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
       refreshOnboardingState({ reason: 'auth_disconnected' }).catch(() => {});
     },
     onAuthAuthenticated: () => {
+      dismissGuestOnboardingOnWalletConnect();
       updatePlayerAvatarVisibility();
       refreshOnboardingState({ reason: 'auth_connected' })
         .then(() => applyOnboardingForScreen())


### PR DESCRIPTION
### Motivation
- Clarify and standardize the guest onboarding state by treating the guest flow as a "dismissed" flag rather than "seen" and ensure the UI is dismissed when the user connects a wallet.
- Prevent the guest spotlight from lingering after a wallet connection and improve runtime-mode detection for guest visits.
- Improve diagnostics and retry handling for the guest spotlight to aid debugging when the target element is not present.

### Description
- Renamed storage constant and functions from `WEB_GUEST_ONBOARDING_SEEN`/`readWebGuestOnboardingSeen`/`writeWebGuestOnboardingSeen` to `WEB_GUEST_ONBOARDING_DISMISSED`/`readWebGuestOnboardingDismissed`/`writeWebGuestOnboardingDismissed` and updated all usages.
- Introduced `guestOnboardingSpotlightActive` flag and adjusted `applyOnboardingUiState` to handle `web_guest_onboarding` runtime mode, to explicitly skip when `web_guest` (dismissed) and to log early-return cases like completed or unknown steps.
- Added additional diagnostic log events and changed event names from `guest_first_visit_*` to `guest_onboarding_*`, and log a warning when guest spotlight retries exceed the attempt limit.
- Exported and implemented `dismissGuestOnboardingOnWalletConnect` which writes the dismissed flag and logs a diagnostic only when a guest-onboarding spotlight was active, and invoked it from the bootstrap `onAuthAuthenticated` callback.

### Testing
- Ran the project test suite with `npm test` and all tests completed successfully.
- Built the frontend with `npm run build` and the build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021ae1c7548326984405cdfea72c6f)