### PR TITLE
Fix onboarding event payload format after ride pack purchase

### DIFF
--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -543,7 +543,7 @@ export function createUpgradesService({
           }));
         }
         if (key === 'rides_pack') {
-          await postOnboardingEvent('ride_pack_bought');
+          await postOnboardingEvent({ action: 'ride_pack_bought' });
           await refreshOnboardingState({ reason: 'ride_pack_bought' });
         }
       } else {


### PR DESCRIPTION
### Motivation
- The frontend was sending a raw JSON string to `/api/onboarding/event` which produced a `400 Bad Request` because the backend expects a structured event object.

### Description
- Replace `postOnboardingEvent('ride_pack_bought')` with `postOnboardingEvent({ action: 'ride_pack_bought' })` in `js/store/upgrades-service.js` so the POST body is an object.

### Testing
- Pre-commit hooks ran during the change and `check:syntax` and `check:static-analysis` both passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03536887b48326bfc42e27cd6c71f3)