### PR TITLE
Fix radar boost timer consistency and main-menu indicators

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2336,6 +2336,9 @@ footer a:hover { color: #e0b0ff; }
 .icon-coin-gold-sm{width:14px;height:14px;background-size:70px auto;background-position:-28px -42px;}
 .icon-coin-silver-sm{width:14px;height:14px;background-size:70px auto;background-position:-14px -42px;}
 
+.icon-radar-obstacles{width:20px;height:20px;background-size:100px auto;background-position:-70px 0px;}
+.icon-radar-gold{width:20px;height:20px;background-size:100px auto;background-position:-70px 0px;filter:hue-rotate(40deg) saturate(1.2);}
+
 .store-tabs {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/js/features/onboarding/boost-timer.js
+++ b/js/features/onboarding/boost-timer.js
@@ -1,0 +1,7 @@
+export function formatRemainingHours(endsAt) {
+  const ts = typeof endsAt === 'string' ? Date.parse(endsAt) : Number(endsAt);
+  if (!Number.isFinite(ts)) return null;
+  const ms = ts - Date.now();
+  if (ms <= 0) return null;
+  return `${Math.max(1, Math.ceil(ms / 3600000))}h`;
+}

--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -1,3 +1,5 @@
+import { formatRemainingHours } from './boost-timer.js';
+
 const GIFT_INDICATOR_ID = 'onboardingGiftIndicator';
 
 function ensureStyles() {
@@ -5,7 +7,7 @@ function ensureStyles() {
   const style = document.createElement('style');
   style.id = 'onboardingGiftIndicatorStyles';
   style.textContent = `
-    #${GIFT_INDICATOR_ID}{position:fixed;top:150px;right:20px;z-index:9001;}
+    #${GIFT_INDICATOR_ID}{position:fixed;top:150px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:8px;}
     #${GIFT_INDICATOR_ID} .gift-btn{border:0;border-radius:999px;padding:8px 10px;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;font-weight:800;color:#111}
     #${GIFT_INDICATOR_ID} .gift-btn.is-boost-active{animation:none;background:linear-gradient(135deg,#60a5fa,#818cf8);color:#fff;display:flex;align-items:center;gap:6px;padding:8px 12px}
     #${GIFT_INDICATOR_ID} .gift-btn .gift-timer{font-size:11px;font-weight:800;letter-spacing:.04em}
@@ -28,23 +30,29 @@ function mountGiftIndicator({ onClick } = {}) {
   document.body.appendChild(node);
 }
 
-function formatRemainingHours(endsAt) {
-  const ms = Number(endsAt) - Date.now();
-  if (ms <= 0) return null;
-  return `${Math.max(1, Math.ceil(ms / 3600000))}h`;
-}
-
-function mountBoostIndicator(timerText) {
+function mountBoostIndicator(activeBoosts = {}) {
   ensureStyles();
   unmountGiftIndicator();
   const node = document.createElement('div');
   node.id = GIFT_INDICATOR_ID;
   const btn = document.createElement('button');
   btn.type = 'button';
-  btn.className = 'gift-btn is-boost-active';
-  btn.title = 'Radar gift active';
-  btn.innerHTML = `<span aria-hidden="true">📡</span><span class="gift-timer">${timerText}</span>`;
-  node.appendChild(btn);
+  const activeItems = [
+    { key: 'radar_obstacles_24h', title: 'Radar Obstacles', iconClass: 'icon-radar-obstacles' },
+    { key: 'radar_gold_24h', title: 'Radar Gold', iconClass: 'icon-radar-gold' }
+  ].map((entry) => ({ ...entry, timer: activeBoosts?.[entry.key]?.active ? formatRemainingHours(activeBoosts?.[entry.key]?.endsAt) : null }))
+    .filter((entry) => Boolean(entry.timer));
+
+  if (!activeItems.length) return;
+
+  activeItems.forEach((entry) => {
+    const iconBtn = btn.cloneNode(false);
+    iconBtn.className = 'gift-btn is-boost-active';
+    iconBtn.title = entry.title;
+    iconBtn.setAttribute('aria-label', entry.title);
+    iconBtn.innerHTML = `<span class="icon-atlas ${entry.iconClass}" aria-hidden="true"></span><span class="gift-timer">${entry.timer}</span>`;
+    node.appendChild(iconBtn);
+  });
   document.body.appendChild(node);
 }
 
@@ -57,4 +65,4 @@ function renderActiveBoostIndicators() {
 }
 
 export { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators };
-export { formatRemainingHours, mountBoostIndicator };
+export { mountBoostIndicator };

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -2,7 +2,7 @@ import { fetchOnboardingState, postOnboardingEvent, resetOnboardingStateCache } 
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
 import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
-import { mountGiftIndicator, mountBoostIndicator, unmountGiftIndicator, renderActiveBoostIndicators, formatRemainingHours } from './gift-indicator.js';
+import { mountGiftIndicator, mountBoostIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { hasAuthenticatedSession, isTelegramMiniApp } from '../auth/index.js';
 import { hasRideLimit } from '../store/index.js';
@@ -375,12 +375,9 @@ function applyOnboardingUiState() {
 
   const gifts = onboardingState.gifts || {};
   const boosts = onboardingState.activeBoosts || {};
-  const obstaclesTimer = boosts.radar_obstacles_24h?.active ? formatRemainingHours(boosts.radar_obstacles_24h?.endsAt) : null;
-  const goldTimer = boosts.radar_gold_24h?.active ? formatRemainingHours(boosts.radar_gold_24h?.endsAt) : null;
-  const boostTimer = obstaclesTimer || goldTimer;
   const hasGiftAvailable = Boolean(gifts.radar_obstacles_24h?.available || gifts.radar_gold_24h?.available);
   if (currentScreen === 'menu') {
-    if (boostTimer) mountBoostIndicator(boostTimer);
+    if (Object.keys(boosts).length > 0) mountBoostIndicator(boosts);
     else if (hasGiftAvailable) mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
   }
 

--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -4,6 +4,7 @@ import { requestJsonResult, REQUEST_PROFILE_STORE_WRITE } from '../request.js';
 import { notifyError, notifySuccess, notifyWarn } from '../notifier.js';
 import { getPrimaryAuthIdentifier, getSigningWalletAddress } from '../features/auth/index.js';
 import { getTelegramInitData } from '../auth-telegram.js';
+import { formatRemainingHours } from '../features/onboarding/boost-timer.js';
 
 const RADAR_GIFT_TIERS = [
   { reward: 'radar_obstacles_24h', selectors: ['#store-radarobstacles-0', '[data-upgrade-key="radar_obstacles"][data-upgrade-tier="0"]'] },
@@ -11,12 +12,6 @@ const RADAR_GIFT_TIERS = [
 ];
 
 let isRadarGiftClickInterceptorBound = false;
-
-function formatRemainingHours(endsAt) {
-  const ms = Number(endsAt) - Date.now();
-  if (ms <= 0) return null;
-  return `${Math.max(1, Math.ceil(ms / 3600000))}h`;
-}
 
 function rewardFromGiftTargetOrKey(value) {
   switch (value) {
@@ -93,12 +88,13 @@ function applyImmediateClaimedUi(reward, until) {
   if (!tierConfig) return;
   const tierEl = tierConfig.selectors.map((selector) => document.querySelector(selector)).find(Boolean);
   if (!tierEl) return;
-  if (!formatRemainingHours(until)) return;
+  const giftTimerText = formatRemainingHours(until);
+  if (!giftTimerText) return;
 
   tierEl.classList.add('is-gift-active');
   tierEl.classList.remove('is-gift-free', 'available');
   delete tierEl.dataset.onboardingGift;
-  tierEl.dataset.giftTimer = '24h';
+  tierEl.dataset.giftTimer = giftTimerText;
   tierEl.style.pointerEvents = 'none';
   const priceEl = tierEl.querySelector('.store-tier-price');
   if (priceEl) priceEl.textContent = '';
@@ -160,7 +156,7 @@ export function applyRadarGiftStoreUi(onboardingState, handlers) {
     if (isGiftBoostActive) {
       tierEl.classList.add('is-gift-active');
       tierEl.classList.remove('available');
-      tierEl.dataset.giftTimer = '24h';
+      tierEl.dataset.giftTimer = giftTimerText;
       if (priceEl) priceEl.textContent = '';
       return;
     }


### PR DESCRIPTION
### Motivation
- Ensure Store and main menu use the same backend-driven timestamp and identical rounding logic for radar boosts so remaining hours are consistent.
- Allow both radar boosts (`radar_obstacles_24h`, `radar_gold_24h`) to be shown simultaneously in the main-menu indicator instead of collapsing to one icon.
- Replace hardcoded `24h` UI labels after claim with a formatter based on `endsAt` from onboarding/activeBoosts and use atlas icons for boost indicators.

### Description
- Added shared helper `formatRemainingHours(endsAt)` in `js/features/onboarding/boost-timer.js` which parses string/number timestamps and returns normalized `Nh` text or `null` for expired values. 
- Updated `js/store/radar-gift-ui.js` to import and use `formatRemainingHours` (removed hardcoded `'24h'`), set `data-gift-timer` from the helper for both immediate-claim and render paths, and only show active UI while `formatRemainingHours` returns a value.
- Reworked `js/features/onboarding/gift-indicator.js` so `mountBoostIndicator` accepts the full `activeBoosts` object and renders separate buttons for `Radar Obstacles` and `Radar Gold` with proper `title`/`aria-label` and per-icon timer pills, disabling pulse for active icons. 
- Adjusted `js/features/onboarding/index.js` to pass `activeBoosts` into the menu indicator renderer and only show the pulsing gift button when no active boosts are displayed. 
- Added atlas icon classes `.icon-radar-obstacles` and `.icon-radar-gold` in `css/style.css` and used the icon-atlas classes for menu boost icons.

### Testing
- Ran the test suite with `npm -s run test -- --runInBand` and all tests passed (86/86). 
- Pre-commit automated checks (`check:syntax`, `check:static-analysis`) passed during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0397dfac5883268b9b4f3caa30e219)