### PR TITLE
Make leaderboard loading non-blocking during bootstrap

### DIFF
--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -516,14 +516,15 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     };
   }
 
-  logger.info('📊 Loading leaderboard...');
-  try {
-    updateGameOverLeaderboardNotice();
-    await loadAndDisplayLeaderboard();
-    logger.info('✅ Leaderboard loaded');
-  } catch (error) {
-    logger.warn('⚠️ Leaderboard loading error:', error);
-  }
+  logger.info('📊 Loading leaderboard in background...');
+  updateGameOverLeaderboardNotice();
+  loadAndDisplayLeaderboard()
+    .then(() => {
+      logger.info('✅ Leaderboard loaded');
+    })
+    .catch((error) => {
+      logger.warn('⚠️ Leaderboard loading error:', error);
+    });
 
   if (DOM.storeBtn) {
     DOM.storeBtn.classList.toggle('menu-hidden', !isStoreAvailable());


### PR DESCRIPTION
### Motivation
- The leaderboard fetch during `initGameBootstrapFlow` blocked final app initialization, delaying UI interactivity on slow or failing networks.
- The change aims to start leaderboard loading in the background while preserving the skeleton/fallback leaderboard UI so buttons and other startup flows remain immediately usable.

### Description
- Modified `js/game/bootstrap.js` to call `updateGameOverLeaderboardNotice()` and invoke `loadAndDisplayLeaderboard()` without `await`, converting it to a background promise chain with `.then()`/`.catch()` and updated log text to `📊 Loading leaderboard in background...`.
- Preserved existing error handling by logging warnings on failure so leaderboard errors do not block initialization.
- Ensures subsequent initialization steps (store button visibility, rides display, music, `prepareViewport()`, screen listeners, ping lifecycle, and final "Game fully initialized" log) run immediately after kicking off the leaderboard load.
- Keeps the skeleton/fallback leaderboard visible immediately by calling `updateGameOverLeaderboardNotice()` before starting the background load.

### Testing
- Ran the syntax checks via `scripts/check-syntax.mjs` (pre-commit hook) which passed.
- Ran static analysis via `scripts/check-static-analysis.mjs` (pre-commit hook) which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039c785ff48326b297b2c1490e8a2b)