### PR TITLE
Fix onboarding spotlight flicker after +3 rides pack purchase

### DIFF
--- a/js/features/onboarding/index.js
+++ b/js/features/onboarding/index.js
@@ -23,6 +23,7 @@ let currentScreen = 'menu';
 let lastShownSignature = '';
 const dismissedOnboardingSteps = new Set();
 const pendingSkipSteps = new Set();
+let storeInOverlaySuppressedUntil = 0;
 
 const TARGET_SELECTOR_MAP = Object.freeze({
   start_game: '#startBtn',
@@ -130,6 +131,16 @@ function isOnboardingUiBlocked() {
   return false;
 }
 
+function isStoreInOverlaySuppressed() {
+  return Date.now() < Number(storeInOverlaySuppressedUntil || 0);
+}
+
+function suppressStoreInOverlay(durationMs = 1500) {
+  const ttl = Math.max(0, Number(durationMs || 0));
+  storeInOverlaySuppressedUntil = Date.now() + ttl;
+  hideSpotlight();
+  clearGameOverOnboardingHook();
+}
 
 function getHookText(active) {
   if (active?.hook) return String(active.hook);
@@ -210,6 +221,7 @@ function resolveActiveOnboardingForScreen(state, screen) {
     }
     const validatedBackend = validateActiveOnboarding(backendActive, backendActive.screen);
     if (validatedBackend && validatedBackend.screen === normalizedScreen) {
+      if (validatedBackend.key === 'store_in' && isStoreInOverlaySuppressed()) return null;
       return validatedBackend;
     }
   }
@@ -228,6 +240,7 @@ function resolveActiveOnboardingForScreen(state, screen) {
   });
 
   if (!candidate) return null;
+  if (candidate.key === 'store_in' && isStoreInOverlaySuppressed()) return null;
   return validateActiveOnboarding({
     key: candidate.key,
     screen: candidate.screen,
@@ -499,6 +512,9 @@ async function refreshOnboardingState({ reason = 'manual', screen = null, resetC
     if (backendSettled) pendingSkipSteps.delete(stepKey);
   }
   applyOnboardingUiState();
+  if (String(onboardingState?.onboarding?.store_in || '').toLowerCase() !== 'none') {
+    storeInOverlaySuppressedUntil = 0;
+  }
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent('ursas:onboarding-state-updated', {
       detail: { reason, screen: screen || currentScreen, state: { ...onboardingState } }
@@ -525,6 +541,14 @@ if (typeof window !== 'undefined') {
   window.addEventListener('ursas:ui-screen-changed', (event) => {
     if (event?.detail?.screen !== 'menu') unmountGiftIndicator();
   });
+  window.addEventListener('ursas:onboarding-store-purchase-pending', (event) => {
+    const activeKey = String(getOnboardingStateSnapshot()?.activeOnboarding?.key || '');
+    const key = String(event?.detail?.key || '');
+    const productKey = String(event?.detail?.productKey || '');
+    if (key === 'store_in' && (activeKey === 'store_in' || productKey === 'rides_pack')) {
+      suppressStoreInOverlay(1500);
+    }
+  });
 }
 async function initOnboardingFeature() {
   onboardingState = readCachedOnboardingState();
@@ -550,6 +574,7 @@ function getOnboardingStateSnapshot() {
 }
 
 async function completeStoreInOnboardingFromPurchase() {
+  suppressStoreInOverlay(1800);
   onboardingState = writeCachedOnboardingState({
     ...onboardingState,
     onboarding: { ...(onboardingState.onboarding || {}), store_in: 'complete' },

--- a/js/store/upgrades-service.js
+++ b/js/store/upgrades-service.js
@@ -238,7 +238,7 @@ async function completeStoreInOnboardingAfterRidesPackPurchase() {
   completingOnboardingKeys.add('store_in');
   try {
     const sent = await postOnboardingEvent({ key: 'store_in', action: 'complete', screen: 'store', target: 'ride_pack_plus3' });
-    if (sent) await completeStoreInOnboardingFromPurchase();
+    if (sent) { await completeStoreInOnboardingFromPurchase(); await refreshOnboardingState({ reason: 'store_in_complete_post_event', screen: 'store' }); }
   } finally { completingOnboardingKeys.delete('store_in'); }
 }
 export function resetUpgradeState() {
@@ -512,6 +512,11 @@ export function createUpgradesService({
           previousBalance,
           nextBalance: playerBalance
         });
+        if (key === 'rides_pack' && typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent('ursas:onboarding-store-purchase-pending', { detail: { key: 'store_in', target: 'ride_pack_plus3', productKey: 'rides_pack' } }));
+          await completeStoreInOnboardingAfterRidesPackPurchase();
+          await new Promise((resolve) => setTimeout(resolve, 300));
+        }
         await loadPlayerUpgrades();
         updateStoreUI({ buyUpgrade: (upgradeKey, upgradeTier) => buyUpgrade(upgradeKey, upgradeTier, { isStoreDataLoading }) });
         updateStoreBalanceElements(playerBalance);
@@ -520,7 +525,6 @@ export function createUpgradesService({
             detail: { upgradeKey: key, tier, timestamp: Date.now() }
           }));
         }
-        if (key === 'rides_pack') await completeStoreInOnboardingAfterRidesPackPurchase();
       } else {
         const failureDiagnostic = buildStoreBuyFailureDiagnostic({ status, data, authMode: isTelegramAuthMode() ? 'telegram' : 'wallet', primaryId: String(primaryId || identifier || '').trim(), telegramId: getTelegramAuthIdentifier(), hasTelegramInitData: Boolean(String(window.Telegram?.WebApp?.initData || '').trim()), hasWallet: Boolean(String(getAuthStateSnapshot()?.linkedWallet || '').trim()) });
         console.warn('[store-buy-failed]', failureDiagnostic);


### PR DESCRIPTION
### Motivation
- The onboarding dim/spotlight briefly reappeared after buying the +3 rides pack due to the store UI refresh running before the `store_in` onboarding completion. 
- The transient re-show during `loadPlayerUpgrades()` looked like a visual glitch and needed a small suppression/ordering fix so balance/rides still update correctly.

### Description
- For `rides_pack` purchases dispatch `ursas:onboarding-store-purchase-pending` immediately on success to signal onboarding suppression. 
- Reordered the success flow in `buyUpgrade` so `completeStoreInOnboardingAfterRidesPackPurchase()` runs (optimistically) before `loadPlayerUpgrades()`/`updateStoreUI()`, and added a `300ms` UX buffer. 
- Hardened `completeStoreInOnboardingAfterRidesPackPurchase()` to avoid duplicates via `completingOnboardingKeys`, apply local completion, and force an onboarding refresh (`refreshOnboardingState`). 
- Added onboarding-side suppression logic in `js/features/onboarding/index.js` including `suppressStoreInOverlay()` TTL, `isStoreInOverlaySuppressed()` checks, immediate `hideSpotlight()` on the pending event, and a listener for `ursas:onboarding-store-purchase-pending`. 
- Files changed: `js/store/upgrades-service.js` and `js/features/onboarding/index.js`.

### Testing
- Ran pre-commit syntax checks (`scripts/check-syntax.mjs`) which passed. 
- Ran static analysis checks (`scripts/check-static-analysis.mjs`) which passed. 
- Commit completed successfully with the pre-commit checks green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07105a8cec83268d422209223b91bd)