### PR TITLE
Fix onboarding skip persistence and block spotlight during loading/preload states

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -68,6 +68,53 @@ function getStorage() { try { return window.localStorage || null; } catch (_) { 
 function readGuestDismissed() { return getStorage()?.getItem(WEB_GUEST_ONBOARDING_DISMISSED_KEY) === '1'; }
 function writeGuestDismissed() { getStorage()?.setItem(WEB_GUEST_ONBOARDING_DISMISSED_KEY, '1'); }
 
+function getOnboardingStatus(key, state = onboardingState) {
+  if (!key) return 'none';
+  const raw = state?.onboarding?.[key];
+  return typeof raw === 'string' ? raw.trim().toLowerCase() : 'none';
+}
+
+function isStepBlocked(key, state = onboardingState) {
+  const status = getOnboardingStatus(key, state);
+  return status === 'skipped' || status === 'skip' || status === 'completed' || status === 'complete';
+}
+
+function isOnboardingUiBlocked(screen = currentScreen) {
+  if (typeof document === 'undefined') return false;
+  const normalizedScreen = normalizeScreenName(screen);
+  if (!AUTH_SCREENS.has(normalizedScreen)) return true;
+
+  const body = document.body;
+  if (body?.classList?.contains('preload-active')) return true;
+  if (body?.classList?.contains('loading-ui')) return true;
+  if (body?.classList?.contains('start-launching')) return true;
+
+  const darkScreen = document.querySelector('#darkScreen');
+  if (darkScreen) {
+    const style = window.getComputedStyle?.(darkScreen);
+    const rect = darkScreen.getBoundingClientRect?.();
+    const visible = style?.display !== 'none' && style?.visibility !== 'hidden' && Number(style?.opacity ?? 1) > 0 && Boolean(rect && rect.width > 0 && rect.height > 0);
+    if (visible) return true;
+  }
+
+  const loadingContainers = [
+    '#gameContainer',
+    '#rendererPlaceholder',
+    '#renderer-placeholder',
+    '[data-renderer-placeholder]'
+  ];
+  for (const selector of loadingContainers) {
+    const el = document.querySelector(selector);
+    if (!el) continue;
+    if (el.classList?.contains('preparing') || el.classList?.contains('loading') || el.classList?.contains('is-preparing') || el.classList?.contains('is-loading')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
 function getHookText(active) {
   if (active?.hook) return String(active.hook);
   const map = {
@@ -136,6 +183,9 @@ function resolveActiveOnboardingForScreen(state, screen) {
   const normalizedScreen = normalizeScreenName(screen);
   const backendActive = state?.activeOnboarding;
   if (backendActive) {
+    if (isStepBlocked(backendActive.key, state)) {
+      return null;
+    }
     const validatedBackend = validateActiveOnboarding(backendActive, backendActive.screen);
     if (validatedBackend && validatedBackend.screen === normalizedScreen) {
       return validatedBackend;
@@ -151,7 +201,7 @@ function resolveActiveOnboardingForScreen(state, screen) {
 
   const candidate = ONBOARDING_FALLBACK_FLOW.find((entry) => {
     if (entry.screen !== normalizedScreen) return false;
-    const status = String(statuses[entry.key] || 'none').toLowerCase();
+    const status = getOnboardingStatus(entry.key, state);
     return status === 'none' && entry.when(stateForResolution);
   });
 
@@ -177,6 +227,11 @@ function normalizeScreenName(screen) {
 }
 
 function showAuthorizedOnboarding(active) {
+  if (isOnboardingUiBlocked()) {
+    hideSpotlight();
+    clearGameOverOnboardingHook();
+    return;
+  }
   const activeScreen = normalizeScreenName(active?.screen);
   if (!active || !AUTH_SCREENS.has(currentScreen) || activeScreen !== currentScreen) {
     logger.info('onboarding show skipped', { currentScreen, active });
@@ -232,13 +287,33 @@ function showAuthorizedOnboarding(active) {
   let attempts = 0;
   const render = () => {
     attempts += 1;
+    if (isOnboardingUiBlocked()) {
+      hideSpotlight();
+      clearGameOverOnboardingHook();
+      return;
+    }
     const resolvedTarget = resolveVisibleTarget(selector);
     const spotlightTarget = resolvedTarget?.selector || selector;
+    if (isOnboardingUiBlocked()) {
+      hideSpotlight();
+      clearGameOverOnboardingHook();
+      return;
+    }
     const shown = showSpotlight({
       target: spotlightTarget,
       text: getHookText(active),
       showSkip: true,
-      onSkip: async () => { await sendEvent('skip', active); hideSpotlight(); },
+      onSkip: async () => {
+        await sendEvent('skip', active);
+        onboardingState = writeCachedOnboardingState({
+          ...onboardingState,
+          onboarding: { ...(onboardingState.onboarding || {}), [active.key]: 'skipped' },
+          activeOnboarding: null
+        });
+        hideSpotlight();
+        clearGameOverOnboardingHook();
+        await refreshOnboardingState({ reason: `skip_${active.key}`, screen: currentScreen });
+      },
       onTargetClick: async () => { await sendEvent('complete', active); hideSpotlight(); }
     });
     if (shown) {
@@ -265,8 +340,8 @@ function applyOnboardingUiState() {
   unmountGiftIndicator();
   renderActiveBoostIndicators(onboardingState.activeBoosts || {});
 
-  if (document.body?.classList?.contains('preload-active')) {
-    logger.info('onboarding show skipped during preload overlay', { currentScreen });
+  if (isOnboardingUiBlocked()) {
+    logger.info('onboarding show skipped while ui blocked', { currentScreen });
     return;
   }
 
@@ -336,7 +411,7 @@ async function refreshOnboardingState({ reason = 'manual', screen = null, resetC
   const remote = await fetchOnboardingState({ screen: screen || currentScreen });
   if (remote) onboardingState = writeCachedOnboardingState(remote);
   else if (!isAuthorizedRuntime()) onboardingState = readCachedOnboardingState();
-  else onboardingState = { ...onboardingState, activeOnboarding: null };
+  else onboardingState = writeCachedOnboardingState({ ...DEFAULT_ONBOARDING_STATE, activeBoosts: onboardingState.activeBoosts || DEFAULT_ONBOARDING_STATE.activeBoosts });
   applyOnboardingUiState();
   return { ...onboardingState };
 }


### PR DESCRIPTION
### Motivation
- Prevent previously-observed bugs where pressing `Skip` on a share-result onboarding could make the same onboarding reappear later and where the onboarding dark overlay could appear over game preload/loading/transition screens.
- Ensure `Skip` is treated as a persistent user choice (frontend must not re-show skipped steps) and avoid showing onboarding UI while game/renderer is preparing or a global dark/loading overlay is visible.

### Description
- Added helpers `getOnboardingStatus(key)`, `isStepBlocked(key)` and `isOnboardingUiBlocked()` to normalize per-key status, decide blocked states (`skipped`, `skip`, `completed`, `complete`), and centrally detect preload/loading/transition blocking conditions (body classes, `#darkScreen`, renderer/container preparing/loading classes, and non-authorized screens).
- Updated `resolveActiveOnboardingForScreen` to ignore backend `activeOnboarding` when the step is blocked and to only consider fallback entries whose status is exactly `none` via `getOnboardingStatus`.
- Updated `showAuthorizedOnboarding` to bail early and hide/clear hooks when `isOnboardingUiBlocked()` is true, and to re-check UI-blocking before each spotlight retry render.
- Changed the skip handling in the spotlight `onSkip` to immediately write a cached state marking the key as `skipped`, clear `activeOnboarding`, hide the spotlight, clear hooks, and then refresh backend state so the UI does not re-show while the network refresh runs.
- Modified `refreshOnboardingState` null/unauthorized handling for authenticated runs to clear stale cached onboarding UI (reset to defaults) while preserving `activeBoosts` so active boost indicators still render.

### Testing
- Ran syntax checks with `npm run check:syntax` and static analysis with `npm run check:static-analysis`, both succeeded.
- Pre-commit quality checks completed and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033e6633688326ab525cb2b1902a40)