### PR TITLE
Implement adaptive difficulty for new/learning players

### DIFF
--- a/js/game/adaptive-difficulty.js
+++ b/js/game/adaptive-difficulty.js
@@ -1,0 +1,56 @@
+import { CONFIG } from '../config.js';
+
+const ADAPTIVE_TIERS = Object.freeze({
+  NEW: 'new_0_6',
+  LEARNING: 'learning_7_15',
+  STANDARD: 'standard'
+});
+
+function toFiniteNumber(value, fallback = NaN) {
+  if (value === null || value === undefined || value === '') return fallback;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
+  const runCount = toFiniteNumber(completedRuns, NaN);
+  const distanceMeters = Math.max(0, toFiniteNumber(distance, 0));
+  const standardProfile = {
+    tier: ADAPTIVE_TIERS.STANDARD,
+    obstacleDensityMultiplier: 1,
+    maxCurveAngleDeg: CONFIG.MAX_CURVE_ANGLE,
+    noDownwardTurns: true
+  };
+
+  if (!Number.isFinite(runCount) || runCount >= 16) {
+    return standardProfile;
+  }
+
+  const isNewTier = runCount <= 6;
+  const tier = isNewTier ? ADAPTIVE_TIERS.NEW : ADAPTIVE_TIERS.LEARNING;
+
+  if (distanceMeters >= 2000) {
+    return {
+      ...standardProfile,
+      tier
+    };
+  }
+
+  if (distanceMeters >= 1000) {
+    return {
+      tier,
+      obstacleDensityMultiplier: isNewTier ? 0.65 : 0.84,
+      maxCurveAngleDeg: 15,
+      noDownwardTurns: true
+    };
+  }
+
+  return {
+    tier,
+    obstacleDensityMultiplier: isNewTier ? 0.5 : 0.7,
+    maxCurveAngleDeg: isNewTier ? 15 : 20,
+    noDownwardTurns: true
+  };
+}
+
+export { getAdaptiveDifficultyProfile };

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -17,6 +17,7 @@ import { getDifficultySegment, normalizeRunIndex } from './difficulty-segmentati
 import { buildGameOverSummary } from './game-over-copy.js';
 import { maybeCelebrateMilestone } from './game-over-confetti.js';
 import { beginAiRun, finishAiRun } from '../ai-mode.js';
+import { getOnboardingStateSnapshot } from '../features/onboarding/index.js';
 const CRASH_FLYER_SRC = 'img/bear_pixel_transparent.webp'; const CRASH_FLYER_FALLBACK_SRC = 'img/bear.png';
 const CRASH_FLY_DEFAULT_DURATION_MS = 6000, START_TRANSITION_STATIC_EYES_SRC = 'img/eyes.png', MENU_EYES_STATIC_SRC = 'img/eyes.png', RUN_INDEX_STORAGE_KEY = 'ursas_run_index';
 const LEADERBOARD_SAVE_SUCCESS_EVENT = 'ursas:leaderboard-save-success';
@@ -224,6 +225,9 @@ function createGameSessionController({
       });
       clearGameplayCollections();
       clearParticles();
+      const onboardingSnapshot = getOnboardingStateSnapshot?.() || null;
+      const completedRuns = Number(onboardingSnapshot?.raceCount);
+      gameState.adaptiveCompletedRuns = Number.isFinite(completedRuns) ? completedRuns : null;
       applyPlayerUpgrades();
       await renderFirstGameplayFrame();
       const firstGameplayFrameReadyAt = performance.now();

--- a/js/physics-spawning.js
+++ b/js/physics-spawning.js
@@ -6,6 +6,7 @@ function createPhysicsSpawning({
   bonuses,
   coins,
   spinTargets,
+  getAdaptiveProfile,
 }) {
   function pushCoin(coin) {
     if (coin?.type === 'silver') {
@@ -34,7 +35,9 @@ function createPhysicsSpawning({
       if (gameState.distance >= 3000) freqMultiplier *= 0.82;
       if (gameState.distance >= 4000) freqMultiplier *= 0.8;
 
-      return Math.max(10, base * freqMultiplier);
+      const adaptiveProfile = getAdaptiveProfile();
+      const densityMultiplier = Number(adaptiveProfile?.obstacleDensityMultiplier) || 1;
+      return Math.max(10, (base * freqMultiplier) / Math.max(0.01, densityMultiplier));
     }
 
     if (gameState.distance < 1000) return spacing[0];

--- a/js/physics.js
+++ b/js/physics.js
@@ -9,9 +9,9 @@ import { endGame } from './game.js';
 import { logger } from './logger.js';
 import { createPhysicsSpawning } from './physics-spawning.js';
 import { updateAiControl } from './ai-mode.js';
+import { getAdaptiveDifficultyProfile } from './game/adaptive-difficulty.js';
 let laneCooldown = getLaneCooldown(); const COLLISION_REACTION_WINDOW_MS = 450, CAMERA_SHAKE_SMOOTHING = 12;
 const removeCoinAt = (index) => { if (coins[index]?.type === 'silver') gameState.activeSilverCoins = Math.max(0, (gameState.activeSilverCoins || 0) - 1); coins.splice(index, 1); };
-
 function resetGameSessionState() {
   player.shield = false;
   player.shieldCount = 0;
@@ -78,6 +78,7 @@ const {
   bonuses,
   coins,
   spinTargets,
+  getAdaptiveProfile: () => getAdaptiveDifficultyProfile({ completedRuns: gameState.adaptiveCompletedRuns, distance: gameState.distance }),
 });
 function update(delta) {
   if (!isFinite(gameState.speed) || gameState.speed < 0) { endGame("Speed error"); return; }
@@ -95,29 +96,26 @@ function update(delta) {
   const normalizedVisualSpeed = gameState.tubeVisualSpeed / Math.max(CONFIG.SPEED_START, Number.EPSILON);
   gameState.tubeScroll += delta * (140 + normalizedVisualSpeed * 260);
   gameState.tubeRotation = 0;
-
   const METERS_PER_SECOND_MULT = 300;
   const metersDelta = gameState.speed * METERS_PER_SECOND_MULT * delta;
   gameState.distance += metersDelta;
+  const adaptiveProfile = getAdaptiveDifficultyProfile({ completedRuns: gameState.adaptiveCompletedRuns, distance: gameState.distance });
+  logger.debug('adaptive_difficulty_profile', { completedRuns: gameState.adaptiveCompletedRuns, distance: Math.max(0, Number(gameState.distance) || 0), tier: adaptiveProfile.tier, obstacleDensityMultiplier: adaptiveProfile.obstacleDensityMultiplier, maxCurveAngleDeg: adaptiveProfile.maxCurveAngleDeg, noDownwardTurns: adaptiveProfile.noDownwardTurns });
   const basePointsPerMeter = 1;
   const speedFactor = gameState.speed / CONFIG.SPEED_START;
   let pointsPerMeter = basePointsPerMeter * speedFactor;
   if (player.invertActive && gameState.invertScoreMultiplier > 1) {
     pointsPerMeter *= gameState.invertScoreMultiplier;
   }
-
   gameState.score += metersDelta * pointsPerMeter;
-
   const coinSpacing = getSpacing("coin");
   if (gameState.distance - gameState.lastCoinSpawnDistance > coinSpacing) {
     spawnCoinPattern();
     gameState.lastCoinSpawnDistance = gameState.distance;
   }
-
   if (Math.floor(gameState.distance / 100) > Math.floor((gameState.distance - metersDelta) / 100)) {
     queueCoinRingSpawn();
   }
-
   if (Math.random() < 0.02 && gameState.activeSilverCoins < 4) {
     spawnCoinCluster();
   }
@@ -312,7 +310,8 @@ function update(delta) {
 
   gameState.centerOffsetX = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_X;
   const nextCenterOffsetY = Math.sin(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_Y;
-  gameState.centerOffsetY = gameState.distance < 1500 ? Math.min(nextCenterOffsetY, 0) : nextCenterOffsetY;
+  const noDownwardTurnsDistanceLimit = adaptiveProfile.noDownwardTurns && adaptiveProfile.tier !== 'standard' ? 2000 : 1500;
+  gameState.centerOffsetY = gameState.distance < noDownwardTurnsDistanceLimit ? Math.min(nextCenterOffsetY, 0) : nextCenterOffsetY;
 
   // Camera shake from speed
   const speedRatio = (gameState.speed - CONFIG.SPEED_START) / (CONFIG.SPEED_MAX - CONFIG.SPEED_START);
@@ -457,7 +456,7 @@ function update(delta) {
 
   gameState.curveDirection = curves.current.direction * (1 - interp) + curves.next.direction * interp;
   gameState.tubeCurveStrength = curves.current.strength * (1 - interp) + curves.next.strength * interp;
-  gameState.tubeCurveAngle = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.MAX_CURVE_ANGLE;
+  gameState.tubeCurveAngle = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * adaptiveProfile.maxCurveAngleDeg;
 
   if (gameState.curveTimer >= gameState.curveTransitionDuration) {
     curves.current.direction = curves.next.direction;

--- a/js/state.js
+++ b/js/state.js
@@ -305,6 +305,7 @@ const gameState = {
   lowFpsStreak: 0,
   highFpsStreak: 0,
   activeSilverCoins: 0,
+  adaptiveCompletedRuns: null,
   debugStats: {
     tubeQuads: 0,
     visibleObstacles: 0,

--- a/scripts/adaptive-difficulty.test.mjs
+++ b/scripts/adaptive-difficulty.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { getAdaptiveDifficultyProfile } from '../js/game/adaptive-difficulty.js';
+import { CONFIG } from '../js/config.js';
+
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: 0, distance: 100 }), {
+  tier: 'new_0_6', obstacleDensityMultiplier: 0.5, maxCurveAngleDeg: 15, noDownwardTurns: true
+});
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: 6, distance: 1500 }), {
+  tier: 'new_0_6', obstacleDensityMultiplier: 0.65, maxCurveAngleDeg: 15, noDownwardTurns: true
+});
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: 7, distance: 200 }), {
+  tier: 'learning_7_15', obstacleDensityMultiplier: 0.7, maxCurveAngleDeg: 20, noDownwardTurns: true
+});
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: 15, distance: 1600 }), {
+  tier: 'learning_7_15', obstacleDensityMultiplier: 0.84, maxCurveAngleDeg: 15, noDownwardTurns: true
+});
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: 1, distance: 2500 }), {
+  tier: 'new_0_6', obstacleDensityMultiplier: 1, maxCurveAngleDeg: CONFIG.MAX_CURVE_ANGLE, noDownwardTurns: true
+});
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: 16, distance: 300 }), {
+  tier: 'standard', obstacleDensityMultiplier: 1, maxCurveAngleDeg: CONFIG.MAX_CURVE_ANGLE, noDownwardTurns: true
+});
+assert.deepEqual(getAdaptiveDifficultyProfile({ completedRuns: null, distance: 300 }), {
+  tier: 'standard', obstacleDensityMultiplier: 1, maxCurveAngleDeg: CONFIG.MAX_CURVE_ANGLE, noDownwardTurns: true
+});
+
+console.log('adaptive-difficulty tests passed');


### PR DESCRIPTION
### Motivation
- Make early runs easier for new players (0–6 runs) and moderately easier for learning players (7–15 runs) while restoring standard difficulty after distance/experience thresholds. 
- Preserve existing no-downward-turn exclusion and use authenticated profile data when available, falling back to standard difficulty for guests.

### Description
- Added helper `getAdaptiveDifficultyProfile({ completedRuns, distance })` that returns `{ tier, obstacleDensityMultiplier, maxCurveAngleDeg, noDownwardTurns }` and implements all requested ranges (files: `js/game/adaptive-difficulty.js`).
- Wire-up: read onboard/runtime snapshot at game start and store normalized completed-run count into `gameState.adaptiveCompletedRuns` for runtime access (file: `js/game/session.js` and `js/state.js`).
- Obstacle spawning: apply `obstacleDensityMultiplier` to obstacle spacing (effective spacing = base * freqMultiplier / multiplier) so multiplier < 1 yields fewer obstacles (file: `js/physics-spawning.js`).
- Curves & downward turns: use `maxCurveAngleDeg` from profile when computing tube curve angle and keep existing no-downward-turn logic active, extending its adaptive range up to 2000m where applicable (file: `js/physics.js`).
- Added debug logging behind the existing logger (`logger.debug`) that emits the adaptive profile per tick (completedRuns, distance, tier, obstacleDensityMultiplier, maxCurveAngleDeg, noDownwardTurns) and kept guest-safe fallback to standard difficulty when `completedRuns` is unavailable.

### Testing
- Unit: `node scripts/adaptive-difficulty.test.mjs` which validates all expected tier/distance outputs passed.
- Static/sanity: `npm run check:static-analysis` passed and syntax checks ran as part of pre-commit (the repository `check-syntax` guard passed).
- Manual smoke: obstacle spawn spacing and curve angle now derive from the adaptive profile at runtime (exerciseable via normal gameplay runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b59269108326a683266a591acb33)