### PR TITLE
Hide Connect Wallet button in Telegram runtime

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -114,12 +114,15 @@ html {
 }
 
 
-body.telegram-runtime #walletBtn,
-body.telegram-runtime .wallet-connect,
-body.telegram-runtime [data-action="connect-wallet"] {
+.telegram-runtime #walletBtn {
   display: none !important;
   visibility: hidden !important;
   pointer-events: none !important;
+}
+
+.telegram-runtime .wallet-connect,
+.telegram-runtime [data-action="connect-wallet"] {
+  display: none !important;
 }
 
 body {

--- a/index.html
+++ b/index.html
@@ -35,10 +35,12 @@
   <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
   <script>
     (() => {
-      const isTelegram = Boolean(window.Telegram?.WebApp?.initData);
-      window.__URSASS_IS_TELEGRAM_RUNTIME__ = isTelegram;
-      if (isTelegram) {
+      const isTelegramRuntime = Boolean(window.Telegram?.WebApp?.initData);
+      window.__URSASS_IS_TELEGRAM_RUNTIME__ = isTelegramRuntime;
+      if (isTelegramRuntime) {
         document.documentElement.classList.add('telegram-runtime');
+        if (document.body) document.body.classList.add('telegram-runtime');
+        else document.addEventListener('DOMContentLoaded', () => document.body?.classList.add('telegram-runtime'), { once: true });
       }
     })();
   </script>
@@ -50,11 +52,6 @@
 
 
 <body class="loading-ui">
-  <script>
-    if (window.__URSASS_IS_TELEGRAM_RUNTIME__) {
-      document.body.classList.add('telegram-runtime');
-    }
-  </script>
   
 <!-- ===== WALLET + INFO ===== -->
 <div id="playerCorner">

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -86,8 +86,8 @@ function renderAuthUiState({
 
   if (session.isTelegramAuthMode) {
     const telegramAccount = formatTelegramAccountLabel(session.telegramUser);
-    btn.textContent = telegramAccount;
-    btn.classList.add('connected');
+    btn.hidden = true;
+    btn.classList.remove('connected');
     btn.classList.add('wallet-btn-readonly');
     btn.onclick = null;
     info.classList.add('visible');
@@ -107,6 +107,7 @@ function renderAuthUiState({
   }
 
   if (session.isWalletAuthMode) {
+    btn.hidden = false;
     const addr = session.primaryId;
     btn.textContent = addr.startsWith('0x') ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : addr;
     btn.classList.add('connected');
@@ -125,6 +126,7 @@ function renderAuthUiState({
     return;
   }
 
+  btn.hidden = false;
   btn.textContent = 'Connect Wallet';
   btn.classList.remove('connected');
   btn.classList.remove('wallet-btn-readonly');

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -36,6 +36,7 @@ let _lastKnownWalletSession = false;
 
 function enforceTelegramWalletUiHidden() {
   if (!(window.__URSASS_IS_TELEGRAM_RUNTIME__ || isTelegramMiniApp()) || typeof document === 'undefined') return;
+  document.documentElement?.classList.add('telegram-runtime');
   document.body?.classList.add('telegram-runtime');
   if (DOM.walletBtn) DOM.walletBtn.hidden = true;
 }


### PR DESCRIPTION
### Motivation
- Prevent the Connect Wallet control from briefly appearing in the Telegram Mini App during load/auth refresh while still allowing balances/profile/avatar to be visible.
- Detect Telegram as early as possible and apply a runtime class to ensure UI can be hidden immediately during bootstrap.

### Description
- Add early detection in `index.html` using `const isTelegramRuntime = Boolean(window.Telegram?.WebApp?.initData)` and immediately add `telegram-runtime` to `<html>` and `<body>` with a `DOMContentLoaded` fallback for body availability.
- Strengthen CSS by adding `.telegram-runtime` rules that hide `#walletBtn`, `.wallet-connect`, and `[data-action="connect-wallet"]` using `!important` so connect controls cannot transiently show in Telegram.
- Change `renderAuthUiState` in `js/auth-ui.js` so when `session.isTelegramAuthMode` the code keeps the wallet button hidden (`btn.hidden = true`) and does not set its label, while still rendering `walletInfo`/balances and `tgAccountBadge`; non-Telegram flows explicitly unhide the button.
- Ensure `enforceTelegramWalletUiHidden` in `js/game/bootstrap.js` also adds the `telegram-runtime` class to `document.documentElement` and keeps `DOM.walletBtn` hidden during lifecycle refreshes.

### Testing
- Automated syntax checks ran via `npm run check:syntax` and completed successfully.
- Automated static analysis ran via the repository check script (`node scripts/check-static-analysis.mjs` / `npm run check:static-analysis`) and passed with no errors.
- Repository quality guard scripts executed as part of the pre-commit hooks and reported success, indicating no static/syntax regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c2586a3883269915368f0bf25ff2)