### PR TITLE
Fix duplicate leaderboard save attempts and add run-level diagnostics

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -270,15 +270,17 @@ async function saveResultToLeaderboard(options = {}) {
   const { score, distance, goldCoins, silverCoins } = getGameplayProgressSnapshot();
   const clientRunId = buildClientRunId({ runToken, wallet: primaryId || identifier, score, distance, goldCoins, silverCoins });
   const runTokenKey = runToken == null ? `no_run:${clientRunId}` : String(runToken);
+  const saveDebugContext = { runToken, clientRunId, runTokenKey };
+  logger.info('🧭 saveResultToLeaderboard invoked', { ...saveDebugContext, submittedRunIds: submittedRunIds.size, inFlight: leaderboardSaveAttemptsByRunToken.size });
 
   if (leaderboardSaveCompletedRunTokens.has(runTokenKey) || submittedRunIds.has(clientRunId)) {
-    logger.info('ℹ️ Leaderboard result already submitted for this run — skipping duplicate submit');
+    logger.info('ℹ️ Leaderboard result already submitted for this run — skipping duplicate submit', saveDebugContext);
     return { status: SAVE_RESULT_STATUS.SKIPPED, reason: 'already_submitted' };
   }
 
   const existingAttempt = leaderboardSaveAttemptsByRunToken.get(runTokenKey);
   if (existingAttempt) {
-    logger.info('ℹ️ Leaderboard save already in-flight for this run — reusing existing promise');
+    logger.info('ℹ️ Leaderboard save already in-flight for this run — reusing existing promise', saveDebugContext);
     return existingAttempt;
   }
 
@@ -290,10 +292,8 @@ async function saveResultToLeaderboard(options = {}) {
   const savePromise = (async () => {
     try {
     const timestamp = Date.now();
-    /** @type {WalletSavePayload|TelegramSavePayload} */
-    let data;
+    /** @type {WalletSavePayload|TelegramSavePayload} */ let data;
     let walletForSignature = "";
-    
     if (isTelegramAuthMode()) {
       const telegramId = getTelegramAuthIdentifier();
       if (!telegramId) {
@@ -319,7 +319,6 @@ async function saveResultToLeaderboard(options = {}) {
         logger.error("❌ Failed to get signature");
         return { status: SAVE_RESULT_STATUS.FAILED, reason: 'signature_missing' };
       }
-      
       data = {
         wallet: walletForSignature,
         score,
@@ -331,15 +330,15 @@ async function saveResultToLeaderboard(options = {}) {
       };
     }
 
+    logger.info('🚀 Leaderboard save request start', saveDebugContext);
     let response = await request(`${BACKEND_URL}/api/leaderboard/save`, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-Wallet": data.wallet },
       body: JSON.stringify(data)
     });
+    logger.info('📬 Leaderboard save response received', { ...saveDebugContext, status: response.status, ok: response.ok });
 
     // Do not retry with extra signatures in web flow to avoid duplicate wallet prompts.
-
-    
     if (response.ok) {
       let responseData = null;
       try {
@@ -350,27 +349,27 @@ async function saveResultToLeaderboard(options = {}) {
       const savePrompt = responseData?.gameOverPrompt && typeof responseData.gameOverPrompt === 'object'
         ? responseData.gameOverPrompt
         : null;
-      if (savePrompt) setGameOverPrompt(savePrompt, { source: 'save', runToken });
-      logger.info("✅ Result saved!");
-      showBonusText("✅ In leaderboard!");
-      await loadAndDisplayLeaderboard({ runToken });
-      await refreshPlayerStats({ source: 'saveResultToLeaderboard' });
+      const duplicateByPayload = responseData?.alreadySaved === true || responseData?.duplicate === true;
       leaderboardSaveCompletedRunTokens.add(runTokenKey);
       submittedRunIds.add(clientRunId);
+      if (savePrompt) setGameOverPrompt(savePrompt, { source: 'save', runToken });
+      logger.info("✅ Result saved!", { ...saveDebugContext, duplicateByPayload });
+      showBonusText("✅ In leaderboard!");
+      await loadAndDisplayLeaderboard({ runToken }).catch((error) => logger.warn('⚠️ Post-save leaderboard refresh failed (non-fatal)', { ...saveDebugContext, error }));
+      await refreshPlayerStats({ source: 'saveResultToLeaderboard' }).catch((error) => logger.warn('⚠️ Post-save player stats refresh failed (non-fatal)', { ...saveDebugContext, error }));
       return { status: SAVE_RESULT_STATUS.SAVED, gameOverPrompt: savePrompt };
     }
-    
     const errText = await response.text();
     if (response.status === 400) {
       logger.warn("⚠️ Leaderboard save rejected (400):", errText || "Bad Request");
       return { status: SAVE_RESULT_STATUS.FAILED, reason: 'bad_request' };
     }
     if (response.status === 409) {
-      logger.info('ℹ️ Leaderboard result already submitted (409) — treating as saved');
+      logger.info('ℹ️ Leaderboard result already submitted (409) — treating as saved', saveDebugContext);
       leaderboardSaveCompletedRunTokens.add(runTokenKey);
       submittedRunIds.add(clientRunId);
-      await loadAndDisplayLeaderboard({ runToken });
-      await refreshPlayerStats({ source: 'saveResultToLeaderboard:already_submitted' });
+      await loadAndDisplayLeaderboard({ runToken }).catch((error) => logger.warn('⚠️ Post-save leaderboard refresh after 409 failed (non-fatal)', { ...saveDebugContext, error }));
+      await refreshPlayerStats({ source: 'saveResultToLeaderboard:already_submitted' }).catch((error) => logger.warn('⚠️ Post-save player stats refresh after 409 failed (non-fatal)', { ...saveDebugContext, error }));
       return { status: SAVE_RESULT_STATUS.SKIPPED, reason: 'already_submitted' };
     }
 
@@ -383,10 +382,12 @@ async function saveResultToLeaderboard(options = {}) {
   })();
 
   leaderboardSaveAttemptsByRunToken.set(runTokenKey, savePromise);
+  logger.info('🪪 Leaderboard save request marked in-flight', saveDebugContext);
 
   return savePromise.finally(() => {
     if (leaderboardSaveAttemptsByRunToken.get(runTokenKey) === savePromise) {
       leaderboardSaveAttemptsByRunToken.delete(runTokenKey);
+      logger.info('🏁 Leaderboard save request completed', saveDebugContext);
     }
   });
 }
@@ -574,7 +575,6 @@ async function setLeaderboardDisplay(mode) {
     body: JSON.stringify({ mode })
   });
 }
-
 export {
   isAuthenticated,
   getAuthIdentifier,


### PR DESCRIPTION
### Motivation
- Investigate and suppress duplicate `/api/leaderboard/save` requests observed after signed runs by adding client-side diagnostics and stronger run-level guards.

### Description
- Added lightweight run-level debug context and lifecycle logs in `saveResultToLeaderboard` to emit `runToken`, `clientRunId`, submitted/in-flight counters and request start/response/completion events in `js/api.js`.
- Ensured duplicate suppression by reusing an existing in-flight promise from `leaderboardSaveAttemptsByRunToken` and returning early when `leaderboardSaveCompletedRunTokens` or `submittedRunIds` indicate a prior save.
- Marked a run as completed (`leaderboardSaveCompletedRunTokens` / `submittedRunIds`) before performing post-save UI refreshes and made `loadAndDisplayLeaderboard` / `refreshPlayerStats` calls non-fatal so post-save refresh failures do not cause duplicate retries.
- Treated backend duplicate indications (`409` and payload flags like `alreadySaved`/`duplicate`) as informational and suppressed re-submission while still performing leaderboard refreshes without elevating the save to a failure.

### Testing
- Ran `node --check js/api.js` to validate syntax and it succeeded.
- Pre-commit automated checks ran `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed. 
- Verified the change compiles in the repository CI-local checks included in the commit hook (no static-analysis violations remaining).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038a41f3d8832688a3f4169bd8df67)