### PR TITLE
Fix Store radar gift onboarding targets and claim reward mapping

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -29,6 +29,8 @@ const TARGET_SELECTOR_MAP = Object.freeze({
   store_button: '#storeBtn',
   store_back: '#storeBackBtn',
   ride_pack_3: '#store-ride-pack-3',
+  radar_obstacles_24h_card: '#store-radarobstacles-0',
+  radar_gold_24h_card: '#store-radargold-0',
   radar_obstacles_card: '#store-radarobstacles-0',
   radar_gold_card: '#store-radargold-0'
 });
@@ -43,8 +45,8 @@ const ONBOARDING_ALLOWED_TARGETS = Object.freeze({
   share_result_player_menu: { screen: 'player-menu', target: 'player_menu_connect_x' },
   store_start: { screen: 'menu', target: 'store_button' },
   store_in: { screen: 'store', target: 'ride_pack_3' },
-  gift_radar_obstacles_store: { screen: 'store', target: 'radar_obstacles_card' },
-  gift_radar_gold_store: { screen: 'store', target: 'radar_gold_card' }
+  gift_radar_obstacles_store: { screen: 'store', target: 'radar_obstacles_24h_card' },
+  gift_radar_gold_store: { screen: 'store', target: 'radar_gold_24h_card' }
 });
 
 const ONBOARDING_FALLBACK_FLOW = [
@@ -57,8 +59,8 @@ const ONBOARDING_FALLBACK_FLOW = [
   { key: 'share_result_player_menu', screen: 'player-menu', target: 'player_menu_connect_x', when: (state) => state.raceCount >= 3 && !state.xConnected },
   { key: 'store_start', screen: 'menu', target: 'store_button', when: (state) => state.raceCount >= 3 },
   { key: 'store_in', screen: 'store', target: 'ride_pack_3', when: (state) => state.raceCount >= 3 },
-  { key: 'gift_radar_obstacles_store', screen: 'store', target: 'radar_obstacles_card', when: (state) => state.gifts?.radar_obstacles_24h?.available },
-  { key: 'gift_radar_gold_store', screen: 'store', target: 'radar_gold_card', when: (state) => state.gifts?.radar_gold_24h?.available }
+  { key: 'gift_radar_obstacles_store', screen: 'store', target: 'radar_obstacles_24h_card', when: (state) => state.gifts?.radar_obstacles_24h?.available },
+  { key: 'gift_radar_gold_store', screen: 'store', target: 'radar_gold_24h_card', when: (state) => state.gifts?.radar_gold_24h?.available }
 ];
 
 function isAuthorizedRuntime() {
@@ -141,7 +143,13 @@ function validateActiveOnboarding(active, screenOverride = null) {
   const expected = ONBOARDING_ALLOWED_TARGETS[key];
   const hookText = getHookText(active);
 
-  if (!expected || expected.screen !== normalizedScreen || expected.target !== target) {
+  const targetAliases = {
+    radar_obstacles_24h_card: new Set(['radar_obstacles_24h_card', 'radar_obstacles_card']),
+    radar_gold_24h_card: new Set(['radar_gold_24h_card', 'radar_gold_card'])
+  };
+  const allowedTargets = targetAliases[expected?.target] || new Set([expected?.target]);
+
+  if (!expected || expected.screen !== normalizedScreen || !allowedTargets.has(target)) {
     logger.warn('⚠️ onboarding allowlist rejected active onboarding', { active, normalizedScreen });
     return null;
   }

--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -10,9 +10,33 @@ const RADAR_GIFT_TIERS = [
 
 let isRadarGiftClickInterceptorBound = false;
 
-async function claimOnboardingGiftReward(reward, { refreshOnboardingState }) {
-  const normalizedReward = String(reward || '').trim();
-  if (!normalizedReward) return false;
+function rewardFromGiftTargetOrKey(value) {
+  switch (value) {
+    case 'radar_obstacles_24h':
+    case 'gift_radar_obstacles_store':
+    case 'radar_obstacles_24h_card':
+    case 'radar_obstacles_card':
+    case 'radar_obstacles':
+      return 'radar_obstacles_24h';
+
+    case 'radar_gold_24h':
+    case 'gift_radar_gold_store':
+    case 'radar_gold_24h_card':
+    case 'radar_gold_card':
+    case 'radar_gold':
+      return 'radar_gold_24h';
+
+    default:
+      return null;
+  }
+}
+
+async function claimOnboardingGiftReward(rewardKeyOrTarget, { refreshOnboardingState }) {
+  const normalizedReward = rewardFromGiftTargetOrKey(String(rewardKeyOrTarget || '').trim());
+  if (!normalizedReward) {
+    console.warn('⚠️ onboarding gift reward mapping failed', { keyOrTarget: rewardKeyOrTarget });
+    return false;
+  }
   try {
     const { ok, data } = await requestJsonResult(`${BACKEND_URL}/api/onboarding/claim`, {
       ...REQUEST_PROFILE_STORE_WRITE,
@@ -32,6 +56,19 @@ async function claimOnboardingGiftReward(reward, { refreshOnboardingState }) {
   }
 }
 
+async function handleGiftClaimAction(rewardKeyOrTarget, handlers) {
+  const { buyUpgrade, isStoreDataLoading, loadPlayerUpgrades, updateStoreUI, refreshOnboardingState } = handlers;
+  if (isStoreDataLoading()) {
+    notifyWarn('⏳ Store is loading, try again in a moment');
+    return;
+  }
+  const claimed = await claimOnboardingGiftReward(rewardKeyOrTarget, { refreshOnboardingState });
+  if (!claimed) return;
+  await loadPlayerUpgrades();
+  updateStoreUI({ buyUpgrade });
+  notifySuccess('✅ 24H gift activated');
+}
+
 function bindRadarGiftClickInterceptor(handlers) {
   if (isRadarGiftClickInterceptorBound) return;
   isRadarGiftClickInterceptorBound = true;
@@ -43,23 +80,13 @@ function bindRadarGiftClickInterceptor(handlers) {
     event.preventDefault();
     event.stopImmediatePropagation();
 
-    const { buyUpgrade, isStoreDataLoading, loadPlayerUpgrades, updateStoreUI, refreshOnboardingState } = handlers;
     const reward = String(tierEl.dataset.onboardingGift || '').trim();
     if (!reward) return;
-    if (isStoreDataLoading()) {
-      notifyWarn('⏳ Store is loading, try again in a moment');
-      return;
-    }
-    const claimed = await claimOnboardingGiftReward(reward, { refreshOnboardingState });
-    if (!claimed) return;
-    await loadPlayerUpgrades();
-    updateStoreUI({ buyUpgrade });
-    notifySuccess('✅ 24H gift activated');
+    await handleGiftClaimAction(reward, handlers);
   }, true);
 }
 
 export function applyRadarGiftStoreUi(onboardingState, handlers) {
-  const { buyUpgrade, isStoreDataLoading, loadPlayerUpgrades, updateStoreUI, refreshOnboardingState } = handlers;
   bindRadarGiftClickInterceptor(handlers);
   const gifts = onboardingState?.gifts || {};
 
@@ -86,15 +113,7 @@ export function applyRadarGiftStoreUi(onboardingState, handlers) {
     tierEl.onclick = async function claimGiftHandler(event) {
       event?.preventDefault?.();
       event?.stopPropagation?.();
-      if (isStoreDataLoading()) {
-        notifyWarn('⏳ Store is loading, try again in a moment');
-        return;
-      }
-      const claimed = await claimOnboardingGiftReward(reward, { refreshOnboardingState });
-      if (!claimed) return;
-      await loadPlayerUpgrades();
-      updateStoreUI({ buyUpgrade });
-      notifySuccess('✅ 24H gift activated');
+      await handleGiftClaimAction(reward, handlers);
     };
   });
 }


### PR DESCRIPTION
### Motivation
- Backend onboarding uses `*_24h_card` as active onboarding targets while claim endpoints accept `*_24h` rewards, and the frontend was sending target-like names which caused rejected allowlist checks and 400 responses.

### Description
- Added `radar_obstacles_24h_card` and `radar_gold_24h_card` to `TARGET_SELECTOR_MAP` while keeping legacy `radar_obstacles_card` and `radar_gold_card` aliases in `js/features/onboarding/index.js`.
- Updated onboarding allowlist and fallback flow to prefer the `_24h_card` targets and implemented alias-aware validation in `validateActiveOnboarding` so legacy `*_card` values remain accepted.
- Implemented `rewardFromGiftTargetOrKey(value)` and normalized claim payloads to backend-accepted reward names (`radar_obstacles_24h`, `radar_gold_24h`) in `js/store/radar-gift-ui.js`.
- Added a defensive guard that logs a warning and skips calling `/api/onboarding/claim` for unknown mappings and unified click/claim handling to refresh onboarding state, reload upgrades, update the Store UI, and show success notification after a claim.

### Testing
- Syntactic checks passed via `node --check js/features/onboarding/index.js` and `node --check js/store/radar-gift-ui.js` (both succeeded).
- Pre-commit automated checks ran and passed the `check:syntax` and `check:static-analysis` scripts (static analysis succeeded).
- Basic runtime validation performed by the repo's pre-commit scripts reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0368b271308326b43565e9cb9c31f4)