### PR TITLE
Delay onboarding spotlight on game-over until target layout stabilizes

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -128,6 +128,35 @@ function showAuthorizedOnboarding(active) {
     return null;
   };
 
+  const waitForLayoutStability = async () => {
+    if (typeof window === 'undefined') return;
+    if (currentScreen !== 'game-over') return;
+
+    const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+    await wait(120);
+
+    let prevSignature = '';
+    let stableFrames = 0;
+    for (let i = 0; i < 16; i += 1) {
+      await wait(50);
+      const resolved = resolveVisibleTarget(selector);
+      const el = resolved?.element;
+      if (!el) {
+        stableFrames = 0;
+        prevSignature = '';
+        continue;
+      }
+      const rect = el.getBoundingClientRect();
+      const signature = `${Math.round(rect.x)}:${Math.round(rect.y)}:${Math.round(rect.width)}:${Math.round(rect.height)}`;
+      if (signature === prevSignature) stableFrames += 1;
+      else {
+        prevSignature = signature;
+        stableFrames = 1;
+      }
+      if (stableFrames >= 3) break;
+    }
+  };
+
   let attempts = 0;
   const render = () => {
     attempts += 1;
@@ -154,7 +183,7 @@ function showAuthorizedOnboarding(active) {
     }
     requestAnimationFrame(() => setTimeout(render, 50));
   };
-  render();
+  waitForLayoutStability().finally(render);
 }
 
 function applyOnboardingUiState() {


### PR DESCRIPTION
### Motivation
- On the `game-over` screen the share/connect button can shift while dynamic text or layout finishes loading, which causes the onboarding spotlight to highlight the wrong area; the UI needs a short stability wait before showing the spotlight.

### Description
- Add `waitForLayoutStability` to `js/features/onboarding/index.js` that, when `currentScreen === 'game-over'`, waits ~120ms then samples the target element bounding rect across frames (50ms intervals) and requires several identical frames to consider the layout stable.
- Invoke `waitForLayoutStability().finally(render)` so the existing spotlight rendering and retry logic remains intact and will still attempt target discovery if the stability wait returns without a stable target.

### Testing
- Ran `npm run -s test:request -- onboarding-hints.test.mjs` and the request test suite completed successfully (all tests passed).
- Pre-commit checks `check:syntax` and `check:static-analysis` were executed and passed during the change validation.
- Verified the modified file is `js/features/onboarding/index.js` and no automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0263a31f1c8326bb8ea52945e72257)