### PR TITLE
Fix Telegram Mini App balance flicker with shared cached state

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -10,6 +10,7 @@ import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGame
 import { validatePlayerInsights, getRankBucket } from './game/leaderboard-insights.js';
 import { isTelegramAuthMode, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot, isTelegramMiniApp } from './features/auth/index.js';
 import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './features/store/index.js';
+import { updateCachedBalance } from './balance-cache.js';
 const SAVE_RESULT_STATUS = Object.freeze({
   SAVED: 'saved',
   SKIPPED: 'skipped',
@@ -466,7 +467,12 @@ async function fetchMyProfile() {
       ...REQUEST_PROFILE_LEADERBOARD_READ,
       headers: buildAuthHeaders()
     });
-    return ok ? data : null;
+    if (!ok) return null;
+    updateCachedBalance({
+      gold: data?.gold ?? data?.totalGoldCoins,
+      silver: data?.silver ?? data?.totalSilverCoins
+    });
+    return data;
   } catch (e) {
     logger.warn('⚠️ fetchMyProfile error:', e);
     return null;
@@ -542,7 +548,12 @@ async function getXStatus() {
       ...REQUEST_PROFILE_LEADERBOARD_READ,
       headers: buildAuthHeaders()
     });
-    return ok ? data : null;
+    if (!ok) return null;
+    updateCachedBalance({
+      gold: data?.gold ?? data?.totalGoldCoins,
+      silver: data?.silver ?? data?.totalSilverCoins
+    });
+    return data;
   } catch (e) {
     logger.warn('⚠️ getXStatus error:', e);
     return null;

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -1,4 +1,5 @@
 import { createIconAtlas } from './dom-render.js';
+import { getCachedBalance, updateCachedBalance } from './balance-cache.js';
 
 function normalizeTelegramUsername(value) {
   return String(value || '').trim().replace(/^@+/, '');
@@ -34,21 +35,25 @@ function createWalletInfoRow({ iconNode, valueId, valueClass, defaultValue }) {
   return row;
 }
 
-function renderWalletStats(infoRoot) {
+function renderWalletStats(infoRoot, { isTelegram = false } = {}) {
+  const cached = getCachedBalance();
+  const placeholder = isTelegram && !cached ? '…' : String(cached?.gold ?? 0);
+  const silverPlaceholder = isTelegram && !cached ? '…' : String(cached?.silver ?? 0);
   infoRoot.append(
     createWalletInfoRow({
       iconNode: createIconAtlas({ width: 24, height: 24, backgroundSize: '120px auto', backgroundPosition: '-48px -72px' }),
       valueId: 'walletGold',
       valueClass: 'val-gold',
-      defaultValue: '0'
+      defaultValue: placeholder
     }),
     createWalletInfoRow({
       iconNode: createIconAtlas({ width: 24, height: 24, backgroundSize: '120px auto', backgroundPosition: '-24px -72px' }),
       valueId: 'walletSilver',
       valueClass: 'val-silver',
-      defaultValue: '0'
+      defaultValue: silverPlaceholder
     })
   );
+  if (cached) updateCachedBalance(cached);
 }
 
 function renderWalletInfoHeader(infoRoot, { compactLabel = null, actionLabel = null, actionName = null }) {
@@ -97,6 +102,7 @@ function renderAuthUiState({
     }
 
     info.textContent = '';
+    if (getCachedBalance()) updateCachedBalance(getCachedBalance());
     if (session.linkedWallet) {
       renderWalletInfoHeader(info, {});
     }

--- a/js/balance-cache.js
+++ b/js/balance-cache.js
@@ -1,0 +1,38 @@
+function toSafeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function getCachedBalance() {
+  if (typeof window === 'undefined') return null;
+  const cached = window.__ursasLastKnownBalance;
+  const gold = toSafeNumber(cached?.gold);
+  const silver = toSafeNumber(cached?.silver);
+  if (gold === null && silver === null) return null;
+  return {
+    gold: gold ?? 0,
+    silver: silver ?? 0
+  };
+}
+
+function writeBalanceToDom(gold, silver) {
+  [['walletGold', gold], ['walletSilver', silver], ['storeGoldVal', gold], ['storeSilverVal', silver]].forEach(([id, value]) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = String(value);
+  });
+}
+
+function updateCachedBalance(balance = {}) {
+  const current = getCachedBalance() || { gold: 0, silver: 0 };
+  const gold = toSafeNumber(balance?.gold);
+  const silver = toSafeNumber(balance?.silver);
+  const next = {
+    gold: gold ?? current.gold,
+    silver: silver ?? current.silver
+  };
+  if (typeof window !== 'undefined') window.__ursasLastKnownBalance = next;
+  writeBalanceToDom(next.gold, next.silver);
+  return next;
+}
+
+export { getCachedBalance, updateCachedBalance };

--- a/js/player-stats.js
+++ b/js/player-stats.js
@@ -1,5 +1,6 @@
 import { DOM } from './state.js';
 import { logger } from './logger.js';
+import { updateCachedBalance } from './balance-cache.js';
 
 function resolveVisibleGold(profile) {
   const canonicalGold = Number(profile?.gold);
@@ -21,8 +22,11 @@ function applyWalletProfile(profile) {
     rankEl.textContent = hasRank ? `#${rank}` : (bestScore > 0 ? '#' : '—');
   }
   if (bestEl) bestEl.textContent = String(bestScore);
-  if (goldEl) goldEl.textContent = String(resolveVisibleGold(profile));
-  if (silverEl) silverEl.textContent = String(Number(profile?.totalSilverCoins || 0));
+  const nextGold = resolveVisibleGold(profile);
+  const nextSilver = Number(profile?.totalSilverCoins || 0);
+  updateCachedBalance({ gold: nextGold, silver: nextSilver });
+  if (goldEl) goldEl.textContent = String(nextGold);
+  if (silverEl) silverEl.textContent = String(nextSilver);
   if (DOM.walletInfo) DOM.walletInfo.classList.add('visible');
 }
 

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -10,6 +10,7 @@ import { buildStoreBuyFailureDiagnostic, isTelegramSessionExpiredError } from '.
 import { postOnboardingEvent } from '../features/onboarding/onboarding-service.js';
 import { refreshOnboardingState, getOnboardingStateSnapshot, completeStoreInOnboardingFromPurchase } from '../features/onboarding/index.js';
 import { applyRadarGiftStoreUi } from './radar-gift-ui.js';
+import { updateCachedBalance } from '../balance-cache.js';
 import {
   parseNumericLevel,
   parseSpinAlertLevel,
@@ -44,7 +45,7 @@ let playerEffects = null;
 let playerBalance = { gold: 0, silver: 0 };
 function updateStoreBalanceElements(balance = playerBalance) {
   const nextGold = Number(balance?.gold || 0), nextSilver = Number(balance?.silver || 0);
-  [['storeGoldVal', nextGold], ['storeSilverVal', nextSilver], ['walletGold', nextGold], ['walletSilver', nextSilver]].forEach(([id, value]) => { const el = document.getElementById(id); if (el) el.textContent = value; });
+  updateCachedBalance({ gold: nextGold, silver: nextSilver });
 }
 function resolveNextBalance(nextBalance, fallbackBalance = playerBalance) {
   const hasGold = Number.isFinite(Number(nextBalance?.gold));
@@ -287,13 +288,6 @@ export function createUpgradesService({
       if (isUnauthRuntimeMode()) return getRuntimeGameConfig();
       return;
     }
-<<<<<<< codex/fix-telegram-mini-app-purchases
-    const identifier = getAuthIdentifier();
-    const primaryId = getPrimaryAuthIdentifier();
-    const walletAddress = String(identifier || '').trim().toLowerCase();
-=======
-
->>>>>>> dev2
     const isTelegramMode = isTelegramAuthMode();
     const primaryId = getPrimaryAuthIdentifier();
     const identifier = isTelegramMode ? String(primaryId || '').trim() : String(getAuthIdentifier() || '').trim();


### PR DESCRIPTION
### Motivation
- Prevent Telegram Mini App main menu balances from briefly showing `0` or disappearing during auth UI refreshes by preserving last-known backend coin values across re-renders.
- Ensure store and wallet counters stay consistent when asynchronous profile/store responses arrive after auth UI refreshes.

### Description
- Add a new shared cache module `js/balance-cache.js` that exposes `getCachedBalance()` and `updateCachedBalance()` and stores the canonical values on `window.__ursasLastKnownBalance` while syncing DOM nodes `walletGold`, `walletSilver`, `storeGoldVal`, `storeSilverVal`.
- Update `renderWalletStats` in `js/auth-ui.js` to prefer cached values, show `…` (ellipsis) as a Telegram placeholder before first known balance, and re-apply cached values immediately after clearing the auth info container so known balances are not erased on refresh.
- Hook backend responses to update the cache and DOM by calling `updateCachedBalance()` from `js/api.js` (profile/X status) and `js/player-stats.js` (apply wallet/profile), and switch `js/store/upgrades-service.js` store balance updates to use the shared updater so store and menu counters remain aligned.
- Remove stale merge conflict markers discovered during build checks in `js/store/upgrades-service.js`.

### Testing
- Ran `node scripts/check-syntax.mjs` (pre-check) which passed for all files including modified ones.
- Ran `node scripts/check-static-analysis.mjs` which reported a line-count violation for `js/api.js` (file exceeds 600 lines) as a static-analysis alert but did not prevent building.
- Ran `npm run -s build` which completed successfully and produced the production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cb1882c88326b8f27817d4180686)