### PR TITLE
Fix adaptive tube curve scaling and disable early-run camera shake

### DIFF
--- a/js/game/adaptive-difficulty.js
+++ b/js/game/adaptive-difficulty.js
@@ -6,6 +6,8 @@ const ADAPTIVE_TIERS = Object.freeze({
   STANDARD: 'standard'
 });
 
+const degToRad = (deg) => deg * Math.PI / 180;
+
 function toFiniteNumber(value, fallback = NaN) {
   if (value === null || value === undefined || value === '') return fallback;
   const num = Number(value);
@@ -18,7 +20,7 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
   const standardProfile = {
     tier: ADAPTIVE_TIERS.STANDARD,
     obstacleDensityMultiplier: 1,
-    maxCurveAngleDeg: CONFIG.MAX_CURVE_ANGLE,
+    maxCurveAngleRad: CONFIG.MAX_CURVE_ANGLE,
     curveTransitionMultiplier: 1,
     centerOffsetMultiplier: 1,
     maxCurveStrength: 1,
@@ -46,13 +48,13 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
     return {
       tier,
       obstacleDensityMultiplier: isNewTier ? 0.65 : 0.84,
-      maxCurveAngleDeg: isNewTier ? 15 : 15,
+      maxCurveAngleRad: isNewTier ? degToRad(8) : degToRad(12),
       curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
-      centerOffsetMultiplier: isNewTier ? 0.3 : 0.35,
-      maxCurveStrength: isNewTier ? 0.4 : 0.45,
-      maxDirectionDelta: isNewTier ? Math.PI / 4 : Math.PI / 3,
-      minCurveTransitionDurationMs: isNewTier ? 11000 : 9500,
-      centerOffsetSmoothing: isNewTier ? 7 : 9,
+      centerOffsetMultiplier: isNewTier ? 0.12 : 0.2,
+      maxCurveStrength: isNewTier ? 0.28 : 0.38,
+      maxDirectionDelta: isNewTier ? Math.PI / 8 : Math.PI / 5,
+      minCurveTransitionDurationMs: isNewTier ? 16000 : 13000,
+      centerOffsetSmoothing: isNewTier ? 1.4 : 2.0,
       noDownwardTurns: true
     };
   }
@@ -60,13 +62,13 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
   return {
     tier,
     obstacleDensityMultiplier: isNewTier ? 0.5 : 0.7,
-    maxCurveAngleDeg: isNewTier ? 15 : 20,
+    maxCurveAngleRad: isNewTier ? degToRad(6) : degToRad(10),
     curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
-    centerOffsetMultiplier: isNewTier ? 0.25 : 0.4,
-    maxCurveStrength: isNewTier ? 0.35 : 0.5,
-    maxDirectionDelta: isNewTier ? Math.PI / 5 : Math.PI / 3,
-    minCurveTransitionDurationMs: isNewTier ? 12000 : 9500,
-    centerOffsetSmoothing: isNewTier ? 7 : 9,
+    centerOffsetMultiplier: isNewTier ? 0.08 : 0.18,
+    maxCurveStrength: isNewTier ? 0.22 : 0.35,
+    maxDirectionDelta: isNewTier ? Math.PI / 10 : Math.PI / 6,
+    minCurveTransitionDurationMs: isNewTier ? 18000 : 14000,
+    centerOffsetSmoothing: isNewTier ? 1.2 : 1.8,
     noDownwardTurns: true
   };
 }

--- a/js/physics.js
+++ b/js/physics.js
@@ -130,7 +130,7 @@ function update(delta) {
   const debugNow = Date.now();
   if (adaptiveDebugEnabled && (!gameState.lastAdaptiveDebugAtMs || debugNow - gameState.lastAdaptiveDebugAtMs >= 2000)) {
     gameState.lastAdaptiveDebugAtMs = debugNow;
-    logger.debug('adaptive_difficulty_profile', { completedRuns: gameState.adaptiveCompletedRuns, distance: Math.max(0, Number(gameState.distance) || 0), tier: adaptiveProfile.tier, obstacleDensityMultiplier: adaptiveProfile.obstacleDensityMultiplier, maxCurveAngleDeg: adaptiveProfile.maxCurveAngleDeg, curveTransitionMultiplier: adaptiveProfile.curveTransitionMultiplier, centerOffsetSmoothing: adaptiveProfile.centerOffsetSmoothing, noDownwardTurns: adaptiveProfile.noDownwardTurns });
+    logger.debug('adaptive_difficulty_profile', { completedRuns: gameState.adaptiveCompletedRuns, distance: Math.max(0, Number(gameState.distance) || 0), tier: adaptiveProfile.tier, obstacleDensityMultiplier: adaptiveProfile.obstacleDensityMultiplier, maxCurveAngleRad: adaptiveProfile.maxCurveAngleRad, maxCurveAngleDegForDebug: (Number(adaptiveProfile.maxCurveAngleRad) || 0) * 180 / Math.PI, centerOffsetMultiplier: adaptiveProfile.centerOffsetMultiplier, centerOffsetSmoothing: adaptiveProfile.centerOffsetSmoothing, minCurveTransitionDurationMs: adaptiveProfile.minCurveTransitionDurationMs, curveTransitionDuration: gameState.curveTransitionDuration });
   }
   const basePointsPerMeter = 1;
   const speedFactor = gameState.speed / CONFIG.SPEED_START;
@@ -351,15 +351,22 @@ function update(delta) {
   gameState.centerOffsetY += (constrainedCenterOffsetY - gameState.centerOffsetY) * centerOffsetLerp;
 
   // Camera shake from speed
-  const speedRatio = (gameState.speed - CONFIG.SPEED_START) / (CONFIG.SPEED_MAX - CONFIG.SPEED_START);
-  const shakeLerp = Math.min(1, delta * CAMERA_SHAKE_SMOOTHING);
-  const shakeIntensity = speedRatio > 0.3 ? (speedRatio - 0.3) * 4 : 0;
-  const shakeTargetX = (Math.random() - 0.5) * shakeIntensity;
-  const shakeTargetY = (Math.random() - 0.5) * shakeIntensity;
-  gameState.cameraShakeX += (shakeTargetX - gameState.cameraShakeX) * shakeLerp;
-  gameState.cameraShakeY += (shakeTargetY - gameState.cameraShakeY) * shakeLerp;
-  gameState.centerOffsetX += gameState.cameraShakeX;
-  gameState.centerOffsetY += gameState.cameraShakeY;
+  const adaptiveTier = adaptiveProfile.tier;
+  const suppressShake = adaptiveTier !== 'standard' && gameState.distance < 2000;
+  if (suppressShake) {
+    gameState.cameraShakeX = 0;
+    gameState.cameraShakeY = 0;
+  } else {
+    const speedRatio = (gameState.speed - CONFIG.SPEED_START) / (CONFIG.SPEED_MAX - CONFIG.SPEED_START);
+    const shakeLerp = Math.min(1, delta * CAMERA_SHAKE_SMOOTHING);
+    const shakeIntensity = speedRatio > 0.3 ? (speedRatio - 0.3) * 4 : 0;
+    const shakeTargetX = (Math.random() - 0.5) * shakeIntensity;
+    const shakeTargetY = (Math.random() - 0.5) * shakeIntensity;
+    gameState.cameraShakeX += (shakeTargetX - gameState.cameraShakeX) * shakeLerp;
+    gameState.cameraShakeY += (shakeTargetY - gameState.cameraShakeY) * shakeLerp;
+  }
+  gameState.renderCenterOffsetX = gameState.centerOffsetX + gameState.cameraShakeX;
+  gameState.renderCenterOffsetY = gameState.centerOffsetY + gameState.cameraShakeY;
   const collisionDepthMin = CONFIG.PLAYER_Z + CONFIG.TUBE_Z_STEP;
   const collisionDepthMax = CONFIG.PLAYER_Z + CONFIG.TUBE_Z_STEP * 2;
   const obstacleCollisionMin = collisionDepthMin - CONFIG.TUBE_Z_STEP * 0.2;
@@ -494,7 +501,11 @@ function update(delta) {
   const interp = (1 - Math.cos(Math.PI * t)) / 2;
   gameState.curveDirection = curves.current.direction * (1 - interp) + curves.next.direction * interp;
   gameState.tubeCurveStrength = curves.current.strength * (1 - interp) + curves.next.strength * interp;
-  gameState.tubeCurveAngle = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * adaptiveProfile.maxCurveAngleDeg;
+  const maxCurveAngleRad = Math.min(
+    CONFIG.MAX_CURVE_ANGLE,
+    Math.max(0, Number(adaptiveProfile.maxCurveAngleRad) || CONFIG.MAX_CURVE_ANGLE)
+  );
+  gameState.tubeCurveAngle = Math.cos(gameState.curveDirection) * gameState.tubeCurveStrength * maxCurveAngleRad;
 
   if (gameState.curveTimer >= gameState.curveTransitionDuration) {
     curves.current.direction = curves.next.direction;

--- a/js/render-snapshot.js
+++ b/js/render-snapshot.js
@@ -44,8 +44,8 @@ function createRenderSnapshot({ width, height, backend = 'phaser' }) {
       waveMod: gameState.tubeWaveMod,
       curveAngle: gameState.tubeCurveAngle,
       curveStrength: gameState.tubeCurveStrength,
-      centerOffsetX: gameState.centerOffsetX,
-      centerOffsetY: gameState.centerOffsetY,
+      centerOffsetX: Number.isFinite(gameState.renderCenterOffsetX) ? gameState.renderCenterOffsetX : gameState.centerOffsetX,
+      centerOffsetY: Number.isFinite(gameState.renderCenterOffsetY) ? gameState.renderCenterOffsetY : gameState.centerOffsetY,
       speed: gameState.speed,
       depthSteps: CONFIG.TUBE_DEPTH_STEPS,
       segments: CONFIG.TUBE_SEGMENTS

--- a/js/state.js
+++ b/js/state.js
@@ -40,6 +40,8 @@ import { CONFIG } from './config.js';
  * @property {number} centerOffsetY
  * @property {number} cameraShakeX
  * @property {number} cameraShakeY
+ * @property {number} renderCenterOffsetX
+ * @property {number} renderCenterOffsetY
  * @property {number} spinCooldownReduction
  * @property {number} invertScoreMultiplier
  * @property {boolean} radarActive
@@ -275,6 +277,8 @@ const gameState = {
   centerOffsetY: 0,
   cameraShakeX: 0,
   cameraShakeY: 0,
+  renderCenterOffsetX: 0,
+  renderCenterOffsetY: 0,
   spinCooldownReduction: 0,
   invertScoreMultiplier: 1.0,
 
@@ -428,6 +432,8 @@ function initializeGameplayRun({
   gameState.centerOffsetY = 0;
   gameState.cameraShakeX = 0;
   gameState.cameraShakeY = 0;
+  gameState.renderCenterOffsetX = 0;
+  gameState.renderCenterOffsetY = 0;
   gameState.lastTime = Number.isFinite(now) ? now : 0;
   gameState.lastObstacleDistance = 0;
   gameState.lastBonusDistance = 0;


### PR DESCRIPTION
### Motivation
- New-player adaptive profile produced `maxCurveAngleDeg` values (e.g. 15/20) that were mistakenly applied as radians, making tube curvature extremely strong and harder than standard mode.
- Camera shake was being added directly into `centerOffsetX/Y` each frame, which amplified perceived tube motion for early adaptive tiers and made runs unstable for new players.

### Description
- Renamed adaptive field and switched units by replacing `maxCurveAngleDeg` with `maxCurveAngleRad` and added `degToRad` conversion; updated early-tier profiles to radian values in `js/game/adaptive-difficulty.js`.
- Updated physics to compute curvature using a safe radian value with clamping: compute `maxCurveAngleRad` (clamped to `CONFIG.MAX_CURVE_ANGLE`) and use it when setting `gameState.tubeCurveAngle` in `js/physics.js`.
- Suppressed camera shake for non-standard adaptive tiers before 2000m and stopped mutating base center offsets by introducing `gameState.renderCenterOffsetX/Y` (render-only offsets) and exposing them in the render snapshot in `js/state.js` and `js/render-snapshot.js`.
- Added richer adaptive debug logging (throttled ~2s) to include `tier`, `distance`, `maxCurveAngleRad` and a debug-degree value plus center offset and transition parameters in `js/physics.js`.

### Testing
- Ran `npm run check:syntax` and it passed successfully.
- Ran `node --test scripts/difficulty-segmentation.test.mjs` and the tests passed.
- Ran static analysis via the repository checks (`npm run check:static-analysis`) during pre-commit and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0717cdc15483268a91838dc7f8eef7)