### PR TITLE
Fix onboarding play-again tooltip positioning

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -197,9 +197,14 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
     const bubbleRect = bubble.getBoundingClientRect();
     const belowTop = top + height + 10;
     const aboveTop = top - bubbleRect.height - 10;
+    const minBubbleLeft = viewport.left + viewportPadding;
     const maxBubbleLeft = viewport.left + viewport.width - bubbleRect.width - viewportPadding;
+    const centeredBubbleLeft = left + (width - bubbleRect.width) / 2;
 
-    let bubbleLeft = Math.min(Math.max(left, viewport.left + viewportPadding), maxBubbleLeft);
+    let bubbleLeft = centeredBubbleLeft;
+    if (maxBubbleLeft <= minBubbleLeft) bubbleLeft = minBubbleLeft;
+    else bubbleLeft = Math.min(Math.max(centeredBubbleLeft, minBubbleLeft), maxBubbleLeft);
+
     let bubbleTop = belowTop;
 
     if (belowTop + bubbleRect.height > viewport.top + viewport.height - viewportPadding) {


### PR DESCRIPTION
### Motivation
- The onboarding spotlight bubble for the "Play again" target could be misaligned (anchored to the left) and end up visually detached from the button on narrow screens or near viewport edges, so the hint needed more robust placement logic.

### Description
- Updated `js/features/onboarding/spotlight.js` to horizontally center the hint bubble relative to the highlighted target and added viewport clamping (min/max based on `viewportPadding`) so the bubble stays fully visible, while keeping the existing vertical (below/above) placement behavior.

### Testing
- Ran the repository static checks used by the commit hooks: `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025e46d9588326bc4245a23de46183)