### PR TITLE
Suppress race-start onboarding when player has no rides

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -5,6 +5,8 @@ import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
 import { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { hasAuthenticatedSession, isTelegramMiniApp } from '../auth/index.js';
+import { hasRideLimit } from '../store/index.js';
+import { getPlayerRides } from '../../store/rides-service.js';
 
 const WEB_GUEST_ONBOARDING_DISMISSED_KEY = 'ursas.guest.onboarding.dismissed.v1';
 const AUTH_SCREENS = new Set(['menu', 'game-over', 'store']);
@@ -61,6 +63,25 @@ function getHookText(active) {
     store_start: 'Open Store to upgrade your runs', store_in: 'Highlight +3 rides pack'
   };
   return map[active?.key] || '';
+}
+
+
+function shouldSuppressRaceStartOnboarding(active) {
+  if (!active?.target) return false;
+  if (active.target !== 'start_game' && active.target !== 'play_again') return false;
+
+  if (!hasRideLimit()) return false;
+
+  const rides = getPlayerRides();
+  const totalRides = Number(rides?.totalRides || 0);
+  if (totalRides > 0) return false;
+
+  logger.info('onboarding suppressed: no rides', {
+    key: active?.key || null,
+    target: active.target,
+    totalRides
+  });
+  return true;
 }
 
 function resolveActiveOnboardingForScreen(state, screen) {
@@ -189,6 +210,10 @@ function applyOnboardingUiState() {
   }
 
   const active = resolveActiveOnboardingForScreen(onboardingState, currentScreen);
+  if (shouldSuppressRaceStartOnboarding(active)) {
+    return;
+  }
+
   const fallbackCandidate = ONBOARDING_FALLBACK_FLOW.find((entry) => {
     if (entry.screen !== currentScreen) return false;
     return entry.when({ raceCount: onboardingState.raceCount, xConnected: onboardingState.xConnected, gifts: onboardingState.gifts || {} });


### PR DESCRIPTION
### Motivation
- Prevent the UI from highlighting "Start Game / Play Again" and showing "Start your first race" when the player cannot start a race due to having zero available rides. 
- Only race-start/continue onboarding should be suppressed while store, gift radar, share/connect flows remain available. 
- Use the same rides state source as the runtime/store code so decisions match the visible "NO RIDES" UI. 

### Description
- Imported `hasRideLimit` and `getPlayerRides` into the onboarding resolver and added the new guard `shouldSuppressRaceStartOnboarding(active)` in `js/features/onboarding/index.js`. 
- The guard checks `active.target` for `start_game` or `play_again`, validates `hasRideLimit()`, reads `getPlayerRides().totalRides`, and returns true when `totalRides <= 0`. 
- Applied the guard before showing the active onboarding so race-start onboarding is not rendered, spotlight is not shown, and onboarding events (`shown`, `skip`, `complete`) are not emitted for suppressed entries. 
- Logs suppression with `onboarding suppressed: no rides` (includes onboarding key, target and totalRides) and leaves non-race onboarding flows unchanged. 

### Testing
- Ran `npm run check:syntax` and the project passed the syntax checks. 
- Executed `node --test scripts/onboarding-hints.test.mjs` and the onboarding hints test passed. 
- Pre-commit static analysis (`check:static-analysis`) ran as part of the commit hooks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0261aa7a8c83268006b95f99f571f6)