### PR TITLE
Fix radar icon atlas coordinates for boost indicators

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2353,8 +2353,8 @@ footer a:hover { color: #e0b0ff; }
 .icon-coin-gold-sm{width:14px;height:14px;background-size:70px auto;background-position:-28px -42px;}
 .icon-coin-silver-sm{width:14px;height:14px;background-size:70px auto;background-position:-14px -42px;}
 
-.icon-radar-obstacles{width:20px;height:20px;background-size:100px auto;background-position:-80px 0px;}
-.icon-radar-gold{width:20px;height:20px;background-size:100px auto;background-position:-80px 0px;filter:hue-rotate(40deg) saturate(1.2);}
+.icon-radar-obstacles{width:24px;height:24px;background-size:120px 96px;background-position:-96px 0px;}
+.icon-radar-gold{width:24px;height:24px;background-size:120px 96px;background-position:-96px 0px;filter:hue-rotate(40deg) saturate(1.2);}
 
 .store-tabs {
   display: grid;


### PR DESCRIPTION
### Motivation
- Fix incorrect sampling/coordinates from `icon_atlas.webp` that caused visual bleed/artifacts for radar boost icons in gift indicators.

### Description
- Update `css/style.css` to adjust `.icon-radar-obstacles` and `.icon-radar-gold` to `width:24px;height:24px`, set `background-size:120px 96px` and `background-position:-96px 0px` so the icons align with the atlas grid and render without sampling artifacts.

### Testing
- Pre-commit automated checks ran and passed successfully: `npm run check:syntax` and `npm run check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061378900c83269fa5ccb05e5642d4)