### PR TITLE
Smooth adaptive tube center shifts for early runs

### DIFF
--- a/js/game/adaptive-difficulty.js
+++ b/js/game/adaptive-difficulty.js
@@ -20,6 +20,10 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
     obstacleDensityMultiplier: 1,
     maxCurveAngleDeg: CONFIG.MAX_CURVE_ANGLE,
     curveTransitionMultiplier: 1,
+    centerOffsetMultiplier: 1,
+    maxCurveStrength: 1,
+    maxDirectionDelta: Math.PI * 2,
+    minCurveTransitionDurationMs: CONFIG.MIN_CURVE_TIME,
     centerOffsetSmoothing: 12,
     noDownwardTurns: true
   };
@@ -44,6 +48,10 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
       obstacleDensityMultiplier: isNewTier ? 0.65 : 0.84,
       maxCurveAngleDeg: isNewTier ? 15 : 15,
       curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
+      centerOffsetMultiplier: isNewTier ? 0.3 : 0.35,
+      maxCurveStrength: isNewTier ? 0.4 : 0.45,
+      maxDirectionDelta: isNewTier ? Math.PI / 4 : Math.PI / 3,
+      minCurveTransitionDurationMs: isNewTier ? 11000 : 9500,
       centerOffsetSmoothing: isNewTier ? 7 : 9,
       noDownwardTurns: true
     };
@@ -54,6 +62,10 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
     obstacleDensityMultiplier: isNewTier ? 0.5 : 0.7,
     maxCurveAngleDeg: isNewTier ? 15 : 20,
     curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
+    centerOffsetMultiplier: isNewTier ? 0.25 : 0.4,
+    maxCurveStrength: isNewTier ? 0.35 : 0.5,
+    maxDirectionDelta: isNewTier ? Math.PI / 5 : Math.PI / 3,
+    minCurveTransitionDurationMs: isNewTier ? 12000 : 9500,
     centerOffsetSmoothing: isNewTier ? 7 : 9,
     noDownwardTurns: true
   };

--- a/js/physics.js
+++ b/js/physics.js
@@ -314,8 +314,11 @@ function update(delta) {
   player.x = p.x - CONFIG.FRAME_SIZE / 2;
   player.y = p.y - CONFIG.FRAME_SIZE / 2;
 
-  const targetCenterOffsetX = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_X;
-  const targetCenterOffsetY = Math.sin(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_Y;
+  const centerOffsetMultiplier = Math.max(0, Number(adaptiveProfile.centerOffsetMultiplier) || 0);
+  const rawTargetCenterOffsetX = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_X;
+  const rawTargetCenterOffsetY = Math.sin(gameState.curveDirection) * gameState.tubeCurveStrength * CONFIG.TUBE_RADIUS * CONFIG.CURVE_OFFSET_Y;
+  const targetCenterOffsetX = rawTargetCenterOffsetX * centerOffsetMultiplier;
+  const targetCenterOffsetY = rawTargetCenterOffsetY * centerOffsetMultiplier;
   const noDownwardTurnsDistanceLimit = adaptiveProfile.noDownwardTurns && adaptiveProfile.tier !== 'standard' ? 2000 : 1500;
   const constrainedCenterOffsetY = gameState.distance < noDownwardTurnsDistanceLimit ? Math.min(targetCenterOffsetY, 0) : targetCenterOffsetY;
   const centerOffsetLerp = Math.min(1, delta * Math.max(1, adaptiveProfile.centerOffsetSmoothing || 1));
@@ -466,10 +469,18 @@ function update(delta) {
   if (gameState.curveTimer >= gameState.curveTransitionDuration) {
     curves.current.direction = curves.next.direction;
     curves.current.strength = curves.next.strength;
-    curves.next.direction = Math.random() * Math.PI * 2;
-    curves.next.strength = 0.5 + Math.random() * 0.5;
+    const maxDirectionDelta = Math.max(0, Number(adaptiveProfile.maxDirectionDelta) || Math.PI * 2);
+    const deltaDirection = (Math.random() * 2 - 1) * maxDirectionDelta;
+    curves.next.direction = curves.current.direction + deltaDirection;
+    const maxCurveStrength = Math.max(0, Number(adaptiveProfile.maxCurveStrength) || 1);
+    curves.next.strength = Math.min(maxCurveStrength, 0.25 + Math.random() * maxCurveStrength);
     const curveTransitionMultiplier = Math.max(1, adaptiveProfile.curveTransitionMultiplier || 1);
-    gameState.curveTransitionDuration = (CONFIG.MIN_CURVE_TIME + Math.random() * (CONFIG.MAX_CURVE_TIME - CONFIG.MIN_CURVE_TIME)) * curveTransitionMultiplier;
+    const baseDuration = CONFIG.MIN_CURVE_TIME + Math.random() * (CONFIG.MAX_CURVE_TIME - CONFIG.MIN_CURVE_TIME);
+    const minCurveTransitionDurationMs = Math.max(CONFIG.MIN_CURVE_TIME, Number(adaptiveProfile.minCurveTransitionDurationMs) || CONFIG.MIN_CURVE_TIME);
+    gameState.curveTransitionDuration = Math.max(
+      minCurveTransitionDurationMs,
+      baseDuration * curveTransitionMultiplier
+    );
     gameState.curveTimer = 0;
   }
 }


### PR DESCRIPTION
### Motivation
- New players experienced rapid, frequent tube center shifts (4–5 visual jumps in ~2–3s) because next curve targets were chosen fully randomly and strength/transition timing were unconstrained. The goal is to make early runs slower, smoother and less visually erratic.

### Description
- Extended adaptive difficulty profile with `centerOffsetMultiplier`, `maxCurveStrength`, `maxDirectionDelta`, and `minCurveTransitionDurationMs` and added tier+distance-specific values for runs `0–6` and `7–15` with standard fallbacks. (`js/game/adaptive-difficulty.js`)
- Replaced fully-random next direction with a bounded delta from the current direction: `curves.next.direction = curves.current.direction + delta`, where `delta` is sampled in `±adaptiveProfile.maxDirectionDelta`. (`js/physics.js`)
- Clamped next curve strength by `adaptiveProfile.maxCurveStrength` to prevent aggressive spikes: `curves.next.strength = Math.min(maxCurveStrength, 0.25 + Math.random() * maxCurveStrength)`. (`js/physics.js`)
- Applied `centerOffsetMultiplier` to raw X/Y center offsets before smoothing so tube lateral/vertical movement is reduced for early tiers. (`js/physics.js`)
- Enforced a profile-specific minimum curve transition duration using `minCurveTransitionDurationMs` while preserving existing `curveTransitionMultiplier` behavior. (`js/physics.js`)
- Kept existing `noDownwardTurns` constraint intact and unchanged. (`js/physics.js`)

### Testing
- Ran syntax checks with `npm run check:syntax` and they passed. 
- Ran targeted unit tests with `node --test scripts/difficulty-segmentation.test.mjs` and they passed. 
- Pre-commit static analysis (`npm run check:static-analysis`) executed as part of checks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0612e5a70c8326976422a9f847b614)