### PR TITLE
Fix Connect Wallet flash in Telegram Mini App from first paint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -114,15 +114,16 @@ html {
 }
 
 
-.telegram-runtime #walletBtn {
+html.telegram-runtime #walletBtn,
+html.telegram-runtime .wallet-connect,
+html.telegram-runtime [data-action="connect-wallet"],
+body.telegram-runtime #walletBtn,
+body.telegram-runtime .wallet-connect,
+body.telegram-runtime [data-action="connect-wallet"] {
   display: none !important;
   visibility: hidden !important;
+  opacity: 0 !important;
   pointer-events: none !important;
-}
-
-.telegram-runtime .wallet-connect,
-.telegram-runtime [data-action="connect-wallet"] {
-  display: none !important;
 }
 
 body {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,20 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <title>URSASS TUBE</title>
+  <script>
+    (function () {
+      try {
+        var isTelegram =
+          !!(window.Telegram && window.Telegram.WebApp) ||
+          /Telegram/i.test(navigator.userAgent || '') ||
+          new URLSearchParams(location.search).has('tgWebAppData');
+
+        if (isTelegram) {
+          document.documentElement.classList.add('telegram-runtime');
+        }
+      } catch (e) {}
+    })();
+  </script>
   <link rel="icon" type="image/webp" href="/assets/icon_atlas.webp">
   <script>
     (() => {
@@ -35,7 +49,10 @@
   <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
   <script>
     (() => {
-      const isTelegramRuntime = Boolean(window.Telegram?.WebApp?.initData);
+      const isTelegramRuntime =
+        Boolean(window.Telegram?.WebApp) ||
+        /Telegram/i.test(navigator.userAgent || '') ||
+        new URLSearchParams(location.search).has('tgWebAppData');
       window.__URSASS_IS_TELEGRAM_RUNTIME__ = isTelegramRuntime;
       if (isTelegramRuntime) {
         document.documentElement.classList.add('telegram-runtime');

--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -27,6 +27,7 @@ async function initAuthFlow({
 }) {
   const isTelegramReady = isTelegramMiniApp() || await waitForTelegramMiniApp();
   if (isTelegramReady) {
+    document.body.classList.add('telegram-runtime');
     document.body.classList.add('telegram-mini-app');
     document.body.classList.add('is-telegram');
     document.body.classList.remove('is-web');

--- a/js/auth.js
+++ b/js/auth.js
@@ -33,6 +33,16 @@ const getSigningWalletAddress = () => getSigningWalletAddressState();
 const getTelegramAuthIdentifier = () => getTelegramAuthIdentifierState();
 const getAuthStateSnapshot = () => getAuthStateSnapshotState();
 
+function hideWalletButtonInTelegram() {
+  if (!isTelegramMiniApp()) return;
+  const btn = document.getElementById('walletBtn');
+  if (!btn) return;
+  btn.hidden = true;
+  btn.style.display = 'none';
+  btn.style.visibility = 'hidden';
+  btn.style.pointerEvents = 'none';
+}
+
 async function connectWalletAuth() {
   trackAnalyticsEvent('wallet_connect_started', {
     source: 'wallet_button'
@@ -51,6 +61,7 @@ function disconnectAuth() {
 }
 
 function updateAuthUI() {
+  hideWalletButtonInTelegram();
   renderAuthUiState({
     dom: DOM,
     session: {
@@ -67,6 +78,7 @@ function updateAuthUI() {
     onLinkWallet: linkWallet,
     onLinkTelegram: linkTelegram
   });
+  hideWalletButtonInTelegram();
 }
 
 async function initAuth() {
@@ -109,6 +121,7 @@ export {
   connectWalletAuth,
   disconnectAuth,
   initAuth,
+  hideWalletButtonInTelegram,
   linkTelegram,
   linkWallet
 };

--- a/js/features/auth/index.js
+++ b/js/features/auth/index.js
@@ -7,7 +7,8 @@ export {
   hasWalletAuthSession,
   isWalletAuthMode,
   setAuthCallbacks,
-  getAuthStateSnapshot
+  getAuthStateSnapshot,
+  hideWalletButtonInTelegram
 } from '../../auth.js';
 
 export {

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -5,7 +5,7 @@ import { assetManager } from '../assets.js';
 import { updateGameOverLeaderboardNotice, getLeaderboardSnapshot } from '../ui.js';
 import { loadPlayerUpgrades, updateRidesDisplay, resetStoreState, loadUnauthGameConfig, isStoreAvailable, isUnauthRuntimeMode } from '../features/store/index.js';
 import { perfMonitor } from '../perf.js';
-import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks, getAuthStateSnapshot } from '../features/auth/index.js';
+import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks, getAuthStateSnapshot, hideWalletButtonInTelegram } from '../features/auth/index.js';
 import { initializePingLifecycle, subscribeAppVisibilityLifecycle, SCREEN_CHANGED_EVENT } from '../core/runtime.js';
 import { initializeTelegramIntegration } from './integrations/telegram.js';
 import { initializeMetaMaskIntegration } from './integrations/metamask.js';
@@ -38,7 +38,7 @@ function enforceTelegramWalletUiHidden() {
   if (!(window.__URSASS_IS_TELEGRAM_RUNTIME__ || isTelegramMiniApp()) || typeof document === 'undefined') return;
   document.documentElement?.classList.add('telegram-runtime');
   document.body?.classList.add('telegram-runtime');
-  if (DOM.walletBtn) DOM.walletBtn.hidden = true;
+  hideWalletButtonInTelegram();
 }
 async function getCachedProfile() {
   const now = Date.now();
@@ -499,7 +499,9 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     }
   });
   logger.info('🔐 Authenticating...');
+  hideWalletButtonInTelegram();
   await initAuth();
+  hideWalletButtonInTelegram();
   enforceTelegramWalletUiHidden();
   await initOnboardingFeature();
   refreshOnboardingState({ reason: 'auth' }).catch(() => {});
@@ -548,6 +550,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
   logger.info('⏸ Main loop deferred until first gameplay start');
   let previousScreen = null;
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
+    hideWalletButtonInTelegram();
     const screen = event.detail?.screen;
     applyOnboardingForScreen(screen);
     if (screen === 'game-over') {


### PR DESCRIPTION
### Motivation
- Prevent the Connect Wallet button from ever appearing (even for one frame) in Telegram Mini App because previous JS-based hiding ran too late and allowed a flash on first paint.

### Description
- Added an early inline runtime detector in `index.html` inside `<head>` that sets `html.telegram-runtime` before styles and the app bundle execute. 
- Broadened Telegram detection logic to check `window.Telegram?.WebApp`, the user agent, and `tgWebAppData` query param and set `window.__URSASS_IS_TELEGRAM_RUNTIME__` accordingly.
- Hardened global CSS in `css/style.css` to hide wallet UI under both `html.telegram-runtime` and `body.telegram-runtime` selectors and added `visibility`, `opacity`, and `pointer-events` overrides to ensure complete invisibility and non-interactivity at first paint.
- Added `hideWalletButtonInTelegram()` helper in `js/auth.js`, exported via `js/features/auth/index.js`, and invoked it from the bootstrap and auth flows (`js/game/bootstrap.js` and `js/auth.js`) before/after `initAuth` and on `SCREEN_CHANGED_EVENT` to defensively keep the button hidden during lifecycle transitions.
- Ensure `document.body.classList.add('telegram-runtime')` is applied in Telegram auth initialization (`js/auth-lifecycle.js`).

### Testing
- Ran the syntax check script `npm run -s check:syntax`; many files passed but the run failed due to a pre-existing merge conflict marker in `js/store/upgrades-service.js` unrelated to these changes, so full CI could not be completed.
- Verified the modified files parse/format locally; no runtime tests were executed in a Telegram Mini App environment in this CLI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ccefaae0832699f3aaee29f76702)