### PR TITLE
Show 'Onboarding bonus' label in coin history

### DIFF
--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -76,6 +76,8 @@ const COIN_HISTORY_TYPE_LABELS = {
   referral: 'Referral bonus',
   referral_bonus: 'Referral bonus',
   refer: 'Friend joined',
+  onboarding_bonus: 'Onboarding bonus',
+  onboarding: 'Onboarding bonus',
   task: 'Task'
 };
 


### PR DESCRIPTION
### Motivation
- The coin/history UI was showing raw backend keys like `onboarding_bonus` to players, so the visible history needs a user-friendly label matching the style of other entries.

### Description
- Added `onboarding_bonus` and `onboarding` → `Onboarding bonus` mappings in `COIN_HISTORY_TYPE_LABELS` inside `js/player-menu/controller.js` so these entries render as `Onboarding bonus` in the history table.

### Testing
- Ran the repository pre-commit checks which executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a94d7434832680c9bed2c757db52)