### PR TITLE
Adjust onboarding gift/boost indicator position to avoid coin overlap

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -7,7 +7,7 @@ function ensureStyles() {
   const style = document.createElement('style');
   style.id = 'onboardingGiftIndicatorStyles';
   style.textContent = `
-    #${GIFT_INDICATOR_ID}{position:fixed;top:112px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:8px;align-items:flex-end;}
+    #${GIFT_INDICATOR_ID}{position:fixed;top:138px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:8px;align-items:flex-end;}
     #${GIFT_INDICATOR_ID} .boost-indicator{height:34px;background:rgba(8,10,24,.28);border:1px solid rgba(255,255,255,.04);border-radius:999px;display:flex;align-items:center;gap:8px;padding:2px 4px;animation:none;cursor:default;pointer-events:none;}
     #${GIFT_INDICATOR_ID} .boost-indicator .boost-icon{width:34px;height:34px;border-radius:999px;display:flex;align-items:center;justify-content:center;}
     #${GIFT_INDICATOR_ID} .boost-indicator .icon-atlas{width:20px;height:20px;}
@@ -16,7 +16,7 @@ function ensureStyles() {
     #${GIFT_INDICATOR_ID} .boost-timer{font-size:13px;font-weight:800;color:#f8fafc;text-shadow:0 0 8px rgba(125,211,252,.35);letter-spacing:.02em;min-width:30px;text-align:left;}
     #${GIFT_INDICATOR_ID} .gift-btn{width:42px;height:42px;border:0;border-radius:999px;padding:0;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;display:flex;align-items:center;justify-content:center;}
     #${GIFT_INDICATOR_ID} .gift-btn .icon-atlas.icon-gift-radar{width:22px;height:22px;background-size:110px auto;background-position:-22px -22px;filter:saturate(1.1) brightness(1.08);}
-    @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:120px;right:14px;}}
+    @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:146px;right:14px;}}
     @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(251,191,36,.7)}70%{box-shadow:0 0 0 12px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}`;
   document.head.appendChild(style);
 }


### PR DESCRIPTION
### Motivation
- Active radar boost indicators were positioned too high and overlapped the top gold/silver coin icons, so they need to be moved down while staying visually grouped with the balance HUD.

### Description
- Updated the inline injected CSS in `js/features/onboarding/gift-indicator.js` to move `#onboardingGiftIndicator` from `top: 112px` to `top: 138px` for desktop and from `top: 120px` to `top: 146px` inside the `@media (max-width: 600px)` rule, keeping horizontal offsets unchanged.

### Testing
- Ran `scripts/check-syntax.mjs` which passed, and ran `scripts/check-static-analysis.mjs` which reported unrelated size-threshold violations in `js/api.js`, `js/game/bootstrap.js`, and `js/physics.js` that affected the pre-commit hook; the style values were verified to match the requested targets and no runtime logic was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fd0018e083269725652e48dc0c1e)