### PR TITLE
Add authorized game-over onboarding continuation spotlights

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -1,4 +1,4 @@
-import { fetchOnboardingState, resetOnboardingStateCache } from './onboarding-service.js';
+import { fetchOnboardingState, postOnboardingEvent, resetOnboardingStateCache } from './onboarding-service.js';
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
 import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
@@ -111,7 +111,33 @@ function resolveOnboardingRuntimeMode() {
   return 'web_guest';
 }
 
-function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) {
+
+function buildBonusBubbleContent({ text, coinType = '' } = {}) {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'display:flex;align-items:center;gap:8px;';
+
+  const textNode = document.createElement('span');
+  textNode.textContent = String(text || '');
+  wrap.appendChild(textNode);
+
+  const coin = document.createElement('span');
+  coin.setAttribute('aria-hidden', 'true');
+  if (coinType === 'silver' || coinType === 'gold') {
+    coin.className = `icon-atlas icon-coin-${coinType}`;
+  } else {
+    coin.textContent = '🪙';
+  }
+  wrap.appendChild(coin);
+
+  return wrap;
+}
+
+function onAuthSpotlightSkip() {
+  skippedSteps.add(resolveMappedStep(onboardingState.step));
+  trackOnboardingStepEvent('onboarding_step_skipped');
+}
+
+function showSpotlightBySelector({ selector, text = '', content = null, showSkip = true, onTargetClick, onSkip } = {}) {
   const maxAttempts = 10;
   let attempts = 0;
   const step = resolveMappedStep(onboardingState.step);
@@ -121,14 +147,14 @@ function showSpotlightBySelector({ selector, text = '', showSkip = true } = {}) 
     const shown = showSpotlight({
       target: selector,
       text,
+      content,
       showSkip,
-      onSkip: () => {
-        skippedSteps.add(resolveMappedStep(onboardingState.step));
-        trackOnboardingStepEvent('onboarding_step_skipped');
-      },
-      onTargetClick: () => {
-        trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
-      },
+      onSkip: typeof onSkip === 'function' ? onSkip : onAuthSpotlightSkip,
+      onTargetClick: typeof onTargetClick === 'function'
+        ? onTargetClick
+        : () => {
+          trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
+        },
       step
     });
     logOnboardingDiagnostic('show_spotlight_attempt', { selector, showSpotlightResult: shown, attempts, showSkip });
@@ -273,15 +299,20 @@ function applyOnboardingUiState() {
     return;
   }
   if ((step === STEP.AUTH_RUN_1_DONE || step === STEP.AFTER_FIRST_RUN) && currentScreen === 'game-over') {
-    showAuthSpotlight({ selector: '#restartBtn', text: 'Run again. Get +100 silver' });
+    showAuthSpotlight({ selector: '#restartBtn', content: () => buildBonusBubbleContent({ text: 'Play again and get +100', coinType: 'silver' }) });
     return;
   }
   if ((step === STEP.AUTH_RUN_2_DONE || step === STEP.AFTER_SECOND_RUN) && currentScreen === 'game-over') {
-    showAuthSpotlight({ selector: '#restartBtn', text: 'One more run. Get +100 gold' });
+    showAuthSpotlight({ selector: '#restartBtn', content: () => buildBonusBubbleContent({ text: 'Play again and get +100', coinType: 'gold' }) });
     return;
   }
   if ((step === STEP.AUTH_RUN_3_DONE || step === STEP.AFTER_THIRD_RUN) && currentScreen === 'game-over') {
-    showAuthSpotlight({ selector: '#shareResultBtn', text: 'Connect X for more rewards' });
+    showAuthSpotlight({ selector: '#shareResultBtn', text: 'Share your result and get a bonus', onTargetClick: async () => {
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: '#shareResultBtn' });
+      await postOnboardingEvent('connect_x_clicked');
+      await refreshOnboardingState({ reason: 'connect_x_clicked' });
+      hideSpotlight();
+    } });
     return;
   }
   const pendingGift = getPendingRadarGift();
@@ -343,20 +374,22 @@ async function initOnboardingFeature() {
 }
 
 export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect };
-function showAuthSpotlight({ selector, text }) {
+function showAuthSpotlight({ selector, text = '', content = null, onTargetClick } = {}) {
+  const handleTargetClick = typeof onTargetClick === 'function'
+    ? onTargetClick
+    : () => {
+      trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
+    };
+
   return showSpotlight({
     target: selector,
     text,
+    content,
     showSkip: true,
-    onSkip: () => {
-      skippedSteps.add(resolveMappedStep(onboardingState.step));
-      trackOnboardingStepEvent('onboarding_step_skipped');
-    },
-    onTargetClick: () => {
-      trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
-    },
+    onSkip: onAuthSpotlightSkip,
+    onTargetClick: handleTargetClick,
     step: resolveMappedStep(onboardingState.step)
-  }) || showSpotlightBySelector({ selector, text, showSkip: true });
+  }) || showSpotlightBySelector({ selector, text, showSkip: true, content, onTargetClick: handleTargetClick, onSkip: onAuthSpotlightSkip });
 }
 
 

--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -54,7 +54,7 @@ export function hideSpotlight() {
   spotlightRoot.innerHTML = '';
 }
 
-export function showSpotlight({ target, text = '', showSkip = true, onSkip, onTargetClick, step = 'unknown' } = {}) {
+export function showSpotlight({ target, text = '', content = null, showSkip = true, onSkip, onTargetClick, step = 'unknown' } = {}) {
   const root = ensureSpotlightRoot();
   if (!root || !target) return false;
 
@@ -105,9 +105,25 @@ export function showSpotlight({ target, text = '', showSkip = true, onSkip, onTa
     'pointer-events:auto',
   ].join(';');
 
-  const textNode = document.createElement('div');
-  textNode.textContent = text || '';
-  bubble.appendChild(textNode);
+  const appendBubbleContent = () => {
+    if (content instanceof Node) {
+      bubble.appendChild(content);
+      return;
+    }
+
+    if (typeof content === 'function') {
+      const built = content();
+      if (built instanceof Node) {
+        bubble.appendChild(built);
+        return;
+      }
+    }
+
+    const textNode = document.createElement('div');
+    textNode.textContent = text || '';
+    bubble.appendChild(textNode);
+  };
+  appendBubbleContent();
 
   const targetProxy = document.createElement('button');
   targetProxy.type = 'button';
@@ -143,7 +159,9 @@ export function showSpotlight({ target, text = '', showSkip = true, onSkip, onTa
     ].join(';');
   }
 
-  if (!String(text || '').trim()) {
+  const hasText = String(text || '').trim().length > 0;
+  const hasContent = Boolean(content);
+  if (!hasText && !hasContent) {
     bubble.style.display = 'none';
   }
 
@@ -191,7 +209,7 @@ export function showSpotlight({ target, text = '', showSkip = true, onSkip, onTa
     dimRight.style.width = `${Math.max(0, viewport.left + viewport.width - (left + width))}px`;
     dimRight.style.height = `${height}px`;
 
-    if (!String(text || '').trim()) return;
+    if (!hasText && !hasContent) return;
 
     const bubbleRect = bubble.getBoundingClientRect();
     const belowTop = top + height + 10;


### PR DESCRIPTION
### Motivation

- Implement visual onboarding continuation on the Game Over screen for authorized users across three post-run steps so they see targeted guidance and bonuses without changing gameplay/backend/store assets. 
- Ensure the overlay spotlights are robust against async UI rendering and keep the `Skip` control always available.

### Description

- Extended the spotlight API to accept optional DOM `content` (Node or builder function) in addition to `text`, keeping text as a fallback and avoiding unsafe `innerHTML` usage (`js/features/onboarding/spotlight.js`).
- Added a safe DOM bubble builder `buildBonusBubbleContent` that programmatically composes the bonus text + coin icon (silver/gold) and used it for first/second run spotlights (`js/features/onboarding/index.js`).
- Wired authorized onboarding steps so that when `currentScreen === 'game-over'`: the 1st run highlights `#restartBtn` with a silver bonus bubble, the 2nd run highlights `#restartBtn` with a gold bonus bubble, and the 3rd run highlights `#shareResultBtn` and posts an onboarding event `connect_x_clicked`, calls `refreshOnboardingState({ reason: 'connect_x_clicked' })`, and hides the spotlight on click (`js/features/onboarding/index.js`, uses `postOnboardingEvent`).
- Kept retry placement logic for Game Over targets (up to 10 attempts with `requestAnimationFrame` + `setTimeout`) and unified skip/click tracking behavior via `showSpotlightBySelector`/`showAuthSpotlight` changes, without touching guest onboarding flow or backend/gameplay logic.

### Testing

- Ran `node --check` on modified modules (`js/features/onboarding/index.js`, `js/features/onboarding/spotlight.js`) and checks passed.
- Pre-commit automated checks executed `scripts/check-syntax.mjs` and `scripts/check-static-analysis.mjs` as part of the commit pipeline and both succeeded. 
- No runtime integration tests were modified; behavior relies on existing DOM ids (`#restartBtn`, `#shareResultBtn`) verified in `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022a7cd9c083269aedb6ecbe43d9f4)