### PR TITLE
Fix Game Over onboarding refresh after leaderboard save

### DIFF
--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -19,21 +19,20 @@ import { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { identifyPostHogUser, resetPostHogUser } from '../integrations/posthog/index.js';
 import { trackTelegramEvent } from '../telegram-analytics.js';
-
 let cleanupPingLifecycle = () => {};
 let uiEventHandlersBound = false;
 let visibilityAudioLifecycleBound = false;
-
+const LEADERBOARD_SAVE_SUCCESS_EVENT = 'ursas:leaderboard-save-success';
+const ONBOARDING_GAME_OVER_RETRY_ATTEMPTS = 5;
+const ONBOARDING_GAME_OVER_RETRY_DELAY_MS = 500;
 let cachedProfile = null;
 let profileCacheTimestamp = 0;
 // Cache TTL: 30s balances freshness vs API calls. Invalidated explicitly after share or X connect.
 const PROFILE_CACHE_TTL_MS = 30000;
-
 // Flag: true only when the user actively initiated a wallet connect this session tick.
 let _walletJustConnected = false;
 // Tracks whether a wallet session was active on the previous auth callback.
 let _lastKnownWalletSession = false;
-
 async function getCachedProfile() {
   const now = Date.now();
   if (cachedProfile && (now - profileCacheTimestamp) < PROFILE_CACHE_TTL_MS) {
@@ -43,35 +42,50 @@ async function getCachedProfile() {
   profileCacheTimestamp = Date.now();
   return cachedProfile;
 }
-
 function invalidateProfileCache() {
   cachedProfile = null;
   profileCacheTimestamp = 0;
 }
-
-async function refreshOnboardingAfterRunFinished() {
-  const firstState = await refreshOnboardingState({ reason: 'run_finished', screen: 'game-over', resetCache: true }).catch(() => null);
-  if (Number(firstState?.raceCount) !== 1) {
-    setTimeout(() => {
-      refreshOnboardingState({ reason: 'run_finished_retry', screen: 'game-over', resetCache: true }).catch(() => {});
-    }, 700);
+let onboardingGameOverRetryTimer = null;
+let onboardingGameOverRetryJobId = 0;
+function cancelGameOverOnboardingRetries() {
+  onboardingGameOverRetryJobId += 1;
+  if (onboardingGameOverRetryTimer) {
+    clearTimeout(onboardingGameOverRetryTimer);
+    onboardingGameOverRetryTimer = null;
   }
 }
-
+async function refreshOnboardingAfterLeaderboardSaveSuccess() {
+  cancelGameOverOnboardingRetries();
+  const jobId = onboardingGameOverRetryJobId;
+  const ensureCurrentScreen = () => document?.body?.dataset?.screen === 'game-over';
+  for (let attempt = 1; attempt <= ONBOARDING_GAME_OVER_RETRY_ATTEMPTS; attempt += 1) {
+    if (jobId !== onboardingGameOverRetryJobId || !ensureCurrentScreen()) return;
+    const state = await refreshOnboardingState({
+      reason: attempt === 1 ? 'leaderboard_save_success' : 'leaderboard_save_success_retry',
+      screen: 'game-over',
+      resetCache: true
+    }).catch(() => null);
+    if (jobId !== onboardingGameOverRetryJobId || !ensureCurrentScreen()) return;
+    applyOnboardingForScreen('game-over');
+    if (Number(state?.raceCount) >= 1) return;
+    if (attempt === ONBOARDING_GAME_OVER_RETRY_ATTEMPTS) return;
+    await new Promise((resolve) => {
+      onboardingGameOverRetryTimer = setTimeout(resolve, ONBOARDING_GAME_OVER_RETRY_DELAY_MS);
+    });
+    onboardingGameOverRetryTimer = null;
+  }
+}
 async function updateGameOverShareButton() {
   const shareBtn = DOM.shareResultBtn;
   if (!shareBtn) return;
-
   if (!isAuthenticated()) {
     shareBtn.hidden = true;
     return;
   }
-
   shareBtn.hidden = false;
   const profile = await getCachedProfile();
-
   shareBtn.classList.remove('is-connect-x', 'is-share', 'is-share-rewarded');
-
   if (!profile?.x?.connected) {
     shareBtn.classList.add('is-connect-x');
     shareBtn.textContent = 'CONNECT X';
@@ -84,7 +98,6 @@ async function updateGameOverShareButton() {
     shareBtn.textContent = 'SHARE RESULT';
   }
 }
-
 function updatePlayerAvatarVisibility() {
   const btn = DOM.playerAvatarBtn;
   if (!btn) return;
@@ -94,13 +107,11 @@ function updatePlayerAvatarVisibility() {
     Boolean(snap?.linkedWallet);
   btn.hidden = !walletConnected;
 }
-
 function checkXOAuthCallback() {
   if (typeof location === 'undefined') return;
   const params = new URLSearchParams(location.search);
   const xParam = params.get('x');
   if (!xParam) return;
-
   const newParams = new URLSearchParams(params);
   newParams.delete('x');
   newParams.delete('username');
@@ -110,7 +121,6 @@ function checkXOAuthCallback() {
     ? `${location.pathname}?${newSearch}${location.hash}`
     : `${location.pathname}${location.hash}`;
   try { history.replaceState(null, '', newUrl); } catch (_e) { /* ignore */ }
-
   if (xParam === 'connected') {
     const username = params.get('username') || '';
     notifySuccess(`✅ X connected${username ? ` as @${username}` : ''}!`);
@@ -123,8 +133,6 @@ function checkXOAuthCallback() {
     notifyError(`❌ X connect failed: ${reason}`);
   }
 }
-
-
 function syncFirstRunOnboardingUiState() {
   if (typeof document === 'undefined') return;
 
@@ -547,7 +555,8 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     if (screen === 'game-over') {
       invalidateProfileCache();
       updateGameOverShareButton().catch(() => {});
-      refreshOnboardingAfterRunFinished().catch(() => {});
+    } else {
+      cancelGameOverOnboardingRetries();
     }
     if (screen === 'store') {
       refreshOnboardingState({ reason: 'store_open' }).catch(() => {});
@@ -556,6 +565,12 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
 
   window.addEventListener('ursas:onboarding-store-buy', () => {
     refreshOnboardingState({ reason: 'store_buy' }).catch(() => {});
+  });
+  window.addEventListener(LEADERBOARD_SAVE_SUCCESS_EVENT, (event) => {
+    const status = event?.detail?.status;
+    if (status === 'saved' || status === 'already_submitted') {
+      refreshOnboardingAfterLeaderboardSaveSuccess().catch(() => {});
+    }
   });
 
   initializeMetaMaskIntegration({

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -19,38 +19,12 @@ import { maybeCelebrateMilestone } from './game-over-confetti.js';
 import { beginAiRun, finishAiRun } from '../ai-mode.js';
 const CRASH_FLYER_SRC = 'img/bear_pixel_transparent.webp'; const CRASH_FLYER_FALLBACK_SRC = 'img/bear.png';
 const CRASH_FLY_DEFAULT_DURATION_MS = 6000, START_TRANSITION_STATIC_EYES_SRC = 'img/eyes.png', MENU_EYES_STATIC_SRC = 'img/eyes.png', RUN_INDEX_STORAGE_KEY = 'ursas_run_index';
+const LEADERBOARD_SAVE_SUCCESS_EVENT = 'ursas:leaderboard-save-success';
 function createGameSessionController({
-  DOM,
-  gameState,
-  player,
-  assetManager,
-  getPlayerRides,
-  getGameplayUpgradeSnapshot,
-  getViewportDimensions,
-  syncViewport,
-  loopController,
-  resetGameSessionState,
-  loadPlayerRides,
-  useRide,
-  updateRidesDisplay,
-  hasRideLimit,
-  isEligibleForLeaderboardFlow,
-  isUnauthRuntimeMode,
-  hasWalletAuthSession,
-  setBestScore,
-  getBestScore,
-  setBestDistance,
-  getBestDistance,
-  ensureRendererReady,
-  showRendererPlaceholder,
-  hideRendererPlaceholder,
-  warmupRendererFrame,
-  initializeGameplayRun,
-  startGameplaySimulation,
-  applyGameplayUpgradeState,
-  clearGameplayCollections,
-  waitForPhaserSceneReady,
-  renderFirstGameplayFrame
+  DOM, gameState, player, assetManager, getPlayerRides, getGameplayUpgradeSnapshot, getViewportDimensions, syncViewport, loopController, resetGameSessionState,
+  loadPlayerRides, useRide, updateRidesDisplay, hasRideLimit, isEligibleForLeaderboardFlow, isUnauthRuntimeMode, hasWalletAuthSession, setBestScore, getBestScore,
+  setBestDistance, getBestDistance, ensureRendererReady, showRendererPlaceholder, hideRendererPlaceholder, warmupRendererFrame, initializeGameplayRun, startGameplaySimulation,
+  applyGameplayUpgradeState, clearGameplayCollections, waitForPhaserSceneReady, renderFirstGameplayFrame
 }) {
   let endGameInProgress = false;
   let runStartedAt = null;
@@ -522,6 +496,7 @@ function createGameSessionController({
         .then((results) => {
           const settledSave = results[2];
           const saveResult = settledSave?.status === 'fulfilled' ? settledSave.value : { status: 'failed', reason: 'promise_rejected' };
+          notifyLeaderboardSaveSuccess({ runToken, saveResult });
           if (saveResult?.status === 'failed') notifyWarn('Result not saved', { durationMs: 2600 });
         })
         .catch((error) => {
@@ -596,3 +571,17 @@ function createGameSessionController({
   };
 }
 export { createGameSessionController };
+  function notifyLeaderboardSaveSuccess({ runToken, saveResult }) {
+    if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return;
+    const status = String(saveResult?.status || '').toLowerCase();
+    const reason = String(saveResult?.reason || '').toLowerCase();
+    const isSaved = status === 'saved';
+    const isAlreadySubmitted = status === 'skipped' && reason === 'already_submitted';
+    if (!isSaved && !isAlreadySubmitted) return;
+    window.dispatchEvent(new CustomEvent(LEADERBOARD_SAVE_SUCCESS_EVENT, {
+      detail: {
+        runToken,
+        status: isSaved ? 'saved' : 'already_submitted'
+      }
+    }));
+  }


### PR DESCRIPTION
### Motivation
- Game Over onboarding sometimes missed `second_race_game_over` because the frontend refreshed onboarding before the backend persisted the run and updated `raceCount`. 
- The existing flow relied only on `screen_changed` timing which could run before the leaderboard save completed, requiring users to return to menu to see onboarding.

### Description
- Emit a `ursas:leaderboard-save-success` event from the save flow when the leaderboard save resolves as `saved` or `already_submitted` by adding `notifyLeaderboardSaveSuccess` in `js/game/session.js`.
- Listen for that event in `js/game/bootstrap.js` and run `refreshOnboardingState({ reason: 'leaderboard_save_success', screen: 'game-over', resetCache: true })` followed by `applyOnboardingForScreen('game-over')`.
- Add a conditional retry loop (max 5 attempts, 500ms delay) that repeats refreshes until `raceCount >= 1` and stop retries if the player leaves the Game Over screen by cancelling pending timers.
- Keep existing `screen_changed` onboarding handling for other flows and avoid triggering refreshes for failed saves so no duplicate or premature spotlights occur.

### Testing
- Ran `node scripts/check-syntax.mjs` and it completed successfully. 
- Ran `node scripts/check-static-analysis.mjs` and static analysis checks passed. 
- Pre-commit hooks (syntax + static analysis) ran and passed during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a4c80f648326b9cdfd8aa434e769)