### PR TITLE
Adjust Telegram/mobile gift indicator position to align with HUD

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -16,7 +16,7 @@ function ensureStyles() {
     #${GIFT_INDICATOR_ID} .boost-timer{font-size:13px;font-weight:800;color:#f8fafc;text-shadow:0 0 8px rgba(125,211,252,.35);letter-spacing:.02em;min-width:30px;text-align:left;}
     #${GIFT_INDICATOR_ID} .gift-btn{width:42px;height:42px;border:0;border-radius:999px;padding:0;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;display:flex;align-items:center;justify-content:center;}
     #${GIFT_INDICATOR_ID} .gift-btn .icon-atlas.icon-gift{width:22px;height:22px;background-size:110px 88px;background-position:-66px -66px;filter:saturate(1.1) brightness(1.08);}
-    @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:146px;right:14px;}}
+    @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:132px;right:14px;}html.telegram-runtime #${GIFT_INDICATOR_ID},body.telegram-runtime #${GIFT_INDICATOR_ID}{top:128px;right:14px;}}
     @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(251,191,36,.7)}70%{box-shadow:0 0 0 12px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}`;
   document.head.appendChild(style);
 }


### PR DESCRIPTION
### Motivation
- Raise the onboarding gift indicator on mobile/Telegram so it visually matches the web HUD and sits closer to the gold/silver balance block without overlapping coin icons.

### Description
- Updated `js/features/onboarding/gift-indicator.js` injected styles to change the mobile offset to `top: 132px; right: 14px;` under the `@media (max-width: 600px)` rule.
- Added Telegram runtime-specific override selectors `html.telegram-runtime #onboardingGiftIndicator` and `body.telegram-runtime #onboardingGiftIndicator` with `top: 128px; right: 14px;` for tighter alignment inside Telegram Mini App rendering.
- Left desktop/web placement unchanged at `top: 138px; right: 20px` and preserved stack ordering so active boosts remain above the gift button.

### Testing
- Ran the syntax checks via `npm run check:syntax` (project script `scripts/check-syntax.mjs`) and all checked JS files passed.
- Ran static analysis via `npm run check:static-analysis` (project script `scripts/check-static-analysis.mjs`) and the static analysis guardrails passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06251e351c83268e9e3db5ac355bbe)