### PR TITLE
Fix vertical alignment of icons in round UI buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,7 @@
   backdrop-filter: blur(12px);
   cursor: pointer;
   transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease, opacity .2s ease;
+  line-height: 1;
 }
 
 .ui-btn:hover {
@@ -95,6 +96,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  line-height: 1;
 }
 
 * {


### PR DESCRIPTION
### Motivation
- Icon-only glyphs (back arrow, audio/music emojis, etc.) were visually shifted downward inside circular buttons due to default font metrics and `line-height` differences.

### Description
- Add `line-height: 1` to `.ui-btn` and `.ui-btn--icon` in `css/style.css` to normalize baseline and vertically center icons/glyphs inside buttons.

### Testing
- Ran `npm run -s check-syntax` (pre-commit) and `node scripts/check-static-analysis.mjs` via the repo checks, and both automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06551f99548326bc470c6848462d59)