### PR TITLE
Remove circular bubble behind active boost icons

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -8,11 +8,11 @@ function ensureStyles() {
   style.id = 'onboardingGiftIndicatorStyles';
   style.textContent = `
     #${GIFT_INDICATOR_ID}{position:fixed;top:138px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:8px;align-items:flex-end;}
-    #${GIFT_INDICATOR_ID} .boost-indicator{height:34px;background:rgba(8,10,24,.28);border:1px solid rgba(255,255,255,.04);border-radius:999px;display:flex;align-items:center;gap:8px;padding:2px 4px;animation:none;cursor:default;pointer-events:none;}
-    #${GIFT_INDICATOR_ID} .boost-indicator .boost-icon{width:34px;height:34px;border-radius:999px;display:flex;align-items:center;justify-content:center;}
-    #${GIFT_INDICATOR_ID} .boost-indicator .icon-atlas{width:20px;height:20px;}
-    #${GIFT_INDICATOR_ID} .boost-radar-obstacles .boost-icon{background:radial-gradient(circle at 35% 30%,rgba(125,211,252,.45),rgba(8,10,24,.76));box-shadow:0 0 12px rgba(56,189,248,.45);}
-    #${GIFT_INDICATOR_ID} .boost-radar-gold .boost-icon{background:radial-gradient(circle at 35% 30%,rgba(192,132,252,.4),rgba(8,10,24,.76));box-shadow:0 0 12px rgba(168,85,247,.45);}
+    #${GIFT_INDICATOR_ID} .boost-indicator{height:34px;background:rgba(8,10,24,.32);border:1px solid rgba(255,255,255,.08);border-radius:999px;display:flex;align-items:center;gap:8px;padding:2px 8px 2px 4px;animation:none;cursor:default;pointer-events:none;}
+    #${GIFT_INDICATOR_ID} .boost-indicator .boost-icon{width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:0;box-shadow:none;flex:0 0 28px;}
+    #${GIFT_INDICATOR_ID} .boost-indicator .icon-atlas{width:24px;height:24px;display:inline-block;}
+    #${GIFT_INDICATOR_ID} .boost-radar-obstacles .icon-atlas{filter:drop-shadow(0 0 6px rgba(59,130,246,.35));}
+    #${GIFT_INDICATOR_ID} .boost-radar-gold .icon-atlas{filter:drop-shadow(0 0 6px rgba(168,85,247,.35));}
     #${GIFT_INDICATOR_ID} .boost-timer{font-size:13px;font-weight:800;color:#f8fafc;text-shadow:0 0 8px rgba(125,211,252,.35);letter-spacing:.02em;min-width:30px;text-align:left;}
     #${GIFT_INDICATOR_ID} .gift-btn{width:42px;height:42px;border:0;border-radius:999px;padding:0;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;display:flex;align-items:center;justify-content:center;}
     #${GIFT_INDICATOR_ID} .gift-btn .icon-atlas.icon-gift-radar{width:22px;height:22px;background-size:110px auto;background-position:-22px -22px;filter:saturate(1.1) brightness(1.08);}


### PR DESCRIPTION
### Motivation
- Reduce visual weight of active boost indicators by removing the circular glassy bubble so only the radar icon and timer remain while preserving subtle accent glows.

### Description
- Update `js/features/onboarding/gift-indicator.js` inline styles to remove the heavy circular background from `.boost-icon`, set the icon wrapper to `28x28` with transparent background and no shadow, set `.icon-atlas` to `24x24`, move glow accents to `.boost-radar-obstacles .icon-atlas` and `.boost-radar-gold .icon-atlas`, and adjust outer pill spacing and border for a subtler appearance.

### Testing
- Ran automated syntax checks with `scripts/check-syntax.mjs`, which passed for the modified file; running `scripts/check-static-analysis.mjs` surfaced pre-existing unrelated oversized-file violations in `js/api.js`, `js/game/bootstrap.js`, and `js/physics.js` that are outside this change's scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060b99e8648326a2fe5431f07852d7)