### PR TITLE
Adjust obstacle collision phase windows by subtype

### DIFF
--- a/js/physics.js
+++ b/js/physics.js
@@ -11,6 +11,25 @@ import { createPhysicsSpawning } from './physics-spawning.js';
 import { updateAiControl } from './ai-mode.js';
 import { getAdaptiveDifficultyProfile } from './game/adaptive-difficulty.js';
 let laneCooldown = getLaneCooldown(); const COLLISION_REACTION_WINDOW_MS = 450, CAMERA_SHAKE_SMOOTHING = 12;
+
+const OBSTACLE_COLLISION_PHASE_WINDOW = Object.freeze({
+  fence: { start: 28, end: 45 },
+  bottles: { start: 28, end: 45 },
+  rock1: { start: 35, end: 65 },
+  rock2: { start: 35, end: 65 },
+  bull: { start: 35, end: 65 },
+  pit: { start: 35, end: 36 },
+  spikes: { start: 35, end: 50 }
+});
+
+function isObstacleInCollisionPhase(subtype, z, zMin, zMax) {
+  const window = OBSTACLE_COLLISION_PHASE_WINDOW[subtype];
+  if (!window || !Number.isFinite(z) || !Number.isFinite(zMin) || !Number.isFinite(zMax) || zMax <= zMin) {
+    return true;
+  }
+  const phasePercent = ((z - zMin) / (zMax - zMin)) * 100;
+  return phasePercent >= window.start && phasePercent <= window.end;
+}
 const removeCoinAt = (index) => { if (coins[index]?.type === 'silver') gameState.activeSilverCoins = Math.max(0, (gameState.activeSilverCoins || 0) - 1); coins.splice(index, 1); };
 function resetGameSessionState() {
   player.shield = false;
@@ -356,7 +375,12 @@ function update(delta) {
   for (let i = obstacles.length - 1; i >= 0; i--) {
     const o = obstacles[i];
     if (gameState.radarObstaclesActive && (Number(o.spawnDelayRemaining) || 0) > 0) continue;
-    if (o.z >= obstacleCollisionMin && o.z <= obstacleCollisionMax && o.lane === player.lane) {
+    if (
+      o.z >= obstacleCollisionMin
+      && o.z <= obstacleCollisionMax
+      && o.lane === player.lane
+      && isObstacleInCollisionPhase(o.subtype, o.z, obstacleCollisionMin, obstacleCollisionMax)
+    ) {
       gameState.obstacleCollisionCount += 1;
       if (player.shieldCount > 0) {
         const shieldHitPoint = project(player.lane, CONFIG.PLAYER_Z);


### PR DESCRIPTION
### Motivation
- Reduce collision likelihood during the early and late approach phases for specific obstacle subtypes so players have a larger readable window to react (requested per-subtype ranges). 

### Description
- Added `OBSTACLE_COLLISION_PHASE_WINDOW` mapping in `js/physics.js` that defines start/end phase percentages for `fence`, `bottles`, `rock1`, `rock2`, `bull`, `pit` (hole) and `spikes`.
- Implemented `isObstacleInCollisionPhase(subtype, z, zMin, zMax)` to compute obstacle approach phase as a percentage and decide whether collisions should be considered for that subtype.
- Updated the obstacle collision check to require `isObstacleInCollisionPhase(...)` to return true before triggering shield/kill logic, leaving unspecified obstacle types behavior unchanged.

### Testing
- Automated syntax checks (`npm run check:syntax`) were executed as part of pre-commit hooks and passed.
- Static analysis guardrails (`npm run check:static-analysis`) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06586d87cc83269c1979245100d008)