### PR TITLE
Resolve authorized onboarding fallback across screens and normalize statuses

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -31,6 +31,20 @@ const TARGET_SELECTOR_MAP = Object.freeze({
   radar_gold_card: '#store-radargold-0'
 });
 
+const ONBOARDING_FALLBACK_FLOW = [
+  { key: 'first_race', screen: 'menu', target: 'start_game', when: (state) => state.raceCount === 0 },
+  { key: 'second_race_game_over', screen: 'game-over', target: 'play_again', hook: 'Play again and get +100 silver', when: (state) => state.raceCount === 1 },
+  { key: 'second_race_menu', screen: 'menu', target: 'start_game', hook: 'Play again and get +100 silver', when: (state) => state.raceCount === 1 },
+  { key: 'third_race_game_over', screen: 'game-over', target: 'play_again', hook: 'Play again and get +100 gold', when: (state) => state.raceCount === 2 },
+  { key: 'third_race_menu', screen: 'menu', target: 'start_game', hook: 'Play again and get +100 gold', when: (state) => state.raceCount === 2 },
+  { key: 'share_result_game_over', screen: 'game-over', target: 'connect_x_or_share_result', when: (state) => state.raceCount >= 3 && !state.xConnected },
+  { key: 'share_result_menu', screen: 'menu', target: 'connect_x_or_share_result', when: (state) => state.raceCount >= 3 && !state.xConnected },
+  { key: 'store_start', screen: 'menu', target: 'store_button', when: (state) => state.raceCount >= 3 },
+  { key: 'store_in', screen: 'store', target: 'ride_pack_3', when: (state) => state.raceCount >= 3 },
+  { key: 'gift_radar_obstacles_store', screen: 'store', target: 'radar_obstacles_card', when: (state) => state.gifts?.radar_obstacles_24h?.available },
+  { key: 'gift_radar_gold_store', screen: 'store', target: 'radar_gold_card', when: (state) => state.gifts?.radar_gold_24h?.available }
+];
+
 function isAuthorizedRuntime() {
   return isTelegramMiniApp() || hasAuthenticatedSession();
 }
@@ -42,12 +56,43 @@ function getHookText(active) {
   if (active?.hook) return String(active.hook);
   const map = {
     first_race: 'Take the lead / Start your first race',
-    second_race_game_over: 'Play again and get +100', second_race_menu: 'Play again and get +100',
-    third_race_game_over: 'Play again and get +100', third_race_menu: 'Play again and get +100',
+    second_race_game_over: 'Play again and get +100 silver', second_race_menu: 'Play again and get +100 silver',
+    third_race_game_over: 'Play again and get +100 gold', third_race_menu: 'Play again and get +100 gold',
     share_result_game_over: 'Share your result and get a bonus', share_result_menu: 'Connect X and get a bonus',
     store_start: 'Open Store to upgrade your runs', store_in: 'Highlight +3 rides pack'
   };
   return map[active?.key] || '';
+}
+
+function resolveActiveOnboardingForScreen(state, screen) {
+  const normalizedScreen = normalizeScreenName(screen);
+  const backendActive = state?.activeOnboarding;
+  if (backendActive && normalizeScreenName(backendActive.screen) === normalizedScreen) {
+    return backendActive;
+  }
+
+  const statuses = state?.onboarding || {};
+  const stateForResolution = {
+    raceCount: Number.isFinite(Number(state?.raceCount)) ? Number(state.raceCount) : 0,
+    xConnected: Boolean(state?.xConnected),
+    gifts: state?.gifts || {}
+  };
+
+  const candidate = ONBOARDING_FALLBACK_FLOW.find((entry) => {
+    if (entry.screen !== normalizedScreen) return false;
+    const status = String(statuses[entry.key] || 'none').toLowerCase();
+    return status === 'none' && entry.when(stateForResolution);
+  });
+
+  if (!candidate) return null;
+  return {
+    key: candidate.key,
+    screen: candidate.screen,
+    target: candidate.target,
+    status: String(statuses[candidate.key] || 'none').toLowerCase(),
+    hook: candidate.hook || '',
+    rewardPreview: null
+  };
 }
 
 async function sendEvent(action, active) {
@@ -57,9 +102,13 @@ async function sendEvent(action, active) {
 
 function showAuthorizedOnboarding(active) {
   const activeScreen = normalizeScreenName(active?.screen);
-  if (!active || !AUTH_SCREENS.has(currentScreen) || activeScreen !== currentScreen) return;
+  if (!active || !AUTH_SCREENS.has(currentScreen) || activeScreen !== currentScreen) {
+    logger.info('onboarding show skipped', { currentScreen, active });
+    return;
+  }
   const selector = TARGET_SELECTOR_MAP[active.target];
   if (!selector) { logger.warn('⚠️ onboarding target mapping missing', { target: active.target }); return; }
+  logger.info('onboarding show attempt', { currentScreen, key: active.key, target: active.target, selector, status: active.status, raceCount: onboardingState.raceCount, xConnected: onboardingState.xConnected, backendActiveOnboarding: onboardingState.activeOnboarding, resolvedActiveOnboarding: active });
 
   let attempts = 0;
   const render = () => {
@@ -114,7 +163,17 @@ function applyOnboardingUiState() {
     mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
   }
 
-  showAuthorizedOnboarding(onboardingState.activeOnboarding);
+  const active = resolveActiveOnboardingForScreen(onboardingState, currentScreen);
+  logger.info('onboarding resolved active', {
+    currentScreen,
+    raceCount: onboardingState.raceCount,
+    xConnected: onboardingState.xConnected,
+    backendActiveOnboarding: onboardingState.activeOnboarding,
+    resolvedActiveOnboarding: active,
+    resolvedStatus: active?.key ? onboardingState.onboarding?.[active.key] : null,
+    selector: active?.target ? TARGET_SELECTOR_MAP[active.target] : null
+  });
+  showAuthorizedOnboarding(active);
 }
 
 async function refreshOnboardingState({ reason = 'manual', screen = null, resetCache = false } = {}) {

--- a/js/features/onboarding/onboarding-state.js
+++ b/js/features/onboarding/onboarding-state.js
@@ -5,7 +5,9 @@ const DEFAULT_ONBOARDING_STATE = Object.freeze({
   completed: false,
   updatedAt: 0,
   raceCount: 0,
+  xConnected: false,
   activeOnboarding: null,
+  onboarding: {},
   gifts: {
     radar_obstacles_24h: { unlocked: false, claimed: false, skipped: false, available: false },
     radar_gold_24h: { unlocked: false, claimed: false, skipped: false, available: false }
@@ -26,11 +28,18 @@ function normalizeOnboardingState(input) {
   const giftsInput = input.gifts || onboarding.gifts || input.rewards || {};
   const boostsInput = onboarding.activeBoosts || onboarding.active_boosts || onboarding.effects || {};
   const activeOnboarding = input.activeOnboarding || onboarding.activeOnboarding || null;
+  const onboardingStatusesInput = input.onboardingStatuses || input.onboarding_statuses || onboarding.statuses || onboarding.onboarding || input.onboarding || {};
+  const normalizedOnboardingStatuses = Object.entries(onboardingStatusesInput && typeof onboardingStatusesInput === 'object' ? onboardingStatusesInput : {}).reduce((acc, [key, value]) => {
+    acc[String(key)] = typeof value === 'string' ? value : 'none';
+    return acc;
+  }, {});
   return {
     step: typeof onboarding.step === 'string' ? onboarding.step : 'unknown',
     completed: Boolean(onboarding.completed),
     updatedAt: Number.isFinite(Number(onboarding.updatedAt)) ? Number(onboarding.updatedAt) : Date.now(),
     raceCount: Number.isFinite(Number(input.raceCount)) ? Number(input.raceCount) : 0,
+    xConnected: Boolean(input.xConnected ?? input.x_connected ?? onboarding.xConnected ?? onboarding.x_connected),
+    onboarding: normalizedOnboardingStatuses,
     activeOnboarding: activeOnboarding && typeof activeOnboarding === 'object' ? {
       key: activeOnboarding.key || '', screen: activeOnboarding.screen || '', target: activeOnboarding.target || '',
       status: activeOnboarding.status || '', hook: activeOnboarding.hook || '', rewardPreview: activeOnboarding.rewardPreview || null


### PR DESCRIPTION
### Motivation
- Backend sometimes returns `raceCount`/statuses but omits `activeOnboarding` for the current screen, leaving the authorized frontend silent (notably `second_race_menu`); a deterministic frontend fallback is required. 

### Description
- Added `resolveActiveOnboardingForScreen(state, screen)` and `ONBOARDING_FALLBACK_FLOW` in `js/features/onboarding/index.js` to derive an active onboarding step from `raceCount`, `onboarding` statuses, `xConnected` and `gifts` when backend `activeOnboarding` is absent. 
- Implemented fallback entries for `first_race`, `second_race_*`, `third_race_*`, `share_result_*`, `store_*`, and `gift_*` with proper `screen/target/hook` mappings and reward copy. 
- Switched `applyOnboardingUiState()` to resolve the active onboarding via the new resolver and then call `showAuthorizedOnboarding(...)`. 
- Improved diagnostics and logging around resolution and show attempts and updated `getHookText` to include reward-specific strings (`+100 silver` / `+100 gold`). 
- Fixed backend state normalization in `js/features/onboarding/onboarding-state.js` by preserving `onboarding` statuses map and `xConnected` in the normalized state so fallback logic can inspect statuses (`none|skip|complete`). 
- Verified `TARGET_SELECTOR_MAP` selectors against the DOM ids in `index.html` (`#startBtn`, `#restartBtn`, `#shareResultBtn`, `#storeBtn`, `#store-ride-pack-3`, gift card ids) and kept the existing retry/warning behavior when a selector is not found.

### Testing
- Ran syntax checks with `node --check` for the modified files and they passed. 
- Pre-commit checks executed `npm run check:syntax` and `npm run check:static-analysis` and both completed successfully. 
- Changes were committed after the static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024d4db00483269f323530a05525a8)