### PR TITLE
Fix menu gift indicator state refresh and add gift debug telemetry

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -37,6 +37,13 @@ function renderGiftAndBoostIndicators({ gifts = {}, activeBoosts = {}, onGiftCli
     (gifts?.radar_gold_24h?.available && !gifts?.radar_gold_24h?.claimed)
   );
 
+  console.info('[gift-debug] renderGiftAndBoostIndicators', {
+    gifts,
+    activeBoosts,
+    hasUnclaimedGift,
+    activeItems
+  });
+
   if (!activeItems.length && !hasUnclaimedGift) return;
 
   const node = document.createElement('div');

--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -409,6 +409,14 @@ function applyOnboardingUiState() {
   const gifts = onboardingState.gifts || {};
   const boosts = onboardingState.activeBoosts || {};
   if (currentScreen === 'menu') {
+    console.info('[gift-debug] apply menu indicators', {
+      currentScreen,
+      gifts: onboardingState.gifts,
+      activeBoosts: onboardingState.activeBoosts,
+      activeOnboarding: onboardingState.activeOnboarding,
+      raceCount: onboardingState.raceCount,
+      isAuthorizedRuntime: isAuthorizedRuntime()
+    });
     renderGiftAndBoostIndicators({
       gifts,
       activeBoosts: boosts,
@@ -463,7 +471,10 @@ async function refreshOnboardingState({ reason = 'manual', screen = null, resetC
   const remote = await fetchOnboardingState({ screen: screen || currentScreen });
   if (remote) onboardingState = writeCachedOnboardingState(remote);
   else if (!isAuthorizedRuntime()) onboardingState = readCachedOnboardingState();
-  else onboardingState = writeCachedOnboardingState({ ...DEFAULT_ONBOARDING_STATE, activeBoosts: onboardingState.activeBoosts || DEFAULT_ONBOARDING_STATE.activeBoosts });
+  else onboardingState = writeCachedOnboardingState({
+    ...onboardingState,
+    activeOnboarding: null
+  });
 
   for (const stepKey of [...pendingSkipSteps]) {
     const status = String(onboardingState?.onboarding?.[stepKey] || '').toLowerCase();
@@ -508,7 +519,11 @@ async function postOnboardingAction({ action, key, screen, target }) {
 }
 
 function getOnboardingStateSnapshot() {
-  return { ...onboardingState, gifts: { ...(onboardingState.gifts || {}) } };
+  return {
+    ...onboardingState,
+    gifts: { ...(onboardingState.gifts || {}) },
+    activeBoosts: { ...(onboardingState.activeBoosts || {}) }
+  };
 }
 
 async function completeStoreInOnboardingFromPurchase() {

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -548,7 +548,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
   }
 
   logger.info('⏸ Main loop deferred until first gameplay start');
-
+  let previousScreen = null;
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
     const screen = event.detail?.screen;
     applyOnboardingForScreen(screen);
@@ -558,9 +558,9 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     } else {
       cancelGameOverOnboardingRetries();
     }
-    if (screen === 'store') {
-      refreshOnboardingState({ reason: 'store_open' }).catch(() => {});
-    }
+    if (screen === 'store') refreshOnboardingState({ reason: 'store_open' }).catch(() => {});
+    else if (previousScreen === 'store' && screen === 'menu') refreshOnboardingState({ reason: 'menu_open_after_store', screen: 'menu', resetCache: true }).then(() => applyOnboardingForScreen('menu')).catch(() => {});
+    previousScreen = screen;
   });
 
   window.addEventListener('ursas:onboarding-store-buy', () => {


### PR DESCRIPTION
### Motivation
- The main menu gift icon could disappear when `/api/onboarding/state` fetches fail or return null, because the local `onboardingState` was being overwritten with defaults and losing `gifts`/`activeBoosts`.
- We need short-term diagnostics to verify that the menu receives the same gift state that the Store already shows.
- Ensure Store→Menu navigation forces a fresh normalized state so UI parity is restored without rewriting gift UI logic.

### Description
- Added temporary diagnostics in `applyOnboardingUiState()` to log `currentScreen`, `gifts`, `activeBoosts`, `activeOnboarding`, `raceCount`, and `isAuthorizedRuntime()` before rendering the menu indicators.
- Added diagnostics inside `renderGiftAndBoostIndicators()` to log `gifts`, `activeBoosts`, computed `hasUnclaimedGift`, and `activeItems`.
- Modified `refreshOnboardingState()` fallback for authenticated runtimes so a failed/null fetch no longer overwrites `gifts` or `activeBoosts`; it now preserves the existing state and only clears `activeOnboarding` before writing cached state.
- Extended `getOnboardingStateSnapshot()` to include a shallow copy of `activeBoosts` alongside `gifts`, and added a Store→Menu navigation path that calls `refreshOnboardingState({ reason: 'menu_open_after_store', screen: 'menu', resetCache: true })` then reapplies onboarding for `menu`.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- Ran the static analysis checks (`npm run check:static-analysis`) and they passed.
- Pre-commit quality hooks ran as part of commits and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045944935083269f3407ceec7bb800)