### PR TITLE
Fix radar gift claim request authentication headers

### DIFF
--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -2,6 +2,8 @@ import { logger } from '../logger.js';
 import { BACKEND_URL } from '../config.js';
 import { requestJsonResult, REQUEST_PROFILE_STORE_WRITE } from '../request.js';
 import { notifyError, notifySuccess, notifyWarn } from '../notifier.js';
+import { getPrimaryAuthIdentifier, getSigningWalletAddress } from '../features/auth/index.js';
+import { getTelegramInitData } from '../auth-telegram.js';
 
 const RADAR_GIFT_TIERS = [
   { reward: 'radar_obstacles_24h', selectors: ['#store-radarobstacles-0', '[data-upgrade-key="radar_obstacles"][data-upgrade-tier="0"]'] },
@@ -38,12 +40,35 @@ async function claimOnboardingGiftReward(rewardKeyOrTarget, { refreshOnboardingS
     return false;
   }
   try {
-    const { ok, data } = await requestJsonResult(`${BACKEND_URL}/api/onboarding/claim`, {
+    const primaryId = getPrimaryAuthIdentifier();
+    const wallet = getSigningWalletAddress();
+    const telegramInitData = getTelegramInitData();
+
+    if (!primaryId) {
+      logger.warn('⚠️ onboarding gift claim skipped: missing primary auth identifier', {
+        reward: normalizedReward,
+        hasWallet: Boolean(wallet),
+        hasTelegramInitData: Boolean(telegramInitData)
+      });
+      notifyError('❌ Missing auth session for gift claim');
+      return false;
+    }
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Primary-Id': String(primaryId)
+    };
+    if (wallet) headers['X-Wallet'] = String(wallet);
+    if (telegramInitData) headers['X-Telegram-Init-Data'] = telegramInitData;
+
+    const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/onboarding/claim`, {
       ...REQUEST_PROFILE_STORE_WRITE,
       method: 'POST',
+      headers,
       body: JSON.stringify({ reward: normalizedReward })
     });
     if (!ok || !data?.success) {
+      console.warn('Gift claim failed', { status, data, reward: normalizedReward });
       notifyError(`❌ ${data?.error || 'Gift claim failed'}`);
       return false;
     }


### PR DESCRIPTION
### Motivation
- The onboarding gift claim endpoint returned `400` because requests were sent without the identity headers the backend requires (`primaryId` / wallet / Telegram init data).

### Description
- Updated `js/store/radar-gift-ui.js` to import `getPrimaryAuthIdentifier`, `getSigningWalletAddress`, and `getTelegramInitData` and build auth headers before claiming a gift.
- The claim flow now skips the API call when `primaryId` is missing to avoid unauthenticated requests, and constructs headers including `Content-Type`, `X-Primary-Id`, `X-Wallet` (if present), and `X-Telegram-Init-Data` (if present).
- The request body remains `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036efff1b883268549824d9fc14594)