### PR TITLE
Пропускать онбординг при активном preload-оверлее

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -164,6 +164,11 @@ function applyOnboardingUiState() {
   unmountGiftIndicator();
   renderActiveBoostIndicators(onboardingState.activeBoosts || {});
 
+  if (document.body?.classList?.contains('preload-active')) {
+    logger.info('onboarding show skipped during preload overlay', { currentScreen });
+    return;
+  }
+
   if (!isAuthorizedRuntime()) {
     if (isTelegramMiniApp()) return;
     if (readGuestDismissed()) return;


### PR DESCRIPTION
### Motivation
- Онбординг-спотлайт иногда отображался поверх экрана предзагрузки при переходах между заездами, из-за чего пользователи видели подсказки во время `preload`-фазы.

### Description
- Добавлен ранний выход в `applyOnboardingUiState()` в файле `js/features/onboarding/index.js`, который пропускает демонстрацию онбординга если `document.body` содержит класс `preload-active`.
- Добавлен лог `onboarding show skipped during preload overlay` для облегчения отладки этого сценария.

### Testing
- Соборка проекта выполнена успешно с `npm run build` и прошла сборка Vite без ошибок.
- Предкоммитные проверки прошли успешно, включая `check:syntax` и `check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025ed328e483268c17ccb605177ece)