### PR TITLE
Hide guest onboarding spotlight when Start Game is clicked

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -208,8 +208,9 @@ function applyOnboardingUiState() {
     const completeGuestOnboarding = ({ skipped = false } = {}) => {
       clearFirstRunWalletDimming();
       writeWebGuestOnboardingDismissed();
+      guestOnboardingSpotlightActive = false;
+      hideSpotlight();
       if (skipped) {
-        hideSpotlight();
         trackOnboardingStepEvent('onboarding_guest_skipped');
         logOnboardingDiagnostic('guest_onboarding_skip', { selector: '#startBtn' });
         return;


### PR DESCRIPTION
### Motivation
- Prevent the onboarding dimming/spotlight and the `Skip` control from remaining visible on the preload screen after a guest presses the Start Game button.

### Description
- In `js/features/onboarding/index.js` update `completeGuestOnboarding` to immediately clear `guestOnboardingSpotlightActive` and call `hideSpotlight()` before handling `skipped` so the spotlight/UI is removed as soon as Start is clicked.

### Testing
- Ran `npm run test` (all tests passed: 86/86) and pre-commit static checks `check:syntax` and `check:static-analysis` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022a13beb0832695e90e5f61509fab)