### PR TITLE
Fix Telegram object visibility depth for obstacles, coins, and bonuses

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -60,6 +60,7 @@ const CONFIG = {
   TUBE_SEGMENTS: 36,
   TUBE_DEPTH_STEPS: 84,
   TUBE_Z_STEP: 0.086,
+  FAR_OBJECT_RENDER_Z: 1.95,
   BASE_ROTATION_SPEED: 1.2,
   MAX_ROTATION_SPEED: 3,
 
@@ -96,7 +97,7 @@ const isMobileViewport = hasWindow ? window.innerWidth < 600 : false;
 const isMobile = isMobileUserAgent || isMobileViewport;
 if (isMobile) {
   CONFIG.TUBE_SEGMENTS = 24;
-  CONFIG.TUBE_DEPTH_STEPS = 48;
+  CONFIG.TUBE_DEPTH_STEPS = 60;
   CONFIG.TUBE_RADIUS = 230;
 }
 

--- a/js/game/projection.js
+++ b/js/game/projection.js
@@ -28,11 +28,12 @@ function project(lane, z, includeSpinRotation = false) {
   if (!Number.isFinite(z)) z = CONFIG.PLAYER_Z;
   if (!Number.isFinite(lane)) lane = 0;
 
-  z = Math.max(0, Math.min(z, 2));
+  z = Math.max(0, Math.min(z, CONFIG.FAR_OBJECT_RENDER_Z + 0.4));
   lane = Math.max(-1, Math.min(lane, 1));
 
   const { width, height } = getProjectionViewport();
-  const scale = Math.max(0.05, 1 - z);
+  const farDepthScaleFloor = 0.035;
+  const scale = Math.max(farDepthScaleFloor, 1 - z);
   const tubeRadius = CONFIG.TUBE_RADIUS * scale;
   let angle = lane * 0.55;
 
@@ -55,7 +56,7 @@ function projectPlayer(z) {
   if (!Number.isFinite(z)) z = CONFIG.PLAYER_Z;
 
   const { width, height } = getProjectionViewport();
-  const scale = Math.max(0.05, 1 - z);
+  const scale = Math.max(0.035, 1 - z);
   const radius = CONFIG.TUBE_RADIUS * scale;
 
   let angleLane = player.lane;

--- a/js/physics-spawning.js
+++ b/js/physics-spawning.js
@@ -91,7 +91,7 @@ function createPhysicsSpawning({
     }
     const type = pickWeightedBonus(weights);
 
-    const spawnZ = 1.65;
+    const spawnZ = CONFIG.FAR_OBJECT_RENDER_Z - 0.08;
     let lane = null;
 
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -113,10 +113,10 @@ function createPhysicsSpawning({
     const spawnDelaySeconds = obstacleRadarEnabled ? (2 + Math.random()) : 0;
     // Projection clamps far-depth scale for z >= ~0.95, so spawn radar-preview obstacles
     // just inside that threshold to keep them visibly inside the tube.
-    const radarVisibleSpawnZ = 0.9;
+    const radarVisibleSpawnZ = 1.25;
     // Without radar obstacles upgrade, keep spawn close enough so obstacles
     // immediately enter active motion instead of looking like a deep "preview".
-    const regularSpawnZ = 1.12;
+    const regularSpawnZ = 1.42;
     const spawnZ = obstacleRadarEnabled ? radarVisibleSpawnZ : regularSpawnZ;
 
     let groupSize = 1;
@@ -177,7 +177,7 @@ function createPhysicsSpawning({
     const hasGold = Math.random() < 0.3;
     if (hasGold) addRadarHintForGoldLane(lane);
     for (let i = 0; i < 3; i++) {
-      pushCoin({ type: i === 0 && hasGold ? 'gold' : 'silver', lane, z: 1.55 - i * 0.1, animFrame: 0 });
+      pushCoin({ type: i === 0 && hasGold ? 'gold' : 'silver', lane, z: 1.72 - i * 0.1, animFrame: 0 });
     }
   }
 
@@ -185,16 +185,16 @@ function createPhysicsSpawning({
     const startLane = CONFIG.LANES[Math.floor(Math.random() * 3)];
     const hasGold = Math.random() < 0.3;
     if (hasGold) addRadarHintForGoldLane(startLane);
-    pushCoin({ type: hasGold ? 'gold' : 'silver', lane: startLane, z: 1.55, animFrame: 0 });
-    pushCoin({ type: 'silver', lane: Math.max(-1, Math.min(1, startLane + (Math.random() < 0.5 ? -1 : 1))), z: 1.45, animFrame: 0 });
-    pushCoin({ type: 'silver', lane: startLane, z: 1.35, animFrame: 0 });
+    pushCoin({ type: hasGold ? 'gold' : 'silver', lane: startLane, z: 1.72, animFrame: 0 });
+    pushCoin({ type: 'silver', lane: Math.max(-1, Math.min(1, startLane + (Math.random() < 0.5 ? -1 : 1))), z: 1.62, animFrame: 0 });
+    pushCoin({ type: 'silver', lane: startLane, z: 1.52, animFrame: 0 });
   }
 
   function spawnCoinDiagonal() {
     const hasGold = Math.random() < 0.3;
     if (hasGold) addRadarHintForGoldLane(-1);
     [-1, 0, 1].forEach((lane, i) => {
-      pushCoin({ type: i === 0 && hasGold ? 'gold' : 'silver', lane, z: 1.55 - i * 0.1, animFrame: 0 });
+      pushCoin({ type: i === 0 && hasGold ? 'gold' : 'silver', lane, z: 1.72 - i * 0.1, animFrame: 0 });
     });
   }
 


### PR DESCRIPTION
### Motivation
- Objects (obstacles, coins, bonuses) were popping into view too late in Telegram/mobile builds because far-depth headroom and projection clamping were too aggressive, causing items to appear only when already close to the player; the change increases render headroom so objects are visible farther down the tube while keeping collision windows intact.

### Description
- Added a shared far-depth constant `CONFIG.FAR_OBJECT_RENDER_Z` and increased mobile `CONFIG.TUBE_DEPTH_STEPS` to preserve depth budget on Telegram/mobile (`js/config.js`).
- Loosened projection clamping and lowered the far-depth scale floor so distant objects remain renderable instead of being clipped (`js/game/projection.js`).
- Moved spawn Zs outward: bonuses now spawn at `CONFIG.FAR_OBJECT_RENDER_Z - 0.08`, radar/regular obstacle spawn Zs increased, and coin pattern Zs were pushed farther (e.g. ~1.55 → ~1.72) so coins/bonuses/obstacles appear earlier in the tube while collision logic remains unchanged (`js/physics-spawning.js`).
- Files changed: `js/config.js`, `js/game/projection.js`, `js/physics-spawning.js`.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- Pre-commit static analysis (`npm run check:static-analysis`) ran as part of commit hooks and passed.
- Changes were committed after checks, and no syntax/static-analysis errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b5c1f9f883268a60f2f34fe85bb7)