### PR TITLE
Improve radar gift claimed-state UI and countdown behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1599,6 +1599,27 @@ body.start-launching #walletCorner {
   letter-spacing: .04em;
 }
 
+.store-tier.is-gift-active {
+  opacity: .55;
+  filter: grayscale(.25);
+  pointer-events: none;
+  position: relative;
+}
+
+.store-tier.is-gift-active::after {
+  content: attr(data-gift-timer);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, .45);
+  color: #fff;
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: .05em;
+  border-radius: inherit;
+}
+
 
 .store-single-buy {
   padding: 10px 16px;

--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -8,6 +8,8 @@ function ensureStyles() {
   style.textContent = `
     #${GIFT_INDICATOR_ID}{position:fixed;top:150px;right:20px;z-index:9001;}
     #${GIFT_INDICATOR_ID} .gift-btn{border:0;border-radius:999px;padding:8px 10px;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;font-weight:800;color:#111}
+    #${GIFT_INDICATOR_ID} .gift-btn.is-boost-active{animation:none;background:linear-gradient(135deg,#60a5fa,#818cf8);color:#fff;display:flex;align-items:center;gap:6px;padding:8px 12px}
+    #${GIFT_INDICATOR_ID} .gift-btn .gift-timer{font-size:11px;font-weight:800;letter-spacing:.04em}
     #${BOOSTS_ID}{position:fixed;top:190px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:6px}
     #${BOOSTS_ID} .boost-pill{background:rgba(17,24,39,.9);border:1px solid rgba(251,191,36,.4);border-radius:999px;padding:4px 8px;font-size:11px;font-weight:700;color:#fde68a}
     @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(251,191,36,.7)}70%{box-shadow:0 0 0 12px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}`;
@@ -25,6 +27,26 @@ function mountGiftIndicator({ onClick } = {}) {
   btn.textContent = '🎁';
   btn.title = 'Claim radar gift';
   btn.addEventListener('click', () => onClick?.());
+  node.appendChild(btn);
+  document.body.appendChild(node);
+}
+
+function formatRemainingHours(endsAt) {
+  const ms = Number(endsAt) - Date.now();
+  if (ms <= 0) return null;
+  return `${Math.max(1, Math.ceil(ms / 3600000))}h`;
+}
+
+function mountBoostIndicator(timerText) {
+  ensureStyles();
+  unmountGiftIndicator();
+  const node = document.createElement('div');
+  node.id = GIFT_INDICATOR_ID;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'gift-btn is-boost-active';
+  btn.title = 'Radar gift active';
+  btn.innerHTML = `<span aria-hidden="true">📡</span><span class="gift-timer">${timerText}</span>`;
   node.appendChild(btn);
   document.body.appendChild(node);
 }
@@ -60,3 +82,4 @@ function renderActiveBoostIndicators(activeBoosts = {}) {
 }
 
 export { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators };
+export { formatRemainingHours, mountBoostIndicator };

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -2,7 +2,7 @@ import { fetchOnboardingState, postOnboardingEvent, resetOnboardingStateCache } 
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
 import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
-import { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
+import { mountGiftIndicator, mountBoostIndicator, unmountGiftIndicator, renderActiveBoostIndicators, formatRemainingHours } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { hasAuthenticatedSession, isTelegramMiniApp } from '../auth/index.js';
 import { hasRideLimit } from '../store/index.js';
@@ -374,11 +374,14 @@ function applyOnboardingUiState() {
   }
 
   const gifts = onboardingState.gifts || {};
-  if (currentScreen === 'menu' && gifts.radar_obstacles_24h?.available) {
-    mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
-  }
-  if (currentScreen === 'menu' && gifts.radar_gold_24h?.available) {
-    mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
+  const boosts = onboardingState.activeBoosts || {};
+  const obstaclesTimer = boosts.radar_obstacles_24h?.active ? formatRemainingHours(boosts.radar_obstacles_24h?.endsAt) : null;
+  const goldTimer = boosts.radar_gold_24h?.active ? formatRemainingHours(boosts.radar_gold_24h?.endsAt) : null;
+  const boostTimer = obstaclesTimer || goldTimer;
+  const hasGiftAvailable = Boolean(gifts.radar_obstacles_24h?.available || gifts.radar_gold_24h?.available);
+  if (currentScreen === 'menu') {
+    if (boostTimer) mountBoostIndicator(boostTimer);
+    else if (hasGiftAvailable) mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
   }
 
   const active = resolveActiveOnboardingForScreen(onboardingState, currentScreen);

--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -12,6 +12,12 @@ const RADAR_GIFT_TIERS = [
 
 let isRadarGiftClickInterceptorBound = false;
 
+function formatRemainingHours(endsAt) {
+  const ms = Number(endsAt) - Date.now();
+  if (ms <= 0) return null;
+  return `${Math.max(1, Math.ceil(ms / 3600000))}h`;
+}
+
 function rewardFromGiftTargetOrKey(value) {
   switch (value) {
     case 'radar_obstacles_24h':
@@ -114,17 +120,32 @@ function bindRadarGiftClickInterceptor(handlers) {
 export function applyRadarGiftStoreUi(onboardingState, handlers) {
   bindRadarGiftClickInterceptor(handlers);
   const gifts = onboardingState?.gifts || {};
+  const activeBoosts = onboardingState?.activeBoosts || {};
 
   RADAR_GIFT_TIERS.forEach(({ reward, selectors }) => {
     const tierEl = selectors.map((selector) => document.querySelector(selector)).find(Boolean);
     if (!tierEl) return;
 
     const giftState = gifts[reward] || {};
+    const boostState = activeBoosts[reward] || {};
+    const giftTimerText = formatRemainingHours(boostState?.endsAt);
+    const isGiftBoostActive = boostState?.active === true && Boolean(giftTimerText);
     const isGiftAvailable = giftState.available === true && giftState.claimed !== true;
     const priceEl = tierEl.querySelector('.store-tier-price');
 
-    tierEl.classList.remove('is-gift-free');
+    tierEl.classList.remove('is-gift-free', 'is-gift-active');
     delete tierEl.dataset.onboardingGift;
+    delete tierEl.dataset.giftTimer;
+    tierEl.style.pointerEvents = '';
+    tierEl.onclick = null;
+
+    if (isGiftBoostActive) {
+      tierEl.classList.add('is-gift-active');
+      tierEl.classList.remove('available');
+      tierEl.dataset.giftTimer = giftTimerText;
+      if (priceEl) priceEl.textContent = '';
+      return;
+    }
 
     if (!isGiftAvailable) return;
 


### PR DESCRIPTION
### Motivation
- Make the Store and main menu reflect backend activeBoosts for radar gifts so claimed free radar boosts show a temporary active state and prevent re-purchase while the boost is running.
- Show a simple hours-only remaining timer UI (with minimum 1h) both on the dimmed Store card and on the main menu indicator to avoid confusion after claiming a gift.

### Description
- Added `formatRemainingHours(endsAt)` helper and wired `activeBoosts` into Store UI to compute an hours-only timer and detect active radar boosts. 
- Store: implemented `is-gift-active` state on `#store-radarobstacles-0` and `#store-radargold-0` by setting `data-gift-timer`, dimming the card, clearing the FREE label, and disabling click/purchase while the boost is active (`js/store/radar-gift-ui.js`).
- Main menu: introduced a non-pulsing boost indicator with timer using `mountBoostIndicator` and re-used the hours formatter; pulsing gift button is shown only when an unclaimed gift is available (`js/features/onboarding/gift-indicator.js`, `js/features/onboarding/index.js`).
- CSS: added `.store-tier.is-gift-active` and a `::after` overlay to center the `data-gift-timer` text and visually dim the active card (`css/style.css`).

### Testing
- Ran repository syntax checks with `node scripts/check-syntax.mjs`, which completed successfully.
- Ran static analysis via pre-commit hooks (`check:static-analysis`) which also passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0374e2406083269b93876a23120927)