### PR TITLE
Fix radar gift indicator sprite alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2336,8 +2336,8 @@ footer a:hover { color: #e0b0ff; }
 .icon-coin-gold-sm{width:14px;height:14px;background-size:70px auto;background-position:-28px -42px;}
 .icon-coin-silver-sm{width:14px;height:14px;background-size:70px auto;background-position:-14px -42px;}
 
-.icon-radar-obstacles{width:20px;height:20px;background-size:100px auto;background-position:-70px 0px;}
-.icon-radar-gold{width:20px;height:20px;background-size:100px auto;background-position:-70px 0px;filter:hue-rotate(40deg) saturate(1.2);}
+.icon-radar-obstacles{width:20px;height:20px;background-size:100px auto;background-position:-80px 0px;}
+.icon-radar-gold{width:20px;height:20px;background-size:100px auto;background-position:-80px 0px;filter:hue-rotate(40deg) saturate(1.2);}
 
 .store-tabs {
   display: grid;


### PR DESCRIPTION
### Motivation
- The radar gift indicator used the icon atlas with an incorrect `background-position`, causing the displayed image to sample the gap between atlas cells instead of the radar icon.

### Description
- Update `css/style.css` to set `background-position` for `.icon-radar-obstacles` and `.icon-radar-gold` from `-70px 0px` to `-80px 0px` so the radar sprite is centered in the correct atlas cell.

### Testing
- Ran pre-commit automated checks which execute `check:syntax` and `check:static-analysis`, and both checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0399c368048326808d2133782163ce)