### PR TITLE
Cap Phaser DPR in Telegram and gate perf/debug logs to fix mobile FPS

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -95,10 +95,18 @@ const hasWindow = typeof window !== 'undefined' && Number.isFinite(window.innerW
 const isMobileUserAgent = hasNavigator ? /Mobi|Android|iPhone/i.test(navigator.userAgent) : false;
 const isMobileViewport = hasWindow ? window.innerWidth < 600 : false;
 const isMobile = isMobileUserAgent || isMobileViewport;
+const isTelegramRuntime = typeof window !== 'undefined'
+  ? Boolean(window.Telegram?.WebApp?.initData || window.Telegram?.WebApp)
+  : false;
 if (isMobile) {
   CONFIG.TUBE_SEGMENTS = 24;
   CONFIG.TUBE_DEPTH_STEPS = 60;
   CONFIG.TUBE_RADIUS = 230;
+}
+
+if (isTelegramRuntime) {
+  CONFIG.TUBE_SEGMENTS = Math.min(CONFIG.TUBE_SEGMENTS, 22);
+  CONFIG.TUBE_DEPTH_STEPS = Math.min(CONFIG.TUBE_DEPTH_STEPS, 52);
 }
 
 const BONUS_TYPES = {

--- a/js/phaser/bridge.js
+++ b/js/phaser/bridge.js
@@ -2,14 +2,26 @@ import { DOM } from '../state.js';
 import { createPhaserRuntime } from './runtime.js';
 
 const PHASER_HOST_ID = 'phaser-root';
-const DPR_MAX = 2;
+
+function isTelegramRuntime() {
+  return Boolean(window.Telegram?.WebApp?.initData || window.Telegram?.WebApp);
+}
+
+function readLocalStorageFlag(key) {
+  try {
+    return window.localStorage?.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
 
 function getViewportMetrics() {
   const fallbackWidth = DOM.gameViewport?.clientWidth || window.innerWidth || 360;
   const fallbackHeight = DOM.gameViewport?.clientHeight || window.innerHeight || 640;
   const width = Math.max(1, Math.round(fallbackWidth));
   const height = Math.max(1, Math.round(fallbackHeight));
-  const resolution = Math.min(window.devicePixelRatio || 1, DPR_MAX);
+  const dprMax = isTelegramRuntime() ? 1 : 2;
+  const resolution = Math.min(window.devicePixelRatio || 1, dprMax);
 
   return { width, height, resolution };
 }
@@ -80,6 +92,69 @@ async function createPhaserBridge() {
   let runtime = null;
   let lastSnapshot = null;
   let teardownListeners = null;
+  let fpsDebugOverlay = null;
+  let lastFpsDebugAt = 0;
+
+  function ensureFpsOverlay() {
+    if (!readLocalStorageFlag('DEBUG_FPS')) {
+      fpsDebugOverlay?.remove();
+      fpsDebugOverlay = null;
+      return null;
+    }
+    if (fpsDebugOverlay) return fpsDebugOverlay;
+
+    fpsDebugOverlay = document.createElement('div');
+    fpsDebugOverlay.setAttribute('aria-hidden', 'true');
+    Object.assign(fpsDebugOverlay.style, {
+      position: 'absolute',
+      top: '8px',
+      left: '8px',
+      zIndex: '5',
+      pointerEvents: 'none',
+      padding: '6px 8px',
+      borderRadius: '6px',
+      background: 'rgba(0,0,0,0.7)',
+      color: '#7CFFB0',
+      font: '12px/1.35 monospace',
+      whiteSpace: 'pre'
+    });
+    document.getElementById(PHASER_HOST_ID)?.appendChild(fpsDebugOverlay);
+    return fpsDebugOverlay;
+  }
+
+  function maybeLogPerf(snapshot) {
+    const now = Date.now();
+    if (now - lastFpsDebugAt < 2000) return;
+    const gameplayDebug = readLocalStorageFlag('DEBUG_GAMEPLAY');
+    const fpsDebug = readLocalStorageFlag('DEBUG_FPS');
+    if (!gameplayDebug && !fpsDebug) return;
+    lastFpsDebugAt = now;
+
+    const metrics = getViewportMetrics();
+    const stats = snapshot?.debugStats || {};
+    const payload = {
+      fps: Math.round(runtime?.game?.loop?.actualFps || 0),
+      dpr: Number(window.devicePixelRatio || 1),
+      resolution: metrics.resolution,
+      tubeSegments: snapshot?.config?.tubeSegments,
+      tubeDepthSteps: snapshot?.config?.tubeDepthSteps,
+      drawMs: Number(stats.drawMs || 0),
+      updateMs: Number(stats.updateMs || 0)
+    };
+
+    if (fpsDebug) {
+      const overlay = ensureFpsOverlay();
+      if (overlay) {
+        overlay.textContent = Object.entries(payload)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join('\n');
+      }
+    }
+
+    if (gameplayDebug) {
+      console.info('[perf-debug]', payload);
+    }
+  }
 
   async function mount(snapshot) {
     const host = ensureHost();
@@ -128,6 +203,7 @@ async function createPhaserBridge() {
     },
     render(snapshot) {
       lastSnapshot = snapshot;
+      maybeLogPerf(snapshot);
       runtime?.applySnapshot({
         ...snapshot,
         backend: 'phaser'
@@ -138,6 +214,8 @@ async function createPhaserBridge() {
       teardownListeners = null;
       runtime?.destroy();
       runtime = null;
+      fpsDebugOverlay?.remove();
+      fpsDebugOverlay = null;
       document.getElementById(PHASER_HOST_ID)?.remove();
     }
   };

--- a/js/physics.js
+++ b/js/physics.js
@@ -101,7 +101,13 @@ function update(delta) {
   gameState.distance += metersDelta;
   const adaptiveProfile = getAdaptiveDifficultyProfile({ completedRuns: gameState.adaptiveCompletedRuns, distance: gameState.distance });
   gameState.currentAdaptiveProfile = adaptiveProfile;
-  const adaptiveDebugEnabled = Boolean(window.__URSAS_DEBUG_ADAPTIVE__);
+  const adaptiveDebugEnabled = (() => {
+    try {
+      return window.localStorage?.getItem('DEBUG_GAMEPLAY') === '1';
+    } catch {
+      return false;
+    }
+  })();
   const debugNow = Date.now();
   if (adaptiveDebugEnabled && (!gameState.lastAdaptiveDebugAtMs || debugNow - gameState.lastAdaptiveDebugAtMs >= 2000)) {
     gameState.lastAdaptiveDebugAtMs = debugNow;


### PR DESCRIPTION
### Motivation
- Telegram Mini App and some iPhones were rendering at 2x DPR causing up to 4× pixel work and a drop to ~30 FPS.
- Per-frame debug output and overlays can further hurt performance and must be throttled/disabled in production.

### Description
- Detect Telegram runtime (`Boolean(window.Telegram?.WebApp?.initData || window.Telegram?.WebApp)`) and cap Phaser DPR to `1` for Telegram while keeping `min(devicePixelRatio, 2)` for regular web in `js/phaser/bridge.js`.
- Add Telegram-specific geometry reduction in `js/config.js` by clamping `CONFIG.TUBE_SEGMENTS` and `CONFIG.TUBE_DEPTH_STEPS` to lower values to reduce polygon/fill cost on mobile Telegram.
- Add an optional FPS/perf overlay behind `localStorage.DEBUG_FPS === "1"`, and add throttled perf logging (max once per 2 seconds) with payload `{ fps, dpr, resolution, tubeSegments, tubeDepthSteps, drawMs, updateMs }` in `js/phaser/bridge.js`.
- Gate adaptive/gameplay debug output in `js/physics.js` behind `localStorage.DEBUG_GAMEPLAY === "1"` and keep the 2s throttle to avoid production console spam.

### Testing
- Ran `npm run -s lint`, which completed successfully.
- Pre-commit checks (including `npm run check:syntax`) ran during commit and passed.
- Static analysis (`npm run check:static-analysis`) ran and passed, no regressions reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0612d1fb3c83268704f2e89601917b)