### PR TITLE
Normalize onboarding gift state to handle alternative backend flags

### DIFF
--- a/js/features/onboarding/onboarding-state.js
+++ b/js/features/onboarding/onboarding-state.js
@@ -18,7 +18,22 @@ const DEFAULT_ONBOARDING_STATE = Object.freeze({
   }
 });
 
-const normalizeGiftState = (input) => ({ unlocked: Boolean(input?.unlocked), claimed: Boolean(input?.claimed), skipped: Boolean(input?.skipped), available: Boolean(input?.available || input?.unlocked) });
+const normalizeGiftState = (input) => {
+  const unlocked = Boolean(input?.unlocked ?? input?.isUnlocked ?? input?.eligible);
+  const claimed = Boolean(input?.claimed ?? input?.isClaimed ?? input?.redeemed);
+  const skipped = Boolean(input?.skipped ?? input?.isSkipped);
+  const availableHints = [
+    input?.available,
+    input?.isAvailable,
+    input?.canClaim,
+    input?.claimable,
+    input?.eligible,
+    input?.unlocked,
+    input?.status === 'available'
+  ];
+  const available = availableHints.some(Boolean) && !claimed;
+  return { unlocked, claimed, skipped, available };
+};
 const toTimestamp = (value) => (Number.isFinite(Number(value)) ? Number(value) : (Number.isFinite(Date.parse(value)) ? Date.parse(value) : 0));
 const normalizeBackendBoost = (untilValue, fallbackInput) => { const endsAt = toTimestamp(untilValue) || toTimestamp(fallbackInput?.endsAt); return { active: endsAt > Date.now(), endsAt }; };
 


### PR DESCRIPTION
### Motivation
- The gift icon stopped appearing on the main menu for new players because the frontend assumed backend gift fields used `available`/`unlocked` only. 
- Backend started returning alternative field names/flags for gifts which caused the onboarding UI to treat available gifts as unavailable.

### Description
- Updated `normalizeGiftState` in `js/features/onboarding/onboarding-state.js` to detect multiple backend variants (`isAvailable`, `canClaim`, `claimable`, `eligible`, `isUnlocked`, `isClaimed`, `redeemed`, `isSkipped`) when computing gift availability. 
- Computed availability now aggregates a list of hints and ensures a gift is not considered available if it is already `claimed`. 
- No other files were modified.

### Testing
- Ran `npm run test:request` and all request/unit tests passed (86 tests, 0 failures). 
- Pre-commit static analysis (`check:static-analysis`) reported an existing unrelated violation in `js/store/upgrades-service.js` (exceeds 600 lines), which caused the pre-commit hook to fail. 
- `check:syntax` and the test suite used by `test:request` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b349bc0c832691a5ee5694552d1a)