### PR TITLE
Complete `store_in` onboarding when +3 rides pack is purchased

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -492,4 +492,15 @@ function getOnboardingStateSnapshot() {
   return { ...onboardingState, gifts: { ...(onboardingState.gifts || {}) } };
 }
 
-export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect, postOnboardingAction, getOnboardingStateSnapshot };
+async function completeStoreInOnboardingFromPurchase() {
+  onboardingState = writeCachedOnboardingState({
+    ...onboardingState,
+    onboarding: { ...(onboardingState.onboarding || {}), store_in: 'complete' },
+    activeOnboarding: null
+  });
+  hideSpotlight();
+  resetOnboardingStateCache();
+  await refreshOnboardingState({ reason: 'store_in_complete', screen: 'store', resetCache: true });
+}
+
+export { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen, dismissGuestOnboardingOnWalletConnect, postOnboardingAction, getOnboardingStateSnapshot, completeStoreInOnboardingFromPurchase };

--- a/js/features/onboarding/onboarding-service.js
+++ b/js/features/onboarding/onboarding-service.js
@@ -68,12 +68,19 @@ async function fetchOnboardingState({ screen = null } = {}) {
 
 async function postOnboardingEvent(payload) {
   try {
-    const { ok } = await requestJsonResult(buildBackendUrl('/api/onboarding/event'), {
+    const { ok, status, data } = await requestJsonResult(buildBackendUrl('/api/onboarding/event'), {
       ...REQUEST_PROFILE_STORE_WRITE,
       method: 'POST',
       headers: buildOnboardingAuthHeaders().headers,
       body: JSON.stringify(payload || {})
     });
+    if (!ok) {
+      logger.warn('⚠️ onboarding event rejected by backend', {
+        payload,
+        status: Number(status || 0),
+        data: data || null
+      });
+    }
     return Boolean(ok);
   } catch (error) {
     logger.warn('⚠️ onboarding event post failed', { payload, error });

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -7,7 +7,7 @@ import { notifyError, notifySuccess, notifyWarn } from '../notifier.js';
 import { updateAiAccessFromBackendPayload } from '../ai-mode.js';
 import { trackUpgradePurchaseAnalytics } from './store-analytics.js';
 import { postOnboardingEvent } from '../features/onboarding/onboarding-service.js';
-import { refreshOnboardingState, getOnboardingStateSnapshot } from '../features/onboarding/index.js';
+import { refreshOnboardingState, getOnboardingStateSnapshot, completeStoreInOnboardingFromPurchase } from '../features/onboarding/index.js';
 import { applyRadarGiftStoreUi } from './radar-gift-ui.js';
 import {
   parseNumericLevel,
@@ -530,8 +530,19 @@ export function createUpgradesService({
           }));
         }
         if (key === 'rides_pack') {
-          await postOnboardingEvent({ action: 'ride_pack_bought' });
-          await refreshOnboardingState({ reason: 'ride_pack_bought' });
+          const onboardingSnapshot = getOnboardingStateSnapshot();
+          const activeKey = String(onboardingSnapshot?.activeOnboarding?.key || '');
+          if (activeKey === 'store_in') {
+            const onboardingCompleted = await postOnboardingEvent({
+              key: 'store_in',
+              action: 'complete',
+              screen: 'store',
+              target: 'ride_pack_plus3'
+            });
+            if (onboardingCompleted) {
+              await completeStoreInOnboardingFromPurchase();
+            }
+          }
         }
       } else {
         const serverError = data && data.error ? data.error : 'Purchase failed';


### PR DESCRIPTION
### Motivation
- The Store onboarding did not finish after purchasing the +3 rides pack because the frontend sent unsupported onboarding keys/actions and did not immediately mark `store_in` complete.
- Backend expects a single supported event `{ key: "store_in", action: "complete", screen: "store", target: "ride_pack_plus3" }` after buying the highlighted pack.

### Description
- When `rides_pack` purchase succeeds and the active onboarding key is `store_in`, send the exact completion payload to the backend: `key: 'store_in', action: 'complete', screen: 'store', target: 'ride_pack_plus3'`, and stop emitting legacy `ride_pack_bought` events (changes in `js/store/upgrades-service.js`).
- Add `completeStoreInOnboardingFromPurchase()` to `js/features/onboarding/index.js` to immediately mark `store_in` as complete locally, clear `activeOnboarding`, hide the spotlight, reset the onboarding cache, and refresh onboarding with `{ reason: 'store_in_complete', screen: 'store', resetCache: true }`.
- Improve error logging for onboarding posts in `js/features/onboarding/onboarding-service.js` to record `payload`, HTTP `status`, and response `data` when the backend rejects the event.
- Wire the new helper into the purchase path so successful onboarding posts finalize frontend state and prevent the spotlight from reappearing.

### Testing
- Ran syntax checks via the repo pre-commit `check:syntax`, which passed.
- Static analysis (`check:static-analysis`) failed due to an existing file-size guardrail (`js/store/upgrades-service.js` exceeds 600 lines), unrelated to the logic changes introduced here.
- Verified the new onboarding post path and local finalization logic via code inspection and local runtime flow (no failing unit tests introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a8c0a1d88326a98c75cf21f28e61)