### PR TITLE
Fix menu gift indicator rendering with boosts

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -15,62 +15,56 @@ function ensureStyles() {
   document.head.appendChild(style);
 }
 
-function ensureContainer() {
-  ensureStyles();
-  let node = document.getElementById(GIFT_INDICATOR_ID);
-  if (!node) {
-    node = document.createElement('div');
-    node.id = GIFT_INDICATOR_ID;
-    document.body.appendChild(node);
-  }
-  return node;
-}
-
-function mountGiftIndicator({ onClick } = {}) {
-  const node = ensureContainer();
-  node.querySelectorAll('[data-indicator="gift"]').forEach((item) => item.remove());
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'gift-btn';
-  btn.dataset.indicator = 'gift';
-  btn.textContent = '🎁';
-  btn.title = 'Claim radar gift';
-  btn.addEventListener('click', () => onClick?.());
-  node.appendChild(btn);
-}
-
-function mountBoostIndicator(activeBoosts = {}) {
-  const node = ensureContainer();
-  node.querySelectorAll('[data-indicator="boost"]').forEach((item) => item.remove());
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  const activeItems = [
-    { key: 'radar_obstacles_24h', title: 'Radar Obstacles', iconClass: 'icon-radar-obstacles' },
-    { key: 'radar_gold_24h', title: 'Radar Gold', iconClass: 'icon-radar-gold' }
-  ].map((entry) => ({ ...entry, timer: activeBoosts?.[entry.key]?.active ? formatRemainingHours(activeBoosts?.[entry.key]?.endsAt) : null }))
-    .filter((entry) => Boolean(entry.timer));
-
-  if (!activeItems.length) return;
-
-  activeItems.forEach((entry) => {
-    const iconBtn = btn.cloneNode(false);
-    iconBtn.className = 'gift-btn is-boost-active';
-    iconBtn.dataset.indicator = 'boost';
-    iconBtn.title = entry.title;
-    iconBtn.setAttribute('aria-label', entry.title);
-    iconBtn.innerHTML = `<span class="icon-atlas ${entry.iconClass}" aria-hidden="true"></span><span class="gift-timer">${entry.timer}</span>`;
-    node.appendChild(iconBtn);
-  });
-}
-
 function unmountGiftIndicator() {
   const node = document.getElementById(GIFT_INDICATOR_ID);
   if (node?.parentElement) node.parentElement.removeChild(node);
 }
 
-function renderActiveBoostIndicators(activeBoosts = {}) {
-  mountBoostIndicator(activeBoosts);
+function renderGiftAndBoostIndicators({ gifts = {}, activeBoosts = {}, onGiftClick } = {}) {
+  ensureStyles();
+  unmountGiftIndicator();
+
+  const activeItems = [
+    { key: 'radar_obstacles_24h', title: 'Radar Obstacles', iconClass: 'icon-radar-obstacles' },
+    { key: 'radar_gold_24h', title: 'Radar Gold', iconClass: 'icon-radar-gold' }
+  ].map((entry) => ({
+    ...entry,
+    timer: activeBoosts?.[entry.key]?.active ? formatRemainingHours(activeBoosts?.[entry.key]?.endsAt) : null
+  })).filter((entry) => Boolean(entry.timer));
+
+  const hasUnclaimedGift = Boolean(
+    (gifts?.radar_obstacles_24h?.available && !gifts?.radar_obstacles_24h?.claimed) ||
+    (gifts?.radar_gold_24h?.available && !gifts?.radar_gold_24h?.claimed)
+  );
+
+  if (!activeItems.length && !hasUnclaimedGift) return;
+
+  const node = document.createElement('div');
+  node.id = GIFT_INDICATOR_ID;
+
+  activeItems.forEach((entry) => {
+    const boostBtn = document.createElement('button');
+    boostBtn.type = 'button';
+    boostBtn.className = 'gift-btn is-boost-active';
+    boostBtn.dataset.indicator = 'boost';
+    boostBtn.title = entry.title;
+    boostBtn.setAttribute('aria-label', entry.title);
+    boostBtn.innerHTML = `<span class="icon-atlas ${entry.iconClass}" aria-hidden="true"></span><span class="gift-timer">${entry.timer}</span>`;
+    node.appendChild(boostBtn);
+  });
+
+  if (hasUnclaimedGift) {
+    const giftBtn = document.createElement('button');
+    giftBtn.type = 'button';
+    giftBtn.className = 'gift-btn is-gift-available';
+    giftBtn.dataset.indicator = 'gift';
+    giftBtn.textContent = '🎁';
+    giftBtn.title = 'Claim radar gift';
+    giftBtn.addEventListener('click', () => onGiftClick?.());
+    node.appendChild(giftBtn);
+  }
+
+  document.body.appendChild(node);
 }
 
-export { mountGiftIndicator, unmountGiftIndicator, renderActiveBoostIndicators };
-export { mountBoostIndicator };
+export { unmountGiftIndicator, renderGiftAndBoostIndicators };

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -2,7 +2,7 @@ import { fetchOnboardingState, postOnboardingEvent, resetOnboardingStateCache } 
 import { DEFAULT_ONBOARDING_STATE, readCachedOnboardingState, writeCachedOnboardingState } from './onboarding-state.js';
 import { hideSpotlight, showSpotlight } from './spotlight.js';
 import { hideMenuStartHook, clearGameOverOnboardingHook } from './hooks.js';
-import { mountGiftIndicator, mountBoostIndicator, unmountGiftIndicator, renderActiveBoostIndicators } from './gift-indicator.js';
+import { unmountGiftIndicator, renderGiftAndBoostIndicators } from './gift-indicator.js';
 import { logger } from '../../logger.js';
 import { hasAuthenticatedSession, isTelegramMiniApp } from '../auth/index.js';
 import { hasRideLimit } from '../store/index.js';
@@ -34,7 +34,8 @@ const TARGET_SELECTOR_MAP = Object.freeze({
   radar_obstacles_24h_card: '#store-radarobstacles-0',
   radar_gold_24h_card: '#store-radargold-0',
   radar_obstacles_card: '#store-radarobstacles-0',
-  radar_gold_card: '#store-radargold-0'
+  radar_gold_card: '#store-radargold-0',
+  gift_icon: '#onboardingGiftIndicator .gift-btn.is-gift-available, #onboardingGiftIndicator, #storeBtn'
 });
 
 const ONBOARDING_ALLOWED_TARGETS = Object.freeze({
@@ -48,7 +49,9 @@ const ONBOARDING_ALLOWED_TARGETS = Object.freeze({
   store_start: { screen: 'menu', target: 'store_button' },
   store_in: { screen: 'store', target: 'ride_pack_3' },
   gift_radar_obstacles_store: { screen: 'store', target: 'radar_obstacles_24h_card' },
-  gift_radar_gold_store: { screen: 'store', target: 'radar_gold_24h_card' }
+  gift_radar_gold_store: { screen: 'store', target: 'radar_gold_24h_card' },
+  gift_radar_obstacles_menu: { screen: 'menu', target: 'gift_icon' },
+  gift_radar_gold_menu: { screen: 'menu', target: 'gift_icon' }
 });
 
 const ONBOARDING_FALLBACK_FLOW = [
@@ -62,7 +65,9 @@ const ONBOARDING_FALLBACK_FLOW = [
   { key: 'store_start', screen: 'menu', target: 'store_button', when: (state) => state.raceCount >= 3 },
   { key: 'store_in', screen: 'store', target: 'ride_pack_3', when: (state) => state.raceCount >= 3 },
   { key: 'gift_radar_obstacles_store', screen: 'store', target: 'radar_obstacles_24h_card', when: (state) => state.gifts?.radar_obstacles_24h?.available },
-  { key: 'gift_radar_gold_store', screen: 'store', target: 'radar_gold_24h_card', when: (state) => state.gifts?.radar_gold_24h?.available }
+  { key: 'gift_radar_gold_store', screen: 'store', target: 'radar_gold_24h_card', when: (state) => state.gifts?.radar_gold_24h?.available },
+  { key: 'gift_radar_obstacles_menu', screen: 'menu', target: 'gift_icon', when: (state) => state.gifts?.radar_obstacles_24h?.available },
+  { key: 'gift_radar_gold_menu', screen: 'menu', target: 'gift_icon', when: (state) => state.gifts?.radar_gold_24h?.available }
 ];
 
 function isAuthorizedRuntime() {
@@ -378,26 +383,12 @@ function showAuthorizedOnboarding(active) {
 }
 
 
-function hasUnclaimedGift(gifts) {
-  return Boolean(
-    (gifts?.radar_obstacles_24h?.available && !gifts?.radar_obstacles_24h?.claimed) ||
-    (gifts?.radar_gold_24h?.available && !gifts?.radar_gold_24h?.claimed)
-  );
-}
-
-function hasAnyActiveBoost(activeBoosts) {
-  return Boolean(
-    activeBoosts?.radar_obstacles_24h?.active ||
-    activeBoosts?.radar_gold_24h?.active
-  );
-}
 
 function applyOnboardingUiState() {
   hideMenuStartHook();
   clearGameOverOnboardingHook();
   hideSpotlight();
   unmountGiftIndicator();
-  renderActiveBoostIndicators(onboardingState.activeBoosts || {});
 
   if (isOnboardingUiBlocked()) {
     logger.info('onboarding show skipped while ui blocked', { currentScreen });
@@ -418,8 +409,11 @@ function applyOnboardingUiState() {
   const gifts = onboardingState.gifts || {};
   const boosts = onboardingState.activeBoosts || {};
   if (currentScreen === 'menu') {
-    if (hasAnyActiveBoost(boosts)) mountBoostIndicator(boosts);
-    if (hasUnclaimedGift(gifts)) mountGiftIndicator({ onClick: () => document.querySelector('#storeBtn')?.click?.() });
+    renderGiftAndBoostIndicators({
+      gifts,
+      activeBoosts: boosts,
+      onGiftClick: () => document.querySelector('#storeBtn')?.click?.()
+    });
   }
 
   const active = resolveActiveOnboardingForScreen(onboardingState, currentScreen);


### PR DESCRIPTION
### Motivation
- The main menu orange gift indicator could be missing even when the Store shows a free radar gift because the UI had separate mount functions that unmounted each other and the onboarding index lacked the `gift_icon` mapping and menu allowlist entries.
- The intent is to show active boost icons and an unclaimed pulsing gift button simultaneously and allow onboarding spotlight to target the menu gift icon.

### Description
- Replaced separate boost/gift mount flows with a single renderer `renderGiftAndBoostIndicators({ gifts, activeBoosts, onGiftClick })` that ensures styles, removes previous `#onboardingGiftIndicator`, and rebuilds one container. (`js/features/onboarding/gift-indicator.js`).
- `renderGiftAndBoostIndicators` appends active boost buttons (`radar_obstacles_24h`, `radar_gold_24h`) with `gift-btn is-boost-active`, icons and timers, and appends an orange pulsing gift button (`🎁`, `gift-btn is-gift-available`, title `Claim radar gift`) when any unclaimed gift is available; it no-ops when nothing to show.
- Updated exports to provide `renderGiftAndBoostIndicators` and `unmountGiftIndicator` only, removing wrapper functions that caused unused-export lint warnings. (`js/features/onboarding/gift-indicator.js`).
- Updated onboarding flow to call `renderGiftAndBoostIndicators` on the menu screen instead of separate `mountBoostIndicator`/`mountGiftIndicator` calls and replaced the conditional logic accordingly. (`js/features/onboarding/index.js`).
- Added `gift_icon` target selector to `TARGET_SELECTOR_MAP`, added allowlist entries `gift_radar_obstacles_menu` and `gift_radar_gold_menu` to `ONBOARDING_ALLOWED_TARGETS`, and added corresponding fallback flow entries so menu onboarding steps can target the gift icon. (`js/features/onboarding/index.js`).

### Testing
- Static checks and pre-commit validations ran successfully (`check:syntax` and `check:static-analysis`).
- Linting passed via `npm run -s lint` with the updated files returning no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03bbd3987483268a56293634ed9f6d)