### PR TITLE
Fix Player Menu history visibility and resilient loading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2726,6 +2726,10 @@ footer a:hover { color: #e0b0ff; }
   display: flex;
 }
 
+#playerMenuOverlay {
+  overflow-y: auto;
+}
+
 .pm-back-btn {
   align-self: flex-start;
   display: flex;
@@ -2772,7 +2776,8 @@ footer a:hover { color: #e0b0ff; }
   gap: 40px;
   flex: 1;
   margin-top: 24px;
-  min-height: 0;
+  min-height: 100%;
+  overflow-y: visible;
 }
 
 .pm-center {
@@ -2781,6 +2786,7 @@ footer a:hover { color: #e0b0ff; }
   flex-direction: column;
   gap: 20px;
   min-width: 0;
+  overflow: visible;
 }
 
 .pm-rank {
@@ -2940,7 +2946,11 @@ footer a:hover { color: #e0b0ff; }
 }
 
 .pm-history {
-  margin-top: 20px;
+  display: block;
+  width: 100%;
+  margin-top: 16px;
+  opacity: 1;
+  visibility: visible;
   border: 1px solid rgba(255, 255, 255, .12);
   border-radius: 14px;
   background: rgba(9, 7, 18, .55);
@@ -2959,8 +2969,8 @@ footer a:hover { color: #e0b0ff; }
 }
 
 .pm-history-table-wrap {
-  max-height: none;
-  overflow: visible;
+  max-height: 220px;
+  overflow-y: auto;
 }
 
 .pm-history-table {

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -132,13 +132,15 @@ function resolveEntryCoins(entry) {
   return { gold: 0, silver: 0 };
 }
 
-function renderCoinHistory(history) {
+function renderCoinHistory(history, options = {}) {
   const tbody = DOM.pmHistoryBody;
   if (!tbody) return;
 
+  const { loadFailed = false } = options;
   const rows = Array.isArray(history) ? history : [];
   if (!rows.length) {
-    tbody.innerHTML = '<tr><td colspan="3" class="pm-history-empty">No rewards yet</td></tr>';
+    const emptyMessage = loadFailed ? 'Could not load history' : 'No rewards yet';
+    tbody.innerHTML = `<tr><td colspan="3" class="pm-history-empty">${emptyMessage}</td></tr>`;
     return;
   }
 
@@ -306,14 +308,24 @@ function fillProfileData(profile) {
 }
 
 async function loadProfile() {
-  const [profile, coinHistory] = await Promise.all([
+  console.info('Player menu history nodes', {
+    historySection: document.querySelector('.pm-history'),
+    body: document.getElementById('pmHistoryBody')
+  });
+
+  const [profileResult, coinHistoryResult] = await Promise.allSettled([
     fetchMyProfile(),
     fetchCoinHistory(50)
   ]);
+
+  const profile = profileResult.status === 'fulfilled' ? profileResult.value : null;
+  const coinHistory = coinHistoryResult.status === 'fulfilled' ? coinHistoryResult.value : [];
+  const coinHistoryLoadFailed = coinHistoryResult.status === 'rejected';
+
   if (profile) {
     fillProfileData(profile);
   }
-  renderCoinHistory(coinHistory);
+  renderCoinHistory(coinHistory, { loadFailed: coinHistoryLoadFailed });
   applyResponsivePlayerMenuLayout();
   // If profile is null (e.g. 401), keep any fallback values already shown
   return profile;


### PR DESCRIPTION
### Motivation
- The Player Menu history table was not visible on web due to overflow/visibility rules and non-resilient loading logic.
- Make the menu scrollable and ensure history renders even if one backend request fails.

### Description
- Make overlay and inner content scroll-friendly by adding `#playerMenuOverlay { overflow-y: auto; }`, ` .pm-content { min-height: 100%; overflow-y: visible; }` and `.pm-center { overflow: visible; }` in `css/style.css`.
- Force the History block to be visible with explicit `.pm-history { display: block; width: 100%; margin-top: 16px; opacity: 1; visibility: visible; }` and make the table area scrollable via `.pm-history-table-wrap { max-height: 220px; overflow-y: auto; }`.
- Make coin-history rendering tolerant to failures by switching `loadProfile()` from `Promise.all(...)` to `Promise.allSettled(...)` and by rendering profile and history independently in `js/player-menu/controller.js`.
- Update `renderCoinHistory()` to accept an options object and show `No rewards yet` for an empty successful response or `Could not load history` when the history request fails.
- Add a temporary debug `console.info` log to surface `.pm-history` and `#pmHistoryBody` DOM node presence.

### Testing
- Ran `npm run check:syntax` and it succeeded with syntax checks passing for all relevant files.
- Ran `npm run test:request` and all request/unit tests passed (86 tests, 0 failures).
- Pre-commit static analysis checks passed (`check:static-analysis`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0394322bac8326b99cf42eafdbcf3e)