### PR TITLE
Fix second-race onboarding visibility on game-over/menu

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -21,7 +21,7 @@ let lastShownSignature = '';
 
 const TARGET_SELECTOR_MAP = Object.freeze({
   start_game: '#startBtn',
-  play_again: '#restartBtn',
+  play_again: '#restartBtn, [data-action="restart-game"], .go-play-again, .play-again-btn',
   connect_x_or_share_result: '#shareResultBtn',
   store_button: '#storeBtn',
   store_back: '#storeBackBtn',
@@ -114,11 +114,27 @@ function showAuthorizedOnboarding(active) {
   if (!selector) { logger.warn('⚠️ onboarding target mapping missing', { target: active.target }); return; }
   logger.info('onboarding show attempt', { currentScreen, key: active.key, target: active.target, selector, status: active.status, raceCount: onboardingState.raceCount, xConnected: onboardingState.xConnected, backendActiveOnboarding: onboardingState.activeOnboarding, resolvedActiveOnboarding: active });
 
+  const resolveVisibleTarget = (selectorInput) => {
+    if (!selectorInput || typeof document === 'undefined') return null;
+    const selectors = String(selectorInput).split(',').map((item) => item.trim()).filter(Boolean);
+    for (const item of selectors) {
+      const element = document.querySelector(item);
+      if (!element) continue;
+      const rect = element.getBoundingClientRect?.();
+      const style = window.getComputedStyle?.(element);
+      const isVisible = Boolean(rect && rect.width > 0 && rect.height > 0 && style?.visibility !== 'hidden' && style?.display !== 'none');
+      if (isVisible) return { selector: item, element };
+    }
+    return null;
+  };
+
   let attempts = 0;
   const render = () => {
     attempts += 1;
+    const resolvedTarget = resolveVisibleTarget(selector);
+    const spotlightTarget = resolvedTarget?.selector || selector;
     const shown = showSpotlight({
-      target: selector,
+      target: spotlightTarget,
       text: getHookText(active),
       showSkip: true,
       onSkip: async () => { await sendEvent('skip', active); hideSpotlight(); },
@@ -168,6 +184,28 @@ function applyOnboardingUiState() {
   }
 
   const active = resolveActiveOnboardingForScreen(onboardingState, currentScreen);
+  const fallbackCandidate = ONBOARDING_FALLBACK_FLOW.find((entry) => {
+    if (entry.screen !== currentScreen) return false;
+    return entry.when({ raceCount: onboardingState.raceCount, xConnected: onboardingState.xConnected, gifts: onboardingState.gifts || {} });
+  }) || null;
+  const playAgainSelectorFound = Boolean(document.querySelector('#restartBtn, [data-action="restart-game"], .go-play-again, .play-again-btn'));
+  const startBtnSelectorFound = Boolean(document.querySelector('#startBtn'));
+  logger.info('onboarding second race debug', {
+    currentScreen,
+    normalizedRaceCount: onboardingState.raceCount,
+    backendRaceCountFields: {
+      raceCount: onboardingState.raceCount,
+      completedRuns: onboardingState.completedRuns,
+      finishedRuns: onboardingState.finishedRuns,
+      runsCompleted: onboardingState.runsCompleted,
+      onboardingRaceCount: onboardingState?.onboarding?.raceCount,
+      onboardingCompletedRuns: onboardingState?.onboarding?.completedRuns
+    },
+    activeOnboarding: onboardingState.activeOnboarding,
+    fallbackCandidate,
+    playAgainSelectorFound,
+    startBtnSelectorFound
+  });
   logger.info('onboarding resolved active', {
     currentScreen,
     raceCount: onboardingState.raceCount,

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -47,6 +47,15 @@ async function fetchOnboardingState({ screen = null } = {}) {
       const { ok, data } = await requestJsonResult(buildOnboardingStateUrl(screen), { ...REQUEST_PROFILE_LEADERBOARD_READ, retries: 0, headers });
       if (!ok) return null;
       const normalizedState = normalizeOnboardingState(data || {});
+      logger.info('onboarding state response debug', {
+        screen,
+        raceCount: data?.raceCount,
+        completedRuns: data?.completedRuns,
+        finishedRuns: data?.finishedRuns,
+        onboardingRaceCount: data?.onboarding?.raceCount,
+        normalizedRaceCount: normalizedState?.raceCount,
+        activeOnboarding: data?.activeOnboarding || null
+      });
       onboardingStateCache = normalizedState;
       return normalizedState;
     } catch (error) {

--- a/js/features/onboarding/onboarding-state.js
+++ b/js/features/onboarding/onboarding-state.js
@@ -25,6 +25,17 @@ const normalizeBackendBoost = (untilValue, fallbackInput) => { const endsAt = to
 function normalizeOnboardingState(input) {
   if (!input || typeof input !== 'object') return { ...DEFAULT_ONBOARDING_STATE };
   const onboarding = input.onboarding && typeof input.onboarding === 'object' ? input.onboarding : input;
+  const raceCountCandidates = [
+    input.raceCount,
+    input.completedRuns,
+    input.finishedRuns,
+    input.runsCompleted,
+    input.stats?.raceCount,
+    input.stats?.completedRuns,
+    onboarding.raceCount,
+    onboarding.completedRuns
+  ];
+  const normalizedRaceCount = raceCountCandidates.find((value) => Number.isFinite(Number(value)));
   const giftsInput = input.gifts || onboarding.gifts || input.rewards || {};
   const boostsInput = onboarding.activeBoosts || onboarding.active_boosts || onboarding.effects || {};
   const activeOnboarding = input.activeOnboarding || onboarding.activeOnboarding || null;
@@ -37,7 +48,7 @@ function normalizeOnboardingState(input) {
     step: typeof onboarding.step === 'string' ? onboarding.step : 'unknown',
     completed: Boolean(onboarding.completed),
     updatedAt: Number.isFinite(Number(onboarding.updatedAt)) ? Number(onboarding.updatedAt) : Date.now(),
-    raceCount: Number.isFinite(Number(input.raceCount)) ? Number(input.raceCount) : 0,
+    raceCount: Number.isFinite(Number(normalizedRaceCount)) ? Number(normalizedRaceCount) : 0,
     xConnected: Boolean(input.xConnected ?? input.x_connected ?? onboarding.xConnected ?? onboarding.x_connected),
     onboarding: normalizedOnboardingStatuses,
     activeOnboarding: activeOnboarding && typeof activeOnboarding === 'object' ? {

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -49,6 +49,15 @@ function invalidateProfileCache() {
   profileCacheTimestamp = 0;
 }
 
+async function refreshOnboardingAfterRunFinished() {
+  const firstState = await refreshOnboardingState({ reason: 'run_finished', screen: 'game-over', resetCache: true }).catch(() => null);
+  if (Number(firstState?.raceCount) !== 1) {
+    setTimeout(() => {
+      refreshOnboardingState({ reason: 'run_finished_retry', screen: 'game-over', resetCache: true }).catch(() => {});
+    }, 700);
+  }
+}
+
 async function updateGameOverShareButton() {
   const shareBtn = DOM.shareResultBtn;
   if (!shareBtn) return;
@@ -533,7 +542,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     if (screen === 'game-over') {
       invalidateProfileCache();
       updateGameOverShareButton().catch(() => {});
-      refreshOnboardingState({ reason: 'run_finished' }).catch(() => {});
+      refreshOnboardingAfterRunFinished().catch(() => {});
     }
     if (screen === 'store') {
       refreshOnboardingState({ reason: 'store_open' }).catch(() => {});


### PR DESCRIPTION
### Motivation
- Second-race onboarding sometimes did not appear because frontend read only `input.raceCount` and could fetch stale state before the backend increment completed. 
- The Play Again target could be missed when markup differed from `#restartBtn`, and game-over onboarding could be applied too early (before leaderboard save settled). 
- Need robust normalization of different backend field names and extra diagnostics to identify server response shape. 

### Description
- Normalize race progress by checking multiple backend fields (`raceCount`, `completedRuns`, `finishedRuns`, `runsCompleted`, `stats.*`, and `onboarding.*`) and use the first finite numeric value as `raceCount` in `js/features/onboarding/onboarding-state.js`.
- Add temporary backend response diagnostics in `fetchOnboardingState` to log `screen`, raw race-count-related fields, normalized `raceCount`, and `activeOnboarding` for investigation in `js/features/onboarding/onboarding-service.js`.
- Expand `play_again` selector mapping to include fallbacks `#restartBtn, [data-action="restart-game"], .go-play-again, .play-again-btn` and resolve to the first visible selector before showing the spotlight in `js/features/onboarding/index.js`.
- Add explicit second-race diagnostics when applying UI state (current screen, normalized race count, backend fields, active/fallback candidate and selector presence) in `js/features/onboarding/index.js`.
- Avoid showing game-over onboarding from stale cache by forcing a cache-reset refresh on `game-over` and retrying once after ~700ms to allow leaderboard save to complete in `js/game/bootstrap.js`.

### Testing
- Ran `npm run -s check:syntax` and the repository syntax checks completed successfully.
- Ran the test invocation with onboarding filter (`npm run -s test -- --test-name-pattern=onboarding`) as part of validation and the test run passed under the scripted test suite run shown in output.
- Pre-commit static analysis (`check:static-analysis`) executed as part of the commit hooks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0251cd3a7883268a43683215243135)