### PR TITLE
Stabilize Telegram store balance & identity handling in upgrades service

### DIFF
--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -46,6 +46,15 @@ function updateStoreBalanceElements(balance = playerBalance) {
   const nextGold = Number(balance?.gold || 0), nextSilver = Number(balance?.silver || 0);
   [['storeGoldVal', nextGold], ['storeSilverVal', nextSilver], ['walletGold', nextGold], ['walletSilver', nextSilver]].forEach(([id, value]) => { const el = document.getElementById(id); if (el) el.textContent = value; });
 }
+function resolveNextBalance(nextBalance, fallbackBalance = playerBalance) {
+  const hasGold = Number.isFinite(Number(nextBalance?.gold));
+  const hasSilver = Number.isFinite(Number(nextBalance?.silver));
+  if (!hasGold && !hasSilver) return { ...(fallbackBalance || { gold: 0, silver: 0 }) };
+  return {
+    gold: hasGold ? Number(nextBalance?.gold) : Number(fallbackBalance?.gold || 0),
+    silver: hasSilver ? Number(nextBalance?.silver) : Number(fallbackBalance?.silver || 0)
+  };
+}
 function getPlayerUpgrades() {
   return playerUpgrades;
 }
@@ -288,14 +297,16 @@ export function createUpgradesService({
       return;
     }
 
-    const identifier = getAuthIdentifier();
-    const primaryId = getPrimaryAuthIdentifier();
-    const walletAddress = String(identifier || '').trim().toLowerCase();
     const isTelegramMode = isTelegramAuthMode();
+    const primaryId = getPrimaryAuthIdentifier();
+    const identifier = isTelegramMode ? String(primaryId || '').trim() : String(getAuthIdentifier() || '').trim();
+    const walletAddress = isTelegramMode
+      ? String(getAuthStateSnapshot()?.linkedWallet || '').trim().toLowerCase()
+      : String(getAuthIdentifier() || '').trim().toLowerCase();
     const authHeaders = buildStoreAuthHeaders({
       primaryId,
       wallet: walletAddress,
-      includeWallet: !isTelegramMode
+      includeWallet: Boolean(walletAddress)
     });
 
     setStoreDataLoading(true);
@@ -308,8 +319,10 @@ export function createUpgradesService({
       clearRuntimeConfig();
       playerUpgrades = data.upgrades;
       playerEffects = data.activeEffects;
-      playerBalance = data.balance;
+      const responseBalance = resolveNextBalance(data?.balance, playerBalance);
+      playerBalance = responseBalance;
       updateStoreBalanceElements(playerBalance);
+      console.info('[telegram-balance-debug]', { identifier, primaryId, responseBalance });
       updateAiAccessFromBackendPayload(data);
       if (data.rides) setPlayerRides(data.rides);
 
@@ -511,7 +524,7 @@ export function createUpgradesService({
         }
 
         logger.info('✅ Purchase success:', data.message);
-        playerBalance = data.balance;
+        playerBalance = resolveNextBalance(data?.balance, playerBalance);
         playerEffects = data.activeEffects;
         trackUpgradePurchaseAnalytics({
           upgradeKey: key,


### PR DESCRIPTION
### Motivation
- Telegram Mini App showed unstable or missing gold/silver balances because store requests could use different identifiers than leaderboard/profile flows and partial backend payloads could overwrite UI with zeros. 
- Balance must be read from the same account identity used by leaderboard/save and should prefer existing Player records (primaryId) when present.

### Description
- Use Telegram `primaryId` as the request `:identifier` when `isTelegramAuthMode()` so store reads align with Telegram profile/leaderboard identity. 
- Send `X-Primary-Id`, include `X-Wallet` only when a linked wallet is present, and preserve `X-Telegram-Init-Data` via `buildStoreAuthHeaders` to make headers consistent for Telegram mode. 
- Add `resolveNextBalance(nextBalance, fallbackBalance)` to avoid overwriting in-memory/UI balances with missing or partial payloads by falling back to previous values for missing fields. 
- Apply `resolveNextBalance` to both the GET `/api/store/upgrades` response path and successful purchase responses, and log a Telegram-specific debug record: `[telegram-balance-debug] { identifier, primaryId, responseBalance }`. 
- Files changed: `js/store/upgrades-service.js` (identifier selection, headers usage, balance resolution, debug log).

### Testing
- Ran a JavaScript syntax check with `node --check js/store/upgrades-service.js`, which succeeded. 
- Ran the repository syntax checks (`scripts/check-syntax.mjs`) via the project's pre-checks, which passed for all scanned files including the modified file. 
- The static analysis guard `scripts/check-static-analysis.mjs` flagged the file length threshold (`js/store/upgrades-service.js` exceeds 600 lines), which is an automated policy failure to be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c216c10c832688698804b0b3207b)