### PR TITLE
Scope Share Result onboarding to Player Menu

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -7,7 +7,7 @@ import { logger } from '../../logger.js';
 import { hasAuthenticatedSession, isTelegramMiniApp } from '../auth/index.js';
 
 const WEB_GUEST_ONBOARDING_DISMISSED_KEY = 'ursas.guest.onboarding.dismissed.v1';
-const AUTH_SCREENS = new Set(['menu', 'game-over', 'store']);
+const AUTH_SCREENS = new Set(['menu', 'game-over', 'store', 'player-menu']);
 
 const SCREEN_ALIASES = Object.freeze({
   main: 'menu',
@@ -23,6 +23,7 @@ const TARGET_SELECTOR_MAP = Object.freeze({
   start_game: '#startBtn',
   play_again: '#restartBtn, [data-action="restart-game"], .go-play-again, .play-again-btn',
   connect_x_or_share_result: '#shareResultBtn',
+  player_menu_connect_x: '#pmShareBtn',
   store_button: '#storeBtn',
   store_back: '#storeBackBtn',
   ride_pack_3: '#store-ride-pack-3',
@@ -37,7 +38,7 @@ const ONBOARDING_FALLBACK_FLOW = [
   { key: 'third_race_game_over', screen: 'game-over', target: 'play_again', hook: 'Play again and get +100 gold', when: (state) => state.raceCount === 2 },
   { key: 'third_race_menu', screen: 'menu', target: 'start_game', hook: 'Play again and get +100 gold', when: (state) => state.raceCount === 2 },
   { key: 'share_result_game_over', screen: 'game-over', target: 'connect_x_or_share_result', when: (state) => state.raceCount >= 3 && !state.xConnected },
-  { key: 'share_result_menu', screen: 'menu', target: 'connect_x_or_share_result', when: (state) => state.raceCount >= 3 && !state.xConnected },
+  { key: 'share_result_player_menu', screen: 'player-menu', target: 'player_menu_connect_x', when: (state) => state.raceCount >= 3 && !state.xConnected },
   { key: 'store_start', screen: 'menu', target: 'store_button', when: (state) => state.raceCount >= 3 },
   { key: 'store_in', screen: 'store', target: 'ride_pack_3', when: (state) => state.raceCount >= 3 },
   { key: 'gift_radar_obstacles_store', screen: 'store', target: 'radar_obstacles_card', when: (state) => state.gifts?.radar_obstacles_24h?.available },
@@ -57,7 +58,7 @@ function getHookText(active) {
     first_race: 'Take the lead / Start your first race',
     second_race_game_over: 'Play again and get +100 silver', second_race_menu: 'Play again and get +100 silver',
     third_race_game_over: 'Play again and get +100 gold', third_race_menu: 'Play again and get +100 gold',
-    share_result_game_over: 'Share your result and get a bonus', share_result_menu: 'Connect X and get a bonus',
+    share_result_game_over: 'Share your result and get a bonus', share_result_player_menu: 'Connect X and get a bonus',
     store_start: 'Open Store to upgrade your runs', store_in: 'Highlight +3 rides pack'
   };
   return map[active?.key] || '';
@@ -254,4 +255,9 @@ function dismissGuestOnboardingOnWalletConnect() {
   writeGuestDismissed();
 }
 
-export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect };
+async function postOnboardingAction({ action, key, screen, target }) {
+  if (!action || !key) return;
+  await postOnboardingEvent({ action, key, screen: normalizeScreenName(screen), target });
+}
+
+export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect, postOnboardingAction };

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -347,7 +347,11 @@ function bindUiEventHandlers({ startGame, restartFromGameOver, goToMainMenu, sho
   }
 
   if (DOM.playerAvatarBtn) {
-    DOM.playerAvatarBtn.addEventListener('click', () => openPlayerMenu());
+    DOM.playerAvatarBtn.addEventListener('click', async () => {
+      await openPlayerMenu();
+      refreshOnboardingState({ screen: 'player-menu', reason: 'player_menu_open' }).catch(() => {});
+      applyOnboardingForScreen('player-menu');
+    });
   }
   document.querySelectorAll('.lb-title').forEach((el) => {
     el.addEventListener('click', () => {

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -7,6 +7,7 @@ import { notifySuccess, notifyError, notifyWarn } from '../notifier.js';
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { analytics } from '../analytics-events.js';
 import { normalizeReferralCode, readReferralCodeFromLocation, readReferralCodeFromTelegram } from '../referral/referralCode.js';
+import { postOnboardingAction } from '../features/onboarding/index.js';
 
 const MAX_STREAK_ICONS = 10;
 const LONG_PRESS_DURATION_MS = 600;
@@ -361,6 +362,12 @@ function initPlayerMenuEvents() {
       if (!currentProfile) return;
 
       if (!currentProfile.x?.connected) {
+        await postOnboardingAction({
+          action: 'complete',
+          key: 'share_result_player_menu',
+          screen: 'player-menu',
+          target: 'player_menu_connect_x'
+        }).catch(() => {});
         await startXConnectFlow({
           onConnected: () => refreshPlayerMenu()
         });


### PR DESCRIPTION
### Motivation
- Prevent the main menu from showing the incorrect “Connect X and get a bonus” spotlight by scoping the share-result onboarding to the Player Menu context only.
- Preserve existing `share_result_game_over` behavior for game-over flows while adding a dedicated Player Menu fallback so the onboarding appears where the Connect X / Share UI actually lives.

### Description
- Added `player-menu` to authorized onboarding screens via `AUTH_SCREENS` and added `player_menu_connect_x` → `#pmShareBtn` in `TARGET_SELECTOR_MAP` in `js/features/onboarding/index.js`.
- Replaced `share_result_menu` fallback with `share_result_player_menu` (screen: `player-menu`, target: `player_menu_connect_x`) and updated hook text mapping accordingly in `js/features/onboarding/index.js`.
- Exposed `postOnboardingAction` helper in onboarding feature to allow posting explicit onboarding events from other features in `js/features/onboarding/index.js`.
- When Player Menu opens, the avatar click handler now awaits `openPlayerMenu()` and then calls `refreshOnboardingState({ screen: 'player-menu', reason: 'player_menu_open' })` and `applyOnboardingForScreen('player-menu')` in `js/game/bootstrap.js` so onboarding is resolved in the Player Menu context.
- In `js/player-menu/controller.js`, imported `postOnboardingAction` and on Player Menu share/connect click (when X is not connected) post a `complete` onboarding event for `share_result_player_menu` before continuing the normal X connect flow.

### Testing
- Ran `npm run lint`, which executes `check:syntax` and `check:static-analysis`, and the checks passed successfully.
- Pre-commit/static analysis checks were executed during the change and passed (no lint or static-analysis failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02678fe814832682e2cac2039108ae)