### PR TITLE
Fix Telegram store purchase identity payload and diagnostics

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1,5 +1,5 @@
 import { isAuthenticated } from './api.js';
-import { isTelegramAuthMode, getPrimaryAuthIdentifier, getTelegramAuthIdentifier } from './auth.js';
+import { isTelegramAuthMode, getPrimaryAuthIdentifier, getTelegramAuthIdentifier, getAuthStateSnapshot } from './auth.js';
 import { createRuntimeConfigController } from './store/runtime-config.js';
 import { createRidesService, resetPlayerRides, setPlayerRides } from './store/rides-service.js';
 import { createUpgradesService, resetUpgradeState, setPlayerStoreState } from './store/upgrades-service.js';
@@ -99,6 +99,7 @@ const upgradesService = createUpgradesService({
   updateRidesDisplay,
   getPrimaryAuthIdentifier,
   getTelegramAuthIdentifier,
+  getAuthStateSnapshot,
   isTelegramAuthMode,
   isStoreAvailable,
   getRuntimeGameConfig,

--- a/js/store/store-buy-diagnostics.js
+++ b/js/store/store-buy-diagnostics.js
@@ -1,0 +1,26 @@
+export function buildStoreBuyFailureDiagnostic({
+  status,
+  data,
+  authMode,
+  primaryId,
+  telegramId,
+  hasTelegramInitData,
+  hasWallet
+}) {
+  return {
+    status,
+    data,
+    requestData: {
+      authMode,
+      primaryId,
+      telegramId,
+      hasTelegramInitData,
+      hasWallet
+    }
+  };
+}
+
+export function isTelegramSessionExpiredError(message = '') {
+  const normalized = String(message || '').toLowerCase();
+  return normalized.includes('missing telegram identity') || normalized.includes('verification failed');
+}

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -6,6 +6,7 @@ import { renderStoreCurrencyButton } from './rides-service.js';
 import { notifyError, notifySuccess, notifyWarn } from '../notifier.js';
 import { updateAiAccessFromBackendPayload } from '../ai-mode.js';
 import { trackUpgradePurchaseAnalytics } from './store-analytics.js';
+import { buildStoreBuyFailureDiagnostic, isTelegramSessionExpiredError } from './store-buy-diagnostics.js';
 import { postOnboardingEvent } from '../features/onboarding/onboarding-service.js';
 import { refreshOnboardingState, getOnboardingStateSnapshot, completeStoreInOnboardingFromPurchase } from '../features/onboarding/index.js';
 import { applyRadarGiftStoreUi } from './radar-gift-ui.js';
@@ -175,7 +176,6 @@ export function getShieldUpgradeSnapshot(effects = playerEffects, upgrades = pla
     startShieldCount: hasStartShield ? Math.max(1, Math.min(startShieldCount || 1, resolvedMaxShieldCount)) : 0
   };
 }
-
 function getLevelFromEffects(upgradeKey) {
   if (!playerEffects) return 0;
   if (upgradeKey === 'shield') {
@@ -187,7 +187,6 @@ function getLevelFromEffects(upgradeKey) {
   if (upgradeKey === 'spin_alert') {
     const directLevel = parseSpinAlertLevel(playerEffects.spin_alert_level);
     if (directLevel > 0) return directLevel;
-
     const modeLevel = parseSpinAlertLevel(playerEffects.spin_alert_mode);
     if (modeLevel > 0) return modeLevel;
 
@@ -250,6 +249,7 @@ export function createUpgradesService({
   updateRidesDisplay,
   getPrimaryAuthIdentifier,
   getTelegramAuthIdentifier,
+  getAuthStateSnapshot,
   isTelegramAuthMode,
   isStoreAvailable,
   getRuntimeGameConfig,
@@ -446,20 +446,14 @@ export function createUpgradesService({
       if (isTelegramAuthMode()) {
         const telegramId = getTelegramAuthIdentifier();
         const telegramInitData = String(window.Telegram?.WebApp?.initData || '').trim();
+        const authState = getAuthStateSnapshot();
+        const linkedWallet = String(authState?.linkedWallet || '').trim().toLowerCase();
         if (!telegramId || !telegramInitData) {
           notifyError('❌ Telegram session is missing, reopen the app and try again');
           return;
         }
 
-        requestData = {
-          primaryId: String(primaryId || identifier || '').trim(),
-          upgradeKey: key === 'shield_capacity' ? 'shield_capacity' : key,
-          tier,
-          timestamp,
-          authMode: 'telegram',
-          telegramId,
-          telegramInitData
-        };
+        requestData = { primaryId: String(primaryId || identifier || '').trim(), upgradeKey: key === 'shield_capacity' ? 'shield_capacity' : key, tier, timestamp, authMode: 'telegram', telegramId, telegramInitData, ...(linkedWallet ? { wallet: linkedWallet } : {}) };
       } else {
         walletForSignature = String(identifier || '').toLowerCase();
         const message = `Buy upgrade\nWallet: ${walletForSignature}\nUpgrade: ${key === 'shield_capacity' ? 'shield_capacity' : key}\nTier: ${tier}\nTimestamp: ${timestamp}`;
@@ -540,6 +534,7 @@ export function createUpgradesService({
         }
         if (key === 'rides_pack') await completeStoreInOnboardingAfterRidesPackPurchase();
       } else {
+        console.warn('[store-buy-failed]', buildStoreBuyFailureDiagnostic({ status, data, authMode: isTelegramAuthMode() ? 'telegram' : 'wallet', primaryId: String(primaryId || identifier || '').trim(), telegramId: getTelegramAuthIdentifier(), hasTelegramInitData: Boolean(String(window.Telegram?.WebApp?.initData || '').trim()), hasWallet: Boolean(String(getAuthStateSnapshot()?.linkedWallet || '').trim()) }));
         const serverError = data && data.error ? data.error : 'Purchase failed';
         const isConflict = isAlreadyPurchasedError(serverError);
         const isAmbiguousServerFailure = status === 500;
@@ -570,6 +565,11 @@ export function createUpgradesService({
             notifySuccess('✅ Purchase confirmed after sync');
             return;
           }
+        }
+
+        if (isTelegramSessionExpiredError(serverError)) {
+          notifyError('Telegram session expired. Reopen the app and try again.');
+          return;
         }
 
         notifyError(`❌ ${serverError}`);


### PR DESCRIPTION
### Motivation
- Telegram Store purchases were failing because the frontend sent a backend-incompatible identity payload and required a wallet signature for Telegram users. 
- Improve observability so backend failure responses are logged with the response body and a concise request identity summary.

### Description
- Update store initialization to pass `getAuthStateSnapshot` through to the upgrades service so the purchase flow can read `linkedWallet` (file: `js/store.js`).
- Change Telegram purchase request construction in `buyUpgrade` to always include `primaryId`, `authMode`, `telegramId`, and `telegramInitData`, and to conditionally include `wallet` only when a linked wallet exists (file: `js/store/upgrades-service.js`).
- Add structured diagnostics helper in `js/store/store-buy-diagnostics.js` and emit `console.warn('[store-buy-failed]', ...)` with `status`, `data`, and a compact `requestData` summary when buys fail (file: `js/store/upgrades-service.js`).
- Map backend identity/verification errors (`Missing Telegram identity` / `verification failed`) to a friendly UI message: "Telegram session expired. Reopen the app and try again." (file: `js/store/upgrades-service.js` and `js/store/store-buy-diagnostics.js`).

### Testing
- Built the frontend with `npm run -s build` and the build completed successfully.
- Ran static analysis via `npm run -s check:static-analysis` and it passed.
- Pre-commit automated checks (including `check:syntax` and `check:static-analysis`) ran and passed during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04acf87b788326b3b41275fc09f58b)