### PR TITLE
Fix Telegram onboarding spotlight transparency

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -38,10 +38,6 @@ function ensureSpotlightStyles() {
   styleTag = document.createElement('style');
   styleTag.id = 'onboarding-spotlight-styles';
   styleTag.textContent = `
-    .onboarding-target-hover {
-      filter: brightness(1.05);
-    }
-
     .onboarding-spotlight-skip {
       position: fixed;
       top: max(12px, env(safe-area-inset-top));
@@ -191,10 +187,6 @@ export async function showSpotlight({ target, text = '', content = null, showSki
 
   const dimmer = document.createElement('div');
   dimmer.style.cssText = 'position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:none;';
-
-  const dimBase = document.createElement('div');
-  dimBase.style.cssText = 'position:absolute;left:0;top:0;width:100%;height:100%;background:rgba(5,8,15,0.68);pointer-events:auto;';
-  dimmer.appendChild(dimBase);
 
   const dimTop = document.createElement('div');
   const dimRight = document.createElement('div');
@@ -387,7 +379,6 @@ export async function showSpotlight({ target, text = '', content = null, showSki
     hole.style.boxShadow = hovered
       ? '0 0 0 2px rgba(255,255,255,0.2), 0 0 26px rgba(125, 211, 252, 0.45)'
       : '0 0 0 1px rgba(255,255,255,0.16)';
-    targetElement.classList.toggle('onboarding-target-hover', hovered);
   };
 
   const onProxyClick = (event) => {


### PR DESCRIPTION
### Motivation
- Ensure the onboarding spotlight hole remains fully transparent and not darkened by overlays so highlighted UI is clearly visible in Telegram and web contexts.
- Use only four surrounding dim rectangles to darken the area around the hole and avoid any global full-screen dim that could overlap the hole.
- Avoid applying any brightness/opacity/filter to the actual target element so its native appearance is preserved.

### Description
- Removed the full-screen dim base (`dimBase`) so dimming is produced solely by the four surrounding rectangles (`dimTop`, `dimRight`, `dimBottom`, `dimLeft`).
- Removed the `.onboarding-target-hover` CSS rule and stopped toggling that class on the target element to prevent any `filter`/brightness effects being applied to the highlighted element.
- Preserved transparent styling for the `hole` and `targetProxy` elements so the hole area and the proxy remain interactive and visually unobstructed.
- Changes made in `js/features/onboarding/spotlight.js`.

### Testing
- Ran syntax checks via `npm run check:syntax` which completed successfully as part of pre-commit checks.
- Ran static analysis via `npm run check:static-analysis` which completed successfully as part of pre-commit checks.
- No automated test failures were reported during the change validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b5a295c4832688c896e436c4c18c)