### PR TITLE
Hide onboarding/auth spotlights when completed or skipped

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -208,8 +208,9 @@ function applyOnboardingUiState() {
     const completeGuestOnboarding = ({ skipped = false } = {}) => {
       clearFirstRunWalletDimming();
       writeWebGuestOnboardingDismissed();
+      guestOnboardingSpotlightActive = false;
+      hideSpotlight();
       if (skipped) {
-        hideSpotlight();
         trackOnboardingStepEvent('onboarding_guest_skipped');
         logOnboardingDiagnostic('guest_onboarding_skip', { selector: '#startBtn' });
         return;
@@ -344,15 +345,18 @@ async function initOnboardingFeature() {
 
 export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect };
 function showAuthSpotlight({ selector, text }) {
+  const closeAuthSpotlight = () => hideSpotlight();
   return showSpotlight({
     target: selector,
     text,
     showSkip: true,
     onSkip: () => {
+      closeAuthSpotlight();
       skippedSteps.add(resolveMappedStep(onboardingState.step));
       trackOnboardingStepEvent('onboarding_step_skipped');
     },
     onTargetClick: () => {
+      closeAuthSpotlight();
       trackOnboardingStepEvent('onboarding_step_clicked', { target: selector });
     },
     step: resolveMappedStep(onboardingState.step)


### PR DESCRIPTION
### Motivation
- Ensure onboarding and authentication spotlight UI is properly dismissed and internal flags are cleared when a guest finishes or skips onboarding, or when the auth spotlight is interacted with, to avoid stray spotlight UI.

### Description
- Set `guestOnboardingSpotlightActive = false` and call `hideSpotlight()` when completing guest onboarding, and add a `closeAuthSpotlight` helper in `showAuthSpotlight` that calls `hideSpotlight()` and is invoked on skip and target click to guarantee the spotlight is closed.

### Testing
- Ran automated checks with `npm test` and `npm run lint`, and the test/lint runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022a13beb0832695e90e5f61509fab)