### PR TITLE
Make unlocked radar gifts show FREE 24H and stay claimable globally

### DIFF
--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -46,11 +46,16 @@ export function applyRadarGiftStoreUi(onboardingState, handlers) {
 
     if (!isGiftAvailable) return;
 
-    tierEl.classList.add('is-gift-free');
+    tierEl.classList.add('is-gift-free', 'available');
+    tierEl.classList.remove('locked', 'purchased');
     tierEl.dataset.onboardingGift = reward;
+    tierEl.style.pointerEvents = 'auto';
+    tierEl.style.opacity = '';
     if (priceEl) priceEl.textContent = 'FREE 24H';
 
-    tierEl.onclick = async function claimGiftHandler() {
+    tierEl.onclick = async function claimGiftHandler(event) {
+      event?.preventDefault?.();
+      event?.stopPropagation?.();
       if (isStoreDataLoading()) {
         notifyWarn('⏳ Store is loading, try again in a moment');
         return;


### PR DESCRIPTION
### Motivation
- Ensure that when a radar onboarding gift is unlocked and unclaimed it appears as a FREE 24H, interactable Store item everywhere (manual open, reload, or skipped spotlight), not only during the spotlight flow. 
- Prevent normal Store rendering from reapplying locked/paid/purchased visuals that would block claiming the onboarding gift.

### Description
- Modified `js/store/radar-gift-ui.js` to force the matching tier into an interactable FREE state by adding `available`, removing `locked`/`purchased`, restoring `pointerEvents`/`opacity`, and setting the price label to `FREE 24H` when a gift is available and unclaimed. 
- The gift click handler now prevents default/propagation and routes exclusively to the onboarding claim flow (`/api/onboarding/claim`) via `claimOnboardingGiftReward`, then refreshes onboarding state, reloads player upgrades, and re-renders the Store UI without invoking permanent purchase endpoints. 
- This `applyRadarGiftStoreUi` function is called from the Store render path (`updateStoreUI`) so the override is applied after normal Store renders/updates, ensuring the gift UI persists across updates.

### Testing
- Ran the repository pre-commit automated checks including `scripts/check-syntax.mjs`, and the syntax checks passed. 
- Static analysis (`scripts/check-static-analysis.mjs`) reported an existing line-count threshold violation in `js/store/upgrades-service.js` that is unrelated to this change and caused the hook to fail. 
- Verified `applyRadarGiftStoreUi` behavior locally by inspecting the patched `js/store/radar-gift-ui.js` to confirm the FREE label, interactive state, and onboarding claim-only handler were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03579694708326a8a897ad97d2d456)