### PR TITLE
Implement persistent FREE 24H radar store UI override

### DIFF
--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -3,6 +3,13 @@ import { BACKEND_URL } from '../config.js';
 import { requestJsonResult, REQUEST_PROFILE_STORE_WRITE } from '../request.js';
 import { notifyError, notifySuccess, notifyWarn } from '../notifier.js';
 
+const RADAR_GIFT_TIERS = [
+  { reward: 'radar_obstacles_24h', selectors: ['#store-radarobstacles-0', '[data-upgrade-key="radar_obstacles"][data-upgrade-tier="0"]'] },
+  { reward: 'radar_gold_24h', selectors: ['#store-radargold-0', '[data-upgrade-key="radar_gold"][data-upgrade-tier="0"]'] }
+];
+
+let isRadarGiftClickInterceptorBound = false;
+
 async function claimOnboardingGiftReward(reward, { refreshOnboardingState }) {
   const normalizedReward = String(reward || '').trim();
   if (!normalizedReward) return false;
@@ -25,16 +32,39 @@ async function claimOnboardingGiftReward(reward, { refreshOnboardingState }) {
   }
 }
 
+function bindRadarGiftClickInterceptor(handlers) {
+  if (isRadarGiftClickInterceptorBound) return;
+  isRadarGiftClickInterceptorBound = true;
+
+  document.addEventListener('click', async (event) => {
+    const tierEl = event.target?.closest?.('.store-tier.is-gift-free[data-onboarding-gift]');
+    if (!tierEl) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const { buyUpgrade, isStoreDataLoading, loadPlayerUpgrades, updateStoreUI, refreshOnboardingState } = handlers;
+    const reward = String(tierEl.dataset.onboardingGift || '').trim();
+    if (!reward) return;
+    if (isStoreDataLoading()) {
+      notifyWarn('⏳ Store is loading, try again in a moment');
+      return;
+    }
+    const claimed = await claimOnboardingGiftReward(reward, { refreshOnboardingState });
+    if (!claimed) return;
+    await loadPlayerUpgrades();
+    updateStoreUI({ buyUpgrade });
+    notifySuccess('✅ 24H gift activated');
+  }, true);
+}
+
 export function applyRadarGiftStoreUi(onboardingState, handlers) {
   const { buyUpgrade, isStoreDataLoading, loadPlayerUpgrades, updateStoreUI, refreshOnboardingState } = handlers;
+  bindRadarGiftClickInterceptor(handlers);
   const gifts = onboardingState?.gifts || {};
-  const giftConfigs = [
-    { reward: 'radar_obstacles_24h', tierId: 'store-radarobstacles-0' },
-    { reward: 'radar_gold_24h', tierId: 'store-radargold-0' }
-  ];
 
-  giftConfigs.forEach(({ reward, tierId }) => {
-    const tierEl = document.getElementById(tierId);
+  RADAR_GIFT_TIERS.forEach(({ reward, selectors }) => {
+    const tierEl = selectors.map((selector) => document.querySelector(selector)).find(Boolean);
     if (!tierEl) return;
 
     const giftState = gifts[reward] || {};


### PR DESCRIPTION
### Motivation
- Ensure radar onboarding gifts are enforced at the Store UI layer so free 24H radar rewards behave as real UI overrides rather than only onboarding spotlight visuals.
- Make the free-radar behavior resilient to Store rerenders and handler rewrites so clicking a free radar never invokes the normal purchase flow.

### Description
- Added `RADAR_GIFT_TIERS` with dual selectors (explicit `#store-radarobstacles-0`/`#store-radargold-0` and `data-upgrade-key` selectors) to reliably locate radar tier 0 cards across renders in `js/store/radar-gift-ui.js`.
- Introduced a capture-phase click interceptor via `document.addEventListener('click', ..., true)` that prevents default propagation for `.store-tier.is-gift-free[data-onboarding-gift]` and routes clicks to the onboarding claim flow (`/api/onboarding/claim`) instead of the store buy flow.
- Kept per-render UI patching in `applyRadarGiftStoreUi(...)` so each Store render reapplies `is-gift-free`, `data-onboarding-gift`, the `FREE 24H` price label, and the per-card claim handler to remain compatible with existing `updateStoreUI` behavior.
- The normal purchase endpoint (`/api/store/buy`) remains unchanged for standard purchases while free-radar clicks are intercepted and sent to onboarding claim logic.

### Testing
- Presence checks with `rg` confirmed required artifacts: `FREE 24H`, `is-gift-free`, and `radar_obstacles_24h` are present in the codebase and used by the override logic.
- A scan of code shows the free click path posts to `/api/onboarding/claim` in `claimOnboardingGiftReward` and the global click interceptor stops propagation so free-radar clicks cannot reach the `/api/store/buy` handler.
- Static automated checks ran: `node scripts/check-syntax.mjs` passed but `node scripts/check-static-analysis.mjs` reported a line-count violation for `js/store/upgrades-service.js` (file exceeds 600 lines) unrelated to the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a035b408d0c8326b0c3bff38226469d)