### PR TITLE
Normalize onboarding screen names to fix game-over spotlight for second race

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -9,6 +9,13 @@ import { hasAuthenticatedSession, isTelegramMiniApp } from '../auth/index.js';
 const WEB_GUEST_ONBOARDING_DISMISSED_KEY = 'ursas.guest.onboarding.dismissed.v1';
 const AUTH_SCREENS = new Set(['menu', 'game-over', 'store']);
 
+function normalizeScreenName(screen) {
+  return String(screen || '')
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+}
+
 let onboardingState = { ...DEFAULT_ONBOARDING_STATE };
 let currentScreen = 'menu';
 let lastShownSignature = '';
@@ -49,7 +56,8 @@ async function sendEvent(action, active) {
 }
 
 function showAuthorizedOnboarding(active) {
-  if (!active || !AUTH_SCREENS.has(currentScreen) || active.screen !== currentScreen) return;
+  const activeScreen = normalizeScreenName(active?.screen);
+  if (!active || !AUTH_SCREENS.has(currentScreen) || activeScreen !== currentScreen) return;
   const selector = TARGET_SELECTOR_MAP[active.target];
   if (!selector) { logger.warn('⚠️ onboarding target mapping missing', { target: active.target }); return; }
 
@@ -122,7 +130,7 @@ async function refreshOnboardingState({ reason = 'manual', screen = null, resetC
 }
 
 function applyOnboardingForScreen(screen) {
-  currentScreen = String(screen || currentScreen || 'menu');
+  currentScreen = normalizeScreenName(screen || currentScreen || 'menu') || 'menu';
   if (isAuthorizedRuntime() && AUTH_SCREENS.has(currentScreen)) {
     refreshOnboardingState({ reason: `screen_${currentScreen}`, screen: currentScreen }).catch(() => applyOnboardingUiState());
     return;


### PR DESCRIPTION
### Motivation
- The onboarding spotlight for the "second race" did not appear on the Game Over screen because backend screen identifiers used underscores (e.g. `game_over`) while the frontend expected hyphenated names (e.g. `game-over`).
- Make onboarding screen matching robust against different naming styles so authorized onboarding renders reliably on screen changes.

### Description
- Add `normalizeScreenName(screen)` to normalize screen identifiers by trimming, lower-casing and converting underscores to hyphens.
- Use the normalizer when deciding whether to show an authorized onboarding spotlight in `showAuthorizedOnboarding` so `active.screen` from the backend matches the frontend `currentScreen`.
- Normalize incoming screen names in `applyOnboardingForScreen` so runtime events and backend-provided screen values are compared consistently.
- No behavior changes to spotlight rendering or event posting beyond improving the screen name comparison.

### Testing
- Ran `node scripts/check-syntax.mjs` which completed successfully.
- Pre-commit static analysis (`check:static-analysis`) and syntax checks ran during the commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024b932e9c832689956ff9c10adc95)