### PR TITLE
Stabilize store/rides UI and adaptive runtime regressions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,6 +156,10 @@ body {
   gap: 10px;
 }
 
+#walletBtn {
+  visibility: hidden;
+}
+
 .wallet-btn-corner {
   width: 156px;
   min-width: 156px;

--- a/js/auth-ui.js
+++ b/js/auth-ui.js
@@ -1,5 +1,6 @@
 import { createIconAtlas } from './dom-render.js';
 import { getCachedBalance, updateCachedBalance } from './balance-cache.js';
+window.__ursasLastKnownBalance = window.__ursasLastKnownBalance || null;
 
 function normalizeTelegramUsername(value) {
   return String(value || '').trim().replace(/^@+/, '');
@@ -36,9 +37,9 @@ function createWalletInfoRow({ iconNode, valueId, valueClass, defaultValue }) {
 }
 
 function renderWalletStats(infoRoot, { isTelegram = false } = {}) {
-  const cached = getCachedBalance();
-  const placeholder = isTelegram && !cached ? '…' : String(cached?.gold ?? 0);
-  const silverPlaceholder = isTelegram && !cached ? '…' : String(cached?.silver ?? 0);
+  const cached = window.__ursasLastKnownBalance || getCachedBalance();
+  const placeholder = cached ? String(cached?.gold ?? 0) : '…';
+  const silverPlaceholder = cached ? String(cached?.silver ?? 0) : '…';
   infoRoot.append(
     createWalletInfoRow({
       iconNode: createIconAtlas({ width: 24, height: 24, backgroundSize: '120px auto', backgroundPosition: '-48px -72px' }),
@@ -92,6 +93,7 @@ function renderAuthUiState({
   if (session.isTelegramAuthMode) {
     const telegramAccount = formatTelegramAccountLabel(session.telegramUser);
     btn.hidden = true;
+    btn.style.visibility = 'hidden';
     btn.classList.remove('connected');
     btn.classList.add('wallet-btn-readonly');
     btn.onclick = null;
@@ -114,6 +116,7 @@ function renderAuthUiState({
 
   if (session.isWalletAuthMode) {
     btn.hidden = false;
+    btn.style.visibility = 'visible';
     const addr = session.primaryId;
     btn.textContent = addr.startsWith('0x') ? `${addr.slice(0, 6)}...${addr.slice(-4)}` : addr;
     btn.classList.add('connected');
@@ -133,6 +136,7 @@ function renderAuthUiState({
   }
 
   btn.hidden = false;
+  btn.style.visibility = 'visible';
   btn.textContent = 'Connect Wallet';
   btn.classList.remove('connected');
   btn.classList.remove('wallet-btn-readonly');

--- a/js/physics-spawning.js
+++ b/js/physics-spawning.js
@@ -113,10 +113,10 @@ function createPhysicsSpawning({
     const spawnDelaySeconds = obstacleRadarEnabled ? (2 + Math.random()) : 0;
     // Projection clamps far-depth scale for z >= ~0.95, so spawn radar-preview obstacles
     // just inside that threshold to keep them visibly inside the tube.
-    const radarVisibleSpawnZ = 1.25;
+    const radarVisibleSpawnZ = 1.55;
     // Without radar obstacles upgrade, keep spawn close enough so obstacles
     // immediately enter active motion instead of looking like a deep "preview".
-    const regularSpawnZ = 1.42;
+    const regularSpawnZ = 1.72;
     const spawnZ = obstacleRadarEnabled ? radarVisibleSpawnZ : regularSpawnZ;
 
     let groupSize = 1;

--- a/js/physics.js
+++ b/js/physics.js
@@ -78,7 +78,7 @@ const {
   bonuses,
   coins,
   spinTargets,
-  getAdaptiveProfile: () => getAdaptiveDifficultyProfile({ completedRuns: gameState.adaptiveCompletedRuns, distance: gameState.distance }),
+  getAdaptiveProfile: () => gameState.currentAdaptiveProfile || getAdaptiveDifficultyProfile({ completedRuns: gameState.adaptiveCompletedRuns, distance: gameState.distance }),
 });
 function update(delta) {
   if (!isFinite(gameState.speed) || gameState.speed < 0) { endGame("Speed error"); return; }
@@ -100,7 +100,13 @@ function update(delta) {
   const metersDelta = gameState.speed * METERS_PER_SECOND_MULT * delta;
   gameState.distance += metersDelta;
   const adaptiveProfile = getAdaptiveDifficultyProfile({ completedRuns: gameState.adaptiveCompletedRuns, distance: gameState.distance });
-  logger.debug('adaptive_difficulty_profile', { completedRuns: gameState.adaptiveCompletedRuns, distance: Math.max(0, Number(gameState.distance) || 0), tier: adaptiveProfile.tier, obstacleDensityMultiplier: adaptiveProfile.obstacleDensityMultiplier, maxCurveAngleDeg: adaptiveProfile.maxCurveAngleDeg, curveTransitionMultiplier: adaptiveProfile.curveTransitionMultiplier, centerOffsetSmoothing: adaptiveProfile.centerOffsetSmoothing, noDownwardTurns: adaptiveProfile.noDownwardTurns });
+  gameState.currentAdaptiveProfile = adaptiveProfile;
+  const adaptiveDebugEnabled = Boolean(window.__URSAS_DEBUG_ADAPTIVE__);
+  const debugNow = Date.now();
+  if (adaptiveDebugEnabled && (!gameState.lastAdaptiveDebugAtMs || debugNow - gameState.lastAdaptiveDebugAtMs >= 2000)) {
+    gameState.lastAdaptiveDebugAtMs = debugNow;
+    logger.debug('adaptive_difficulty_profile', { completedRuns: gameState.adaptiveCompletedRuns, distance: Math.max(0, Number(gameState.distance) || 0), tier: adaptiveProfile.tier, obstacleDensityMultiplier: adaptiveProfile.obstacleDensityMultiplier, maxCurveAngleDeg: adaptiveProfile.maxCurveAngleDeg, curveTransitionMultiplier: adaptiveProfile.curveTransitionMultiplier, centerOffsetSmoothing: adaptiveProfile.centerOffsetSmoothing, noDownwardTurns: adaptiveProfile.noDownwardTurns });
+  }
   const basePointsPerMeter = 1;
   const speedFactor = gameState.speed / CONFIG.SPEED_START;
   let pointsPerMeter = basePointsPerMeter * speedFactor;

--- a/js/store/rides-service.js
+++ b/js/store/rides-service.js
@@ -61,7 +61,24 @@ export function renderStoreCurrencyButton(target, { prefixIconPosition = null, l
 }
 
 export function setPlayerRides(nextPlayerRides = DEFAULT_PLAYER_RIDES) {
-  playerRides = { ...DEFAULT_PLAYER_RIDES, ...(nextPlayerRides || {}) };
+  const merged = { ...DEFAULT_PLAYER_RIDES, ...(nextPlayerRides || {}) };
+  const toFinite = (value, fallback) => {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+  };
+  const freeRides = Math.max(0, toFinite(merged.freeRides, DEFAULT_PLAYER_RIDES.freeRides));
+  const paidRides = Math.max(0, toFinite(merged.paidRides, DEFAULT_PLAYER_RIDES.paidRides));
+  const totalRides = Math.max(0, toFinite(merged.totalRides, freeRides + paidRides));
+  const resetInMs = Math.max(0, toFinite(merged.resetInMs, DEFAULT_PLAYER_RIDES.resetInMs));
+  const resetInFormatted = String(merged.resetInFormatted || '').trim() || 'Ready';
+  playerRides = {
+    ...merged,
+    freeRides,
+    paidRides,
+    totalRides,
+    resetInMs,
+    resetInFormatted
+  };
 }
 
 export function resetPlayerRides() {
@@ -81,6 +98,7 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
       logger.info('🎟 Rides:', getPlayerRides());
     } catch (error) {
       logger.error('❌ Error loading rides:', error);
+      setPlayerRides(getPlayerRides());
     }
   }
 
@@ -142,9 +160,10 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
     ridesInfo.setAttribute('aria-hidden', 'false');
 
     const currentRides = getPlayerRides();
-    const total = currentRides.totalRides;
-    const free = currentRides.freeRides;
-    const paid = currentRides.paidRides;
+    const total = Number.isFinite(Number(currentRides.totalRides)) ? Number(currentRides.totalRides) : 0;
+    const free = Number.isFinite(Number(currentRides.freeRides)) ? Number(currentRides.freeRides) : 0;
+    const paid = Number.isFinite(Number(currentRides.paidRides)) ? Number(currentRides.paidRides) : 0;
+    const resetInFormatted = String(currentRides.resetInFormatted || '').trim() || 'Ready';
     const limited = hasRideLimit();
 
     if (ridesText) {
@@ -158,10 +177,10 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
     }
 
     if (ridesTimer) {
-      if (limited && free < 3 && currentRides.resetInMs > 0) {
+      if (limited && free < 3 && Number(currentRides.resetInMs || 0) > 0) {
         appendRidesLabel(ridesTimer, {
           iconPosition: '-112px -28px',
-          text: `Resets in ${currentRides.resetInFormatted}`
+          text: `Resets in ${resetInFormatted}`
         });
         ridesTimer.style.display = '';
       } else {
@@ -173,7 +192,7 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
       if (limited && (total || 0) <= 0) {
         startBtn.style.opacity = '0.4';
         startBtn.style.pointerEvents = 'none';
-        startBtn.textContent = `NO RIDES (${currentRides.resetInFormatted})`;
+        startBtn.textContent = `NO RIDES (${resetInFormatted})`;
       } else {
         startBtn.style.opacity = '';
         startBtn.style.pointerEvents = '';
@@ -185,7 +204,7 @@ export function createRidesService({ isUnauthRuntimeMode, hasRideLimit }) {
       if (limited && (total || 0) <= 0) {
         restartBtn.style.opacity = '0.4';
         restartBtn.style.pointerEvents = 'none';
-        restartBtn.textContent = `NO RIDES (${currentRides.resetInFormatted})`;
+        restartBtn.textContent = `NO RIDES (${resetInFormatted})`;
       } else {
         restartBtn.style.opacity = '';
         restartBtn.style.pointerEvents = '';

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -45,6 +45,15 @@ let playerEffects = null;
 let playerBalance = { gold: 0, silver: 0 };
 function updateStoreBalanceElements(balance = playerBalance) {
   const nextGold = Number(balance?.gold || 0), nextSilver = Number(balance?.silver || 0);
+  window.__ursasLastKnownBalance = { gold: nextGold, silver: nextSilver };
+  const walletGold = document.getElementById('walletGold');
+  const walletSilver = document.getElementById('walletSilver');
+  const storeGoldVal = document.getElementById('storeGoldVal');
+  const storeSilverVal = document.getElementById('storeSilverVal');
+  if (walletGold) walletGold.textContent = String(nextGold);
+  if (walletSilver) walletSilver.textContent = String(nextSilver);
+  if (storeGoldVal) storeGoldVal.textContent = String(nextGold);
+  if (storeSilverVal) storeSilverVal.textContent = String(nextSilver);
   updateCachedBalance({ gold: nextGold, silver: nextSilver });
 }
 function resolveNextBalance(nextBalance, fallbackBalance = playerBalance) {
@@ -319,7 +328,7 @@ export function createUpgradesService({
           if (!playerUpgrades[key]) continue;
           const rawLevel = getLevelFromUpgradeState(playerUpgrades[key], key);
           const effectiveLevel = getEffectiveUpgradeLevel(key, playerUpgrades[key]);
-          playerUpgrades[key].currentLevel = effectiveLevel;
+          playerUpgrades[key].runtimeLevel = effectiveLevel;
           if (effectiveLevel !== rawLevel) {
             logger.warn(`⚠️ ${key} level normalized from ${rawLevel} to ${effectiveLevel}`, {
               upgrade: playerUpgrades[key],
@@ -347,7 +356,7 @@ export function createUpgradesService({
       const data = playerUpgrades[key] || null;
       const tierElements = getTierElements(prefix);
       if (tierElements.length === 0) continue;
-      const currentLevel = getEffectiveUpgradeLevel(key, data);
+      const currentLevel = getLevelFromUpgradeState(data, key);
       const maxLevel = tierElements.length || Number(data?.maxLevel || 0);
       for (let i = 0; i < maxLevel; i++) {
         const el = tierElements[i] || document.getElementById(`store-${prefix}-${i}`);
@@ -403,7 +412,7 @@ export function createUpgradesService({
       return;
     }
     const upgradeState = playerUpgrades && playerUpgrades[key];
-    const expectedTier = getEffectiveUpgradeLevel(key, upgradeState);
+    const expectedTier = getLevelFromUpgradeState(upgradeState, key);
     if (tier < expectedTier) {
       notifyWarn('❌ Already purchased (permanent)');
       return;
@@ -414,7 +423,7 @@ export function createUpgradesService({
     }
     const identifier = getAuthIdentifier();
     const beforePurchaseSnapshot = {
-      upgradeLevel: getEffectiveUpgradeLevel(key, upgradeState),
+      upgradeLevel: getLevelFromUpgradeState(upgradeState, key),
       ridesTotal: Number((typeof getPlayerRides === 'function' ? getPlayerRides() : null)?.total || 0),
       balance: { ...(playerBalance || {}) }
     };


### PR DESCRIPTION
### Motivation
- Fix regressions introduced during recent Telegram debugging that broke Store purchases/visibility, produced impossible rides UI states, reduced FPS, caused object pop‑in, and showed the Connect Wallet button during Telegram loading.  
- Ensure frontend never overwrites real backend state with null/0 and that store visuals reflect permanent backend ownership rather than temporary runtime effects.

### Description
- Normalize rides state and safe rendering: `setPlayerRides` now enforces finite non‑negative `totalRides`, `freeRides`, `paidRides`, `resetInMs` and always provides a `resetInFormatted` fallback, and preserves a safe prior rides state on fetch failures to avoid `NO RIDES (null)`. (js/store/rides-service.js)
- Stabilize balance rendering: introduce a shared `window.__ursasLastKnownBalance` and update `#walletGold`, `#walletSilver`, `#storeGoldVal`, `#storeSilverVal` immediately when store responses arrive to avoid flicker and delayed balances. (js/store/upgrades-service.js, js/auth-ui.js)
- Auth / wallet UI improvements: wallet button hidden by default until auth makes it visible; Telegram mode keeps wallet button hidden (no visible Connect Wallet during Telegram loading); auth UI uses cached balance when available and shows `…` placeholder instead of `0` until known. (css/style.css, js/auth-ui.js)
- Separate permanent upgrade ownership from runtime effects: store UI now uses backend ownership level (`getLevelFromUpgradeState`) for marking purchased tiers, while runtime/effect normalization is stored separately as `runtimeLevel` for gameplay. This prevents gifts/temporary effects from marking permanent upgrades as purchased. (js/store/upgrades-service.js)
- Reduce adaptive runtime overhead and FPS regression: cache the adaptive profile once per frame (`gameState.currentAdaptiveProfile`) and throttle debug logging to once every 2 seconds gated by `window.__URSAS_DEBUG_ADAPTIVE__`. (js/physics.js)
- Reduce object pop‑in by moving obstacle/bonus/coin spawn Z farther out so objects become visible earlier instead of appearing halfway to the player. (js/physics-spawning.js)

### Testing
- Ran `npm run check:syntax` and it completed successfully.  
- Ran `npm run test:request` (project test bundle) and all included automated tests passed.  
- Note: repository static analysis guardrails flagged existing oversized modules (`js/api.js`, `js/game/bootstrap.js`, `js/physics.js`) in the pre‑commit static analysis step; those are unrelated baseline issues and did not block the runtime/test validation in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cc9eee7c8326b99100a6eb4a2ef1)