### PR TITLE
Fix onboarding Skip button right offset to prevent overflow

### DIFF
--- a/js/features/onboarding/spotlight.js
+++ b/js/features/onboarding/spotlight.js
@@ -41,7 +41,7 @@ function ensureSpotlightStyles() {
     .onboarding-spotlight-skip {
       position: fixed;
       top: max(12px, env(safe-area-inset-top));
-      right: max(12px, env(safe-area-inset-right));
+      right: max(22px, calc(env(safe-area-inset-right) + 10px));
       padding: 8px 12px;
       border: 0;
       border-radius: 999px;


### PR DESCRIPTION
### Motivation
- Prevent the onboarding `Skip` button from overflowing the viewport on narrow/safe-area screens by shifting it 10px left while keeping safe-area handling.

### Description
- Update CSS in `js/features/onboarding/spotlight.js` changing `right: max(12px, env(safe-area-inset-right));` to `right: max(22px, calc(env(safe-area-inset-right) + 10px));` so the button stays inside the window.

### Testing
- Pre-commit static checks were run and passed: `npm run check:syntax` and `npm run check:static-analysis`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070ba8e04083269188649e7774a2e6)