### PR TITLE
Auto-scroll onboarding spotlight to keep CTA visible

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -159,6 +159,19 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   const viewportPadding = 12;
   const highlightPadding = 8;
 
+  const ensureTargetInViewport = () => {
+    const rect = targetElement.getBoundingClientRect();
+    const viewport = getViewportRect();
+    const visibleTop = Math.max(rect.top, viewport.top);
+    const visibleBottom = Math.min(rect.bottom, viewport.top + viewport.height);
+    const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+    const visibilityRatio = rect.height > 0 ? visibleHeight / rect.height : 0;
+
+    if (visibilityRatio < 0.7) {
+      targetElement.scrollIntoView({ block: 'center', inline: 'center', behavior: 'smooth' });
+    }
+  };
+
   const place = () => {
     const targetRect = targetElement.getBoundingClientRect();
     const viewport = getViewportRect();
@@ -257,6 +270,7 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   cleanupFns.push(() => dimmer.removeEventListener('click', swallowClick));
   cleanupFns.push(() => targetElement.removeEventListener('click', onTargetElementClick));
 
+  ensureTargetInViewport();
   schedulePlace();
   const targetRect = targetElement.getBoundingClientRect();
   if (targetRect.width <= 0 || targetRect.height <= 0) {


### PR DESCRIPTION
### Motivation
- On small or scrolled screens the highlighted CTA (e.g. the `PLAY AGAIN` button on Game Over) can be outside the viewport, making onboarding hints ineffective. 
- The change ensures the spotlight target is brought into view before computing highlight and tooltip placement so users can see and interact with the CTA.

### Description
- Added `ensureTargetInViewport()` to `js/features/onboarding/spotlight.js` which computes visible ratio and calls `scrollIntoView({ block: 'center', inline: 'center', behavior: 'smooth' })` when visibility is under `0.7`.
- Call to `ensureTargetInViewport()` is invoked before the initial `schedulePlace()` so the spotlight hole and bubble are positioned after the element is centered.
- No changes to public APIs; change is localized to the onboarding spotlight placement logic in `showSpotlight`.

### Testing
- Pre-commit checks ran successfully during the change, including `npm run check:syntax` and `npm run check:static-analysis`, and reported no errors.
- Commit completed with the checks passing and no static analysis violations were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025e8062f08326be4cd04c8d175408)