### PR TITLE
Fix onboarding spotlight so button hover works

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -125,19 +125,6 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   };
   appendBubbleContent();
 
-  const targetProxy = document.createElement('button');
-  targetProxy.type = 'button';
-  targetProxy.setAttribute('aria-label', 'Onboarding target action');
-  targetProxy.style.cssText = [
-    'position:absolute',
-    'border:0',
-    'background:transparent',
-    'cursor:pointer',
-    'pointer-events:auto',
-    'z-index:3',
-    'padding:0',
-  ].join(';');
-
   let skipFixedBtn = null;
   if (showSkip) {
     skipFixedBtn = document.createElement('button');
@@ -165,7 +152,7 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
     bubble.style.display = 'none';
   }
 
-  container.append(dimmer, hole, targetProxy, bubble);
+  container.append(dimmer, hole, bubble);
   if (skipFixedBtn) container.appendChild(skipFixedBtn);
   root.appendChild(container);
 
@@ -185,10 +172,6 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
     hole.style.top = `${top}px`;
     hole.style.width = `${width}px`;
     hole.style.height = `${height}px`;
-    targetProxy.style.left = `${left}px`;
-    targetProxy.style.top = `${top}px`;
-    targetProxy.style.width = `${width}px`;
-    targetProxy.style.height = `${height}px`;
     dimTop.style.left = `${viewport.left}px`;
     dimTop.style.top = `${viewport.top}px`;
     dimTop.style.width = `${viewport.width}px`;
@@ -241,16 +224,10 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   };
 
   dimmer.addEventListener('click', swallowClick);
-  const targetClickHandler = () => {
+  const onTargetElementClick = () => {
     if (typeof onTargetClick === 'function') onTargetClick({ target, element: targetElement });
   };
-  const onTargetProxyClick = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    targetClickHandler();
-    targetElement.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-  };
-  targetProxy.addEventListener('click', onTargetProxyClick);
+  targetElement.addEventListener('click', onTargetElementClick);
 
   if (skipFixedBtn) {
     const onSkipClick = (event) => {
@@ -278,7 +255,7 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   }
 
   cleanupFns.push(() => dimmer.removeEventListener('click', swallowClick));
-  cleanupFns.push(() => targetProxy.removeEventListener('click', onTargetProxyClick));
+  cleanupFns.push(() => targetElement.removeEventListener('click', onTargetElementClick));
 
   schedulePlace();
   const targetRect = targetElement.getBoundingClientRect();


### PR DESCRIPTION
### Motivation

- Onboarding used a transparent `targetProxy` overlay that sat on top of highlighted controls and prevented native CSS `:hover` from activating on start-screen buttons.
- Restore hover interactions during onboarding while keeping outside-area click blocking so the spotlight UX remains intact.

### Description

- Removed the `targetProxy` overlay creation and its insertion into the spotlight container in `js/features/onboarding/spotlight.js`.
- Stopped positioning the proxy in `place()` and instead bind `onTargetClick` directly to the real `targetElement` with `targetElement.addEventListener('click', onTargetElementClick)`.
- Kept dimmer segments and the `swallowClick` handler to block clicks outside the highlighted area and added cleanup to remove the new click listener on hide.

### Testing

- Ran `node scripts/onboarding-hints.test.mjs` and all tests passed.
- Pre-commit automated checks (`npm run check:syntax` and `npm run check:static-analysis`) executed by hooks and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0249e5bd60832691293124ae810259)