### PR TITLE
Fix FREE radar gift claim flow during store onboarding

### DIFF
--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -5,6 +5,7 @@ import { notifyError, notifySuccess, notifyWarn } from '../notifier.js';
 import { getPrimaryAuthIdentifier, getSigningWalletAddress } from '../features/auth/index.js';
 import { getTelegramInitData } from '../auth-telegram.js';
 import { formatRemainingHours } from '../features/onboarding/boost-timer.js';
+import { postOnboardingEvent } from '../features/onboarding/onboarding-service.js';
 
 const RADAR_GIFT_TIERS = [
   { reward: 'radar_obstacles_24h', selectors: ['#store-radarobstacles-0', '[data-upgrade-key="radar_obstacles"][data-upgrade-tier="0"]'] },
@@ -13,6 +14,12 @@ const RADAR_GIFT_TIERS = [
 
 let isRadarGiftClickInterceptorBound = false;
 const pendingGiftClaims = new Set();
+let lastOnboardingState = null;
+
+const GIFT_ONBOARDING_BY_REWARD = Object.freeze({
+  radar_obstacles_24h: { key: 'gift_radar_obstacles_store', target: 'radar_obstacles_24h_card' },
+  radar_gold_24h: { key: 'gift_radar_gold_store', target: 'radar_gold_24h_card' }
+});
 
 function rewardFromGiftTargetOrKey(value) {
   switch (value) {
@@ -35,7 +42,7 @@ function rewardFromGiftTargetOrKey(value) {
   }
 }
 
-async function claimOnboardingGiftReward(rewardKeyOrTarget, { refreshOnboardingState }) {
+async function claimOnboardingGiftReward(rewardKeyOrTarget) {
   const normalizedReward = rewardFromGiftTargetOrKey(String(rewardKeyOrTarget || '').trim());
   if (!normalizedReward) {
     console.warn('⚠️ onboarding gift reward mapping failed', { keyOrTarget: rewardKeyOrTarget });
@@ -75,8 +82,7 @@ async function claimOnboardingGiftReward(rewardKeyOrTarget, { refreshOnboardingS
       return { claimed: false, reward: normalizedReward, until: null };
     }
     const claimedUntil = data?.until;
-    await refreshOnboardingState({ reason: `gift_claim_${normalizedReward}`, screen: 'store' });
-    return { claimed: true, reward: normalizedReward, until: claimedUntil };
+    return { claimed: true, reward: normalizedReward, until: claimedUntil, data };
   } catch (error) {
     logger.error('❌ onboarding gift claim failed', { reward: normalizedReward, error });
     notifyError('❌ Gift claim failed');
@@ -93,9 +99,11 @@ function applyPendingClaimUi(reward) {
   tierEl.classList.remove('is-gift-free', 'available');
   tierEl.classList.add('is-gift-pending');
   delete tierEl.dataset.onboardingGift;
+  tierEl.dataset.giftClaimPending = 'true';
   tierEl.style.pointerEvents = 'none';
-  tierEl.removeAttribute('aria-busy');
+  tierEl.setAttribute('aria-disabled', 'true');
   tierEl.setAttribute('aria-busy', 'true');
+  if ('disabled' in tierEl) tierEl.disabled = true;
   const priceEl = tierEl.querySelector('.store-tier-price');
   if (priceEl) priceEl.textContent = 'Activating...';
 }
@@ -111,9 +119,12 @@ function applyImmediateClaimedUi(reward, until) {
   tierEl.classList.add('is-gift-active');
   tierEl.classList.remove('is-gift-free', 'available', 'is-gift-pending');
   delete tierEl.dataset.onboardingGift;
+  delete tierEl.dataset.giftClaimPending;
   tierEl.dataset.giftTimer = giftTimerText;
   tierEl.style.pointerEvents = 'none';
+  tierEl.setAttribute('aria-disabled', 'true');
   tierEl.removeAttribute('aria-busy');
+  if ('disabled' in tierEl) tierEl.disabled = true;
   const priceEl = tierEl.querySelector('.store-tier-price');
   if (priceEl) priceEl.textContent = '';
 }
@@ -127,8 +138,11 @@ function restoreGiftAvailableUi(reward) {
   tierEl.classList.remove('is-gift-active', 'is-gift-pending');
   tierEl.classList.add('is-gift-free', 'available');
   tierEl.dataset.onboardingGift = reward;
+  delete tierEl.dataset.giftClaimPending;
   tierEl.style.pointerEvents = 'auto';
+  tierEl.setAttribute('aria-disabled', 'false');
   tierEl.removeAttribute('aria-busy');
+  if ('disabled' in tierEl) tierEl.disabled = false;
   const priceEl = tierEl.querySelector('.store-tier-price');
   if (priceEl) priceEl.textContent = 'FREE 24H';
 }
@@ -148,12 +162,33 @@ async function handleGiftClaimAction(rewardKeyOrTarget, handlers) {
   applyPendingClaimUi(normalizedReward);
 
   try {
-    const claimResult = await claimOnboardingGiftReward(normalizedReward, { refreshOnboardingState });
+    const claimResult = await claimOnboardingGiftReward(normalizedReward);
     if (!claimResult?.claimed) {
-      restoreGiftAvailableUi(normalizedReward);
+      const backendGift = claimResult?.data?.gifts?.[normalizedReward] || null;
+      const stillAvailable = backendGift?.available === true && backendGift?.claimed !== true;
+      if (stillAvailable) restoreGiftAvailableUi(normalizedReward);
+      else {
+        await refreshOnboardingState({ reason: `gift_claim_failed_${normalizedReward}`, screen: 'store', resetCache: true });
+      }
       return;
     }
     applyImmediateClaimedUi(claimResult.reward, claimResult.until);
+    const onboardingMeta = GIFT_ONBOARDING_BY_REWARD[claimResult.reward];
+    if (onboardingMeta) {
+      const onboardingStatus = String(lastOnboardingState?.onboarding?.[onboardingMeta.key] || 'none').toLowerCase();
+      const activeKey = String(lastOnboardingState?.activeOnboarding?.key || '').toLowerCase();
+      const canComplete = activeKey === onboardingMeta.key || onboardingStatus === 'none' || onboardingStatus === 'shown';
+      const alreadyBlocked = ['skip', 'skipped', 'complete', 'completed'].includes(onboardingStatus);
+      if (canComplete && !alreadyBlocked) {
+        await postOnboardingEvent({
+          key: onboardingMeta.key,
+          action: 'complete',
+          screen: 'store',
+          target: onboardingMeta.target
+        });
+      }
+    }
+    await refreshOnboardingState({ reason: `gift_claim_${normalizedReward}`, screen: 'store', resetCache: true });
     await loadPlayerUpgrades();
     updateStoreUI({ buyUpgrade });
     notifySuccess('✅ 24H gift activated');
@@ -170,6 +205,16 @@ function bindRadarGiftClickInterceptor(handlers) {
     const tierEl = event.target?.closest?.('.store-tier.is-gift-free[data-onboarding-gift]');
     if (!tierEl) return;
 
+    if (
+      tierEl.classList.contains('is-gift-pending')
+      || tierEl.classList.contains('is-gift-active')
+      || tierEl.dataset.giftClaimPending === 'true'
+    ) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
     event.preventDefault();
     event.stopImmediatePropagation();
 
@@ -181,12 +226,18 @@ function bindRadarGiftClickInterceptor(handlers) {
 
 export function applyRadarGiftStoreUi(onboardingState, handlers) {
   bindRadarGiftClickInterceptor(handlers);
+  lastOnboardingState = onboardingState || null;
   const gifts = onboardingState?.gifts || {};
   const activeBoosts = onboardingState?.activeBoosts || {};
 
   RADAR_GIFT_TIERS.forEach(({ reward, selectors }) => {
     const tierEl = selectors.map((selector) => document.querySelector(selector)).find(Boolean);
     if (!tierEl) return;
+
+    if (pendingGiftClaims.has(reward)) {
+      applyPendingClaimUi(reward);
+      return;
+    }
 
     const giftState = gifts[reward] || {};
     const boostState = activeBoosts[reward] || {};
@@ -197,9 +248,12 @@ export function applyRadarGiftStoreUi(onboardingState, handlers) {
 
     tierEl.classList.remove('is-gift-free', 'is-gift-active', 'is-gift-pending');
     delete tierEl.dataset.onboardingGift;
+    delete tierEl.dataset.giftClaimPending;
     delete tierEl.dataset.giftTimer;
     tierEl.style.pointerEvents = '';
+    tierEl.setAttribute('aria-disabled', 'false');
     tierEl.removeAttribute('aria-busy');
+    if ('disabled' in tierEl) tierEl.disabled = false;
 
     if (isGiftBoostActive) {
       tierEl.classList.add('is-gift-active');


### PR DESCRIPTION
### Motivation
- Prevent UI from reverting a pending FREE Radar gift back to an actionable FREE state while a claim is in-flight. 
- Prevent duplicate clicks and multiple POST /api/onboarding/claim requests for the same reward. 
- Ensure onboarding is completed and store UI is updated in the correct order after a successful claim.

### Description
- Updated `js/store/radar-gift-ui.js` to preserve pending state during `applyRadarGiftStoreUi()` by reapplying pending UI when `pendingGiftClaims.has(reward)` and skipping normal reset for that tier. 
- Hardened `applyPendingClaimUi()` to set `dataset.giftClaimPending = 'true'`, add `is-gift-pending`, set `aria-disabled`/`aria-busy`, block pointer events, set `disabled` where supported, and show price text `Activating...`. 
- Added a click-interceptor guard that blocks handling when an element is pending/active or `dataset.giftClaimPending === 'true'`. 
- Reordered claim flow in `handleGiftClaimAction()` so the UI is locked immediately, `POST /api/onboarding/claim` is awaited, then `applyImmediateClaimedUi()` is applied, then onboarding completion event is posted (when eligible via a reward->onboarding mapping), and only after that the onboarding state is refreshed and store data reloaded. 
- On failures, the handler restores FREE UI only when backend response explicitly indicates the gift is still available, otherwise it refreshes onboarding state instead of blindly re-enabling the card. 
- Added `lastOnboardingState` and `GIFT_ONBOARDING_BY_REWARD` mapping and imported `postOnboardingEvent` to support guarded onboarding completion posting.

### Testing
- Ran `npm run -s lint` and static checks which completed successfully. 
- Pre-commit automated checks (`check:syntax` and `check:static-analysis`) ran as part of the commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07103fd2dc8326a049c0a18851513a)