### PR TITLE
Frontend: Fix leaderboard display-name priority for Telegram players

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -157,15 +157,30 @@ function updateGameOverLeaderboardNotice(message = '') {
   notice.hidden = text.length === 0;
 }
 
+function normalizeTelegramUsername(username) {
+  return String(username || '').trim().replace(/^@/, '');
+}
+
+function shortenWalletAddress(wallet) {
+  const value = String(wallet || '').trim();
+  if (!/^0x[a-fA-F0-9]{40}$/.test(value)) return '';
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
 function formatLeaderboardName(entry = {}) {
-  if (entry.displayName) return String(entry.displayName);
-  if (entry.wallet && entry.wallet.startsWith('0x')) {
-    return `${entry.wallet.slice(0, 6)}...${entry.wallet.slice(-4)}`;
-  }
-  if (entry.wallet) {
-    return entry.wallet.length > 14 ? `${entry.wallet.slice(0, 10)}...` : entry.wallet;
-  }
-  return 'Unknown';
+  const displayName = String(entry?.displayName || '').trim();
+  if (displayName) return displayName;
+
+  const nickname = String(entry?.nickname || '').trim();
+  if (nickname) return nickname;
+
+  const shortWallet = shortenWalletAddress(entry?.wallet);
+  if (shortWallet) return shortWallet;
+
+  const telegramUsername = normalizeTelegramUsername(entry?.telegramUsername);
+  if (telegramUsername) return `@${telegramUsername}`;
+
+  return 'Player';
 }
 
 function createLeaderboardRow(entry, idx, { isMe = false, isDimmed = false, rankOverride = null } = {}) {


### PR DESCRIPTION
### Motivation
- Telegram-authenticated players were rendered incorrectly on the leaderboard because the frontend recomputed display names and could show raw `tg_...` ids or the wrong fallback; the UI must follow deterministic priority `nickname > wallet > telegramUsername > Player` while respecting an explicit backend `displayName` when present.

### Description
- Update `js/ui.js` to use `entry.displayName` verbatim when present and otherwise apply the deterministic fallback order `nickname` → shortened EVM wallet → Telegram username (`@username`) → `Player`.
- Add `normalizeTelegramUsername(username)` to trim and remove leading `@`, and add `shortenWalletAddress(wallet)` which only shortens valid EVM addresses (`/^0x[a-fA-F0-9]{40}$/`) to avoid treating `tg_...` as wallets.
- Replace the old `formatLeaderboardName` implementation with the new logic so the frontend no longer fabricates display names when the backend provides `displayName`.

### Testing
- Ran repository request/unit tests via `npm run test` (including `scripts/leaderboard-insights.test.mjs`); all automated tests passed (86 passed, 0 failed).
- Pre-commit checks executed during the change ran `npm run check:syntax` and `npm run check:static-analysis`, both passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061634e1808326a6dc0177f6a4ca0f)