### PR TITLE
Fix undefined isStoreDataLoading ReferenceError when opening store

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -63,8 +63,9 @@ function showStore() {
   syncAllAudioUI();
   applyStoreDefaultLockState();
   setActiveStoreTab('upgrade');
-  const { isStoreDataLoading } = getStoreStateSnapshot();
-  if (!isStoreDataLoading) {
+  const storeState = getStoreStateSnapshot();
+  const storeDataLoading = Boolean(storeState?.isStoreDataLoading);
+  if (!storeDataLoading) {
     loadPlayerUpgrades().then(() => { updateStoreUI(); });
   }
   logger.info("🛒 Store opened");


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` when opening the store due to an undefined `isStoreDataLoading` reference in the `showStore` flow.

### Description
- In `js/ui.js` replaced direct destructuring with a safe snapshot access (`const storeState = getStoreStateSnapshot(); const storeDataLoading = Boolean(storeState?.isStoreDataLoading);`) and used `storeDataLoading` to gate `loadPlayerUpgrades()`.

### Testing
- Ran `npm run check:syntax` and it passed.
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run check:static-analysis` which reported an unrelated baseline violation (oversized `js/store/upgrades-service.js`) that is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036393af7483268bd649df093c3481)