### PR TITLE
Fix gift indicator to use correct atlas 'gift' sprite

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2353,6 +2353,8 @@ footer a:hover { color: #e0b0ff; }
 .icon-coin-gold-sm{width:14px;height:14px;background-size:70px auto;background-position:-28px -42px;}
 .icon-coin-silver-sm{width:14px;height:14px;background-size:70px auto;background-position:-14px -42px;}
 
+.icon-gift{width:24px;height:24px;background-size:120px 96px;background-position:-72px -72px;}
+
 .icon-radar-obstacles{width:24px;height:24px;background-size:120px 96px;background-position:-96px 0px;}
 .icon-radar-gold{width:24px;height:24px;background-size:120px 96px;background-position:-96px 0px;filter:hue-rotate(40deg) saturate(1.2);}
 

--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -15,7 +15,7 @@ function ensureStyles() {
     #${GIFT_INDICATOR_ID} .boost-radar-gold .icon-atlas{filter:drop-shadow(0 0 6px rgba(168,85,247,.35));}
     #${GIFT_INDICATOR_ID} .boost-timer{font-size:13px;font-weight:800;color:#f8fafc;text-shadow:0 0 8px rgba(125,211,252,.35);letter-spacing:.02em;min-width:30px;text-align:left;}
     #${GIFT_INDICATOR_ID} .gift-btn{width:42px;height:42px;border:0;border-radius:999px;padding:0;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;display:flex;align-items:center;justify-content:center;}
-    #${GIFT_INDICATOR_ID} .gift-btn .icon-atlas.icon-gift-radar{width:22px;height:22px;background-size:110px auto;background-position:-22px -22px;filter:saturate(1.1) brightness(1.08);}
+    #${GIFT_INDICATOR_ID} .gift-btn .icon-atlas.icon-gift{width:22px;height:22px;background-size:110px 88px;background-position:-66px -66px;filter:saturate(1.1) brightness(1.08);}
     @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:146px;right:14px;}}
     @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(251,191,36,.7)}70%{box-shadow:0 0 0 12px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}`;
   document.head.appendChild(style);
@@ -74,7 +74,7 @@ function renderGiftAndBoostIndicators({ gifts = {}, activeBoosts = {}, onGiftCli
     giftBtn.className = 'gift-btn is-gift-available';
     giftBtn.dataset.indicator = 'gift';
     giftBtn.setAttribute('aria-label', 'Claim radar gift');
-    giftBtn.innerHTML = '<span class="icon-atlas icon-gift-radar" aria-hidden="true"></span>';
+    giftBtn.innerHTML = '<span class="icon-atlas icon-gift" aria-hidden="true"></span>';
     giftBtn.title = 'Claim radar gift';
     giftBtn.addEventListener('click', () => onGiftClick?.());
     node.appendChild(giftBtn);


### PR DESCRIPTION
### Motivation
- The onboarding gift button displayed the wrong sprite because it referenced an incorrect atlas mapping rather than the actual `gift` frame from the icon atlas.
- The fix ensures the UI uses exact atlas coordinates so the gift indicator renders correctly across desktop, mobile web and Telegram.

### Description
- Use atlas metadata from `public/assets/icon_atlas_map.json` (frame `gift`: `x:192,y:192,w:64,h:64`) to derive CSS coordinates.
- Add a dedicated `.icon-gift` rule in `css/style.css` with `background-size: 120px 96px` and `background-position: -72px -72px` for 24px icon usage.
- Update `js/features/onboarding/gift-indicator.js` to render `<span class="icon-atlas icon-gift" aria-hidden="true"></span>` and apply a 22px variant using `background-size: 110px 88px` and `background-position: -66px -66px` in the inline onboarding styles.
- Keep existing radar boost icons (`icon-radar-obstacles`, `icon-radar-gold`) unchanged.

### Testing
- Ran the repository pre-commit automated checks (including `check:syntax` and `check:static-analysis`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061b905e948326b57c0d123a01d3c7)