### PR TITLE
Отключить кнопку PLAY AGAIN на Game Over при отсутствии заездов

### DIFF
--- a/js/store/rides-service.js
+++ b/js/store/rides-service.js
@@ -129,7 +129,7 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
   }
 
   function updateRidesDisplay() {
-    const { ridesInfo, ridesText, ridesTimer, startBtn } = DOM;
+    const { ridesInfo, ridesText, ridesTimer, startBtn, restartBtn } = DOM;
     if (!ridesInfo) return;
 
     if (!isAuthenticated() && !isUnauthRuntimeMode()) {
@@ -178,6 +178,18 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
         startBtn.style.opacity = '';
         startBtn.style.pointerEvents = '';
         startBtn.textContent = 'START GAME';
+      }
+    }
+
+    if (restartBtn) {
+      if (limited && (total || 0) <= 0) {
+        restartBtn.style.opacity = '0.4';
+        restartBtn.style.pointerEvents = 'none';
+        restartBtn.textContent = `NO RIDES (${currentRides.resetInFormatted})`;
+      } else {
+        restartBtn.style.opacity = '';
+        restartBtn.style.pointerEvents = '';
+        restartBtn.textContent = 'PLAY AGAIN';
       }
     }
   }


### PR DESCRIPTION
### Motivation
- Сделать поведение экрана Game Over консистентным с главной страницей: когда у игрока закончились заезды, кнопка повторного запуска должна быть неактивной и показывать таймер сброса.

### Description
- Внесена правка в `js/store/rides-service.js`: в `updateRidesDisplay` добавлен `restartBtn` в дескруктуризацию `DOM` и синхронизация состояния с логикой `startBtn`.
- Когда есть лимит и `totalRides <= 0`, для `#restartBtn` устанавливается `style.opacity = '0.4'`, `style.pointerEvents = 'none'` и текст `NO RIDES (<reset timer>)`; иначе восстанавливается нормальное состояние с текстом `PLAY AGAIN`.
- Изменения затрагивают только обновление отображения UI (функция `updateRidesDisplay`) и не меняют контрактов с бэкендом.

### Testing
- Запуск `npm run -s check` успешно прошёл и включал статический анализ, тесты и смоки-синонимы; все проверки прошли успешно.
- Пред-commit проверки `check:syntax` и `check:static-analysis` успешно завершились при фиксации изменений.
- UI button check (сканирование кнопок в HTML) прошёл успешно, подтверждая корректную интеграцию новой логики в интерфейс.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0229b5638c83269e7b756ae52e6dab)