### PR TITLE
Reorder right-side in-game HUD icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,10 +84,10 @@
       <div id="uiTopRight">
         <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span></span><span class="value" id="shieldVal">✗</span></div>
         <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px 0px"></span></span><span class="value" id="magnetVal">OFF</span></div>
-        <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -84px"></span></span><span class="value" id="invertVal">OK</span></div>
-        <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px -56px"></span></span><span class="value" id="multiplierVal">x1</span></div>
+        <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -28px"></span></span><span class="value" id="invertVal">OK</span></div>
+        <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span></span><span class="value" id="multiplierVal">x1</span></div>
         <div style="border-top: 1px solid rgba(255,255,255,.06); margin-top: 5px; padding-top: 5px;">
-          <span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -28px"></span></span><span class="value" id="spinVal">✓</span>
+          <span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span></span><span class="value" id="spinVal">✓</span>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Fix visual order of the status icons in the in-game right HUD so they appear top-to-bottom as: `shield`, `magnet`, `rotate`, `cross`, `refresh`.

### Description
- Adjusted atlas `background-position` values for the status icons in `index.html` to reorder the icons in the right HUD column without changing any game logic or JS behavior.

### Testing
- Automated pre-commit checks were executed and passed: `npm run check:syntax` and `npm run check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0390f8bd348326887958f92a9af68a)