### PR TITLE
Fix onboarding spotlight leaks to main menu and harden auth fallback

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -33,6 +33,20 @@ const TARGET_SELECTOR_MAP = Object.freeze({
   radar_gold_card: '#store-radargold-0'
 });
 
+const ONBOARDING_ALLOWED_TARGETS = Object.freeze({
+  first_race: { screen: 'menu', target: 'start_game' },
+  second_race_game_over: { screen: 'game-over', target: 'play_again' },
+  second_race_menu: { screen: 'menu', target: 'start_game' },
+  third_race_game_over: { screen: 'game-over', target: 'play_again' },
+  third_race_menu: { screen: 'menu', target: 'start_game' },
+  share_result_game_over: { screen: 'game-over', target: 'connect_x_or_share_result' },
+  share_result_player_menu: { screen: 'player-menu', target: 'player_menu_connect_x' },
+  store_start: { screen: 'menu', target: 'store_button' },
+  store_in: { screen: 'store', target: 'ride_pack_3' },
+  gift_radar_obstacles_store: { screen: 'store', target: 'radar_obstacles_card' },
+  gift_radar_gold_store: { screen: 'store', target: 'radar_gold_card' }
+});
+
 const ONBOARDING_FALLBACK_FLOW = [
   { key: 'first_race', screen: 'menu', target: 'start_game', when: (state) => state.raceCount === 0 },
   { key: 'second_race_game_over', screen: 'game-over', target: 'play_again', hook: 'Play again and get +100 silver', when: (state) => state.raceCount === 1 },
@@ -66,6 +80,39 @@ function getHookText(active) {
   return map[active?.key] || '';
 }
 
+function isSharePromptText(text) {
+  const normalized = String(text || '').toLowerCase();
+  return normalized.includes('connect x') || normalized.includes('share your result');
+}
+
+function validateActiveOnboarding(active, screenOverride = null) {
+  if (!active) return null;
+  const key = String(active.key || '');
+  const normalizedScreen = normalizeScreenName(screenOverride || active.screen);
+  const target = String(active.target || '');
+  const expected = ONBOARDING_ALLOWED_TARGETS[key];
+  const hookText = getHookText(active);
+
+  if (!expected || expected.screen !== normalizedScreen || expected.target !== target) {
+    logger.warn('⚠️ onboarding allowlist rejected active onboarding', { active, normalizedScreen });
+    return null;
+  }
+  if (target === 'player_menu_connect_x' && normalizedScreen !== 'player-menu') {
+    logger.warn('⚠️ onboarding blocked player menu share target outside player-menu', { active, normalizedScreen });
+    return null;
+  }
+  if (target === 'connect_x_or_share_result' && normalizedScreen !== 'game-over') {
+    logger.warn('⚠️ onboarding blocked game-over share target outside game-over', { active, normalizedScreen });
+    return null;
+  }
+  if (isSharePromptText(hookText) && normalizedScreen !== 'game-over' && normalizedScreen !== 'player-menu') {
+    logger.warn('⚠️ onboarding blocked share/connect hook text outside allowed screens', { active, normalizedScreen, hookText });
+    return null;
+  }
+
+  return { ...active, screen: normalizedScreen };
+}
+
 
 function shouldSuppressRaceStartOnboarding(active) {
   if (!active?.target) return false;
@@ -88,8 +135,11 @@ function shouldSuppressRaceStartOnboarding(active) {
 function resolveActiveOnboardingForScreen(state, screen) {
   const normalizedScreen = normalizeScreenName(screen);
   const backendActive = state?.activeOnboarding;
-  if (backendActive && normalizeScreenName(backendActive.screen) === normalizedScreen) {
-    return backendActive;
+  if (backendActive) {
+    const validatedBackend = validateActiveOnboarding(backendActive, backendActive.screen);
+    if (validatedBackend && validatedBackend.screen === normalizedScreen) {
+      return validatedBackend;
+    }
   }
 
   const statuses = state?.onboarding || {};
@@ -106,14 +156,14 @@ function resolveActiveOnboardingForScreen(state, screen) {
   });
 
   if (!candidate) return null;
-  return {
+  return validateActiveOnboarding({
     key: candidate.key,
     screen: candidate.screen,
     target: candidate.target,
     status: String(statuses[candidate.key] || 'none').toLowerCase(),
     hook: candidate.hook || '',
     rewardPreview: null
-  };
+  }, candidate.screen);
 }
 
 async function sendEvent(action, active) {
@@ -286,6 +336,7 @@ async function refreshOnboardingState({ reason = 'manual', screen = null, resetC
   const remote = await fetchOnboardingState({ screen: screen || currentScreen });
   if (remote) onboardingState = writeCachedOnboardingState(remote);
   else if (!isAuthorizedRuntime()) onboardingState = readCachedOnboardingState();
+  else onboardingState = { ...onboardingState, activeOnboarding: null };
   applyOnboardingUiState();
   return { ...onboardingState };
 }
@@ -293,7 +344,10 @@ async function refreshOnboardingState({ reason = 'manual', screen = null, resetC
 function applyOnboardingForScreen(screen) {
   currentScreen = normalizeScreenName(screen || currentScreen || 'menu');
   if (isAuthorizedRuntime() && AUTH_SCREENS.has(currentScreen)) {
-    refreshOnboardingState({ reason: `screen_${currentScreen}`, screen: currentScreen }).catch(() => applyOnboardingUiState());
+    refreshOnboardingState({ reason: `screen_${currentScreen}`, screen: currentScreen }).catch(() => {
+      onboardingState = { ...onboardingState, activeOnboarding: null };
+      applyOnboardingUiState();
+    });
     return;
   }
   applyOnboardingUiState();

--- a/js/features/onboarding/onboarding-state.js
+++ b/js/features/onboarding/onboarding-state.js
@@ -45,8 +45,8 @@ function normalizeOnboardingState(input) {
     return acc;
   }, {});
   return {
-    step: typeof onboarding.step === 'string' ? onboarding.step : 'unknown',
-    completed: Boolean(onboarding.completed),
+    step: input.step || input.currentStep || onboarding.step || 'unknown',
+    completed: Boolean(input.completed || input.mainFlowCompleted || onboarding.completed),
     updatedAt: Number.isFinite(Number(onboarding.updatedAt)) ? Number(onboarding.updatedAt) : Date.now(),
     raceCount: Number.isFinite(Number(normalizedRaceCount)) ? Number(normalizedRaceCount) : 0,
     xConnected: Boolean(input.xConnected ?? input.x_connected ?? onboarding.xConnected ?? onboarding.x_connected),


### PR DESCRIPTION
### Motivation
- The share/connect onboarding prompt ("Connect X and get a bonus") was rendering on the main `menu` due to permissive backend/cached payloads and stale active onboarding state. 
- The goal is to strictly restrict which onboarding keys can appear on which screens, hard-block share/X prompts outside their intended screens, and avoid showing stale cached prompts for authenticated users when remote fetch fails.

### Description
- Added a strict allowlist `ONBOARDING_ALLOWED_TARGETS` and a validator `validateActiveOnboarding` to reject any `activeOnboarding` whose `key/screen/target` combination is not explicitly allowed. (`js/features/onboarding/index.js`)
- Implemented `isSharePromptText` and hard-block rules to prevent `player_menu_connect_x` outside `player-menu`, prevent `connect_x_or_share_result` outside `game-over`, and block hook text containing "Connect X" or "Share your result" on disallowed screens. (`js/features/onboarding/index.js`)
- Routed both backend-provided `activeOnboarding` and fallback candidates through the same validator so fallback flow cannot leak share/X prompts onto the `menu`. (`js/features/onboarding/index.js`)
- Prevented use of stale cached `activeOnboarding` for authenticated runtimes by clearing `activeOnboarding` when the remote fetch returns `null` or fails (cached state is still used for guest fallback only). (`js/features/onboarding/index.js`)
- Fixed state normalization in `normalizeOnboardingState` to support backend fields `currentStep` and `mainFlowCompleted` with the new logic `step = input.step || input.currentStep || onboarding.step || "unknown"` and `completed = Boolean(input.completed || input.mainFlowCompleted || onboarding.completed)`. (`js/features/onboarding/onboarding-state.js`)

### Testing
- Ran syntax/type checks with `node --check js/features/onboarding/index.js && node --check js/features/onboarding/onboarding-state.js` and they completed successfully. 
- Pre-commit static checks executed `scripts/check-syntax.mjs` and `scripts/check-static-analysis.mjs` (invoked by the commit hooks) and both checks passed. 
- Verified that `js/features/onboarding` changes pass the repository's static-analysis and syntax gates (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033b70b24483269410a7e9187d5e67)