### PR TITLE
Center onboarding spotlight target by pre-scrolling scrollable parents

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -301,7 +301,7 @@ function showAuthorizedOnboarding(active) {
   };
 
   let attempts = 0;
-  const render = () => {
+  const render = async () => {
     attempts += 1;
     if (isOnboardingUiBlocked()) {
       hideSpotlight();
@@ -315,7 +315,7 @@ function showAuthorizedOnboarding(active) {
       clearGameOverOnboardingHook();
       return;
     }
-    const shown = showSpotlight({
+    const shown = await showSpotlight({
       target: spotlightTarget,
       text: getHookText(active),
       showSkip: true,
@@ -361,9 +361,13 @@ function showAuthorizedOnboarding(active) {
       clearGameOverOnboardingHook();
       return;
     }
-    requestAnimationFrame(() => setTimeout(render, 50));
+    requestAnimationFrame(() => setTimeout(() => {
+      render().catch(() => {});
+    }, 50));
   };
-  waitForLayoutStability().finally(render);
+  waitForLayoutStability().finally(() => {
+    render().catch(() => {});
+  });
 }
 
 function applyOnboardingUiState() {
@@ -385,7 +389,7 @@ function applyOnboardingUiState() {
       target: '#startBtn', text: 'Start your first run', showSkip: true,
       onSkip: () => { writeGuestDismissed(); hideSpotlight(); },
       onTargetClick: () => { writeGuestDismissed(); hideSpotlight(); }
-    });
+    }).catch(() => {});
     return;
   }
 

--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -98,7 +98,72 @@ export function hideSpotlight() {
   spotlightRoot.innerHTML = '';
 }
 
-export function showSpotlight({ target, text = '', content = null, showSkip = true, onSkip, onTargetClick, step = 'unknown' } = {}) {
+function findScrollableParent(element) {
+  if (!element || typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+
+  let current = element.parentElement;
+  while (current && current !== document.body) {
+    const style = window.getComputedStyle(current);
+    const overflowY = style?.overflowY || style?.overflow || 'visible';
+    const isScrollable = /(auto|scroll|overlay)/.test(overflowY);
+    if (isScrollable && current.scrollHeight > current.clientHeight + 1) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return document.scrollingElement || document.documentElement;
+}
+
+async function centerTargetInScrollableArea(targetElement) {
+  if (!targetElement || typeof window === 'undefined') return;
+
+  const scrollParent = findScrollableParent(targetElement);
+  if (!scrollParent) return;
+
+  const isDocScroller = scrollParent === document.scrollingElement || scrollParent === document.documentElement || scrollParent === document.body;
+  const scrollTop = isDocScroller ? window.scrollY : scrollParent.scrollTop;
+  const clientHeight = isDocScroller ? window.innerHeight : scrollParent.clientHeight;
+  const scrollHeight = isDocScroller
+    ? Math.max(document.documentElement.scrollHeight, document.body?.scrollHeight || 0)
+    : scrollParent.scrollHeight;
+  const canScroll = scrollHeight > clientHeight + 1;
+  if (!canScroll) return;
+
+  const targetRect = targetElement.getBoundingClientRect();
+  const parentRect = isDocScroller
+    ? { top: 0, height: window.innerHeight }
+    : scrollParent.getBoundingClientRect();
+
+  const targetCenter = targetRect.top + targetRect.height / 2;
+  const viewportCenter = parentRect.top + parentRect.height / 2;
+  const delta = targetCenter - viewportCenter;
+  if (Math.abs(delta) <= Math.max(24, targetRect.height * 0.2)) return;
+
+  const maxScroll = Math.max(0, scrollHeight - clientHeight);
+  const nextTop = Math.min(maxScroll, Math.max(0, scrollTop + delta));
+  if (Math.abs(nextTop - scrollTop) < 1) return;
+
+  const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+  const behavior = reduceMotion ? 'auto' : 'smooth';
+
+  if (isDocScroller) {
+    window.scrollTo({ top: nextTop, behavior });
+  } else {
+    scrollParent.scrollTo({ top: nextTop, behavior });
+  }
+
+  if (reduceMotion) {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+}
+
+export async function showSpotlight({ target, text = '', content = null, showSkip = true, onSkip, onTargetClick, step = 'unknown' } = {}) {
   const root = ensureSpotlightRoot();
   if (!root || !target) return false;
 
@@ -208,18 +273,6 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   const viewportPadding = 12;
   const highlightPadding = 8;
 
-  const ensureTargetInViewport = () => {
-    const rect = targetElement.getBoundingClientRect();
-    const viewport = getViewportRect();
-    const visibleTop = Math.max(rect.top, viewport.top);
-    const visibleBottom = Math.min(rect.bottom, viewport.top + viewport.height);
-    const visibleHeight = Math.max(0, visibleBottom - visibleTop);
-    const visibilityRatio = rect.height > 0 ? visibleHeight / rect.height : 0;
-
-    if (visibilityRatio < 0.7) {
-      targetElement.scrollIntoView({ block: 'center', inline: 'center', behavior: 'smooth' });
-    }
-  };
 
   const place = () => {
     const targetRect = targetElement.getBoundingClientRect();
@@ -351,7 +404,7 @@ export function showSpotlight({ target, text = '', content = null, showSkip = tr
   cleanupFns.push(() => targetProxy.removeEventListener('click', onProxyClick));
   cleanupFns.push(() => setTargetHoverState(false));
 
-  ensureTargetInViewport();
+  await centerTargetInScrollableArea(targetElement);
   schedulePlace();
   const targetRect = targetElement.getBoundingClientRect();
   if (targetRect.width <= 0 || targetRect.height <= 0) {


### PR DESCRIPTION
### Motivation
- Onboarding highlights could appear near the bottom of a scrollable page (Store, Player Menu), causing the info bubble to overlap the target and making it hard to see or interact with. 
- The goal is to ensure the highlighted element is centered in the visible area before the spotlight overlay and bubble are measured and positioned. 
- Keep behavior unchanged for non-scrollable screens and respect users who prefer reduced motion. 

### Description
- Added a nearest-scrollable-parent helper `findScrollableParent(element)` in `js/features/onboarding/spotlight.js` to locate the vertical scroll container or fall back to `document.scrollingElement`.
- Added `centerTargetInScrollableArea(targetElement)` in `js/features/onboarding/spotlight.js` which centers the target vertically inside its scrollable parent, uses smooth scrolling when allowed, respects `prefers-reduced-motion`, and waits (~300ms) for scroll settling.
- Made `showSpotlight` async in `js/features/onboarding/spotlight.js` and call `await centerTargetInScrollableArea(targetElement)` before measuring; overlay/hole/bubble are then positioned from fresh `getBoundingClientRect()` values.
- Updated onboarding render flow in `js/features/onboarding/index.js` to `await` the async `showSpotlight` call and to handle retries without causing jumpy repeated scrolling; guest flow call to `showSpotlight` is now promise-handled.
- Bubble placement logic remains: prefer below the target, fall back above when space is insufficient, clamp horizontally within viewport with a 12px padding and keep at least 12px margins from screen edges.
- These changes enable existing onboarding entries (for example `#store-ride-pack-3` and radar gift cards) to be scrolled into center before spotlight shows up, while leaving non-scrollable screens (main menu, game over when unscrollable) unaffected.

### Testing
- Ran `npm run -s lint` and static analysis, both completed successfully with no errors.
- Pre-commit automated checks `check:syntax` and `check:static-analysis` were executed as part of local validation and passed.
- Manual sanity checks: spotlight continues to position and place bubble as before when target is already centered or when the page is not scrollable (no automatic scroll performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a8299d7883268f931455ac969b20)