### PR TITLE
Fix onboarding spotlight blocking Start Game clicks

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -71,14 +71,14 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   container.style.cssText = 'position:fixed;inset:0;pointer-events:none;';
 
   const dimmer = document.createElement('div');
-  dimmer.style.cssText = 'position:absolute;inset:0;pointer-events:auto;';
+  dimmer.style.cssText = 'position:absolute;inset:0;pointer-events:none;';
 
   const dimTop = document.createElement('div');
   const dimRight = document.createElement('div');
   const dimBottom = document.createElement('div');
   const dimLeft = document.createElement('div');
   [dimTop, dimRight, dimBottom, dimLeft].forEach((part) => {
-    part.style.cssText = 'position:absolute;background:rgba(5,8,15,0.68);';
+    part.style.cssText = 'position:absolute;background:rgba(5,8,15,0.68);pointer-events:auto;';
     dimmer.appendChild(part);
   });
 


### PR DESCRIPTION
### Motivation
- Во время первого запуска оверлей онбординга перехватывал клики по подсвеченной кнопке `START GAME`, из‑за чего кнопка не реагировала на нажатия.

### Description
- В `js/features/onboarding/spotlight.js` у `dimmer` установлено `pointer-events:none`, чтобы обёртка не блокировала события по всей области экрана.
- Сегментам затемнения (`dimTop`, `dimRight`, `dimBottom`, `dimLeft`) добавлен `pointer-events:auto`, чтобы сохранить интерактивность затемнённых зон, при этом вырез (`hole`) оставлен с `pointer-events:none` и целевой элемент остаётся кликабельным.
- Изменение минимально и ограничено логикой расположения/рендера spotlight, не затрагивая прочие части онбординга.

### Testing
- Выполнена сборка с `npm run build`, сборка завершилась успешно.
- Автоматические проверки предкоммита (`check:syntax` и `check:static-analysis`) были запущены и прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025d8a46388326a89745267a36d6c8)