### PR TITLE
HUD multiplier icon -> lightning; soften new-player curve; shift tunnel outer ring +3px

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
         <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px 0px"></span></span><span class="value" id="shieldVal">✗</span></div>
         <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-56px 0px"></span></span><span class="value" id="magnetVal">OFF</span></div>
         <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -28px"></span></span><span class="value" id="invertVal">OK</span></div>
-        <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-28px -56px"></span></span><span class="value" id="multiplierVal">x1</span></div>
+        <div><span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -56px"></span></span><span class="value" id="multiplierVal">x1</span></div>
         <div style="border-top: 1px solid rgba(255,255,255,.06); margin-top: 5px; padding-top: 5px;">
           <span class="label"><span class="icon-atlas" style="width:28px;height:28px;background-size:140px auto;background-position:-84px -28px"></span></span><span class="value" id="spinVal">✓</span>
         </div>

--- a/js/game/adaptive-difficulty.js
+++ b/js/game/adaptive-difficulty.js
@@ -48,13 +48,13 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
     return {
       tier,
       obstacleDensityMultiplier: isNewTier ? 0.65 : 0.84,
-      maxCurveAngleRad: isNewTier ? degToRad(8) : degToRad(12),
+      maxCurveAngleRad: isNewTier ? degToRad(2.0) : degToRad(12),
       curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
-      centerOffsetMultiplier: isNewTier ? 0.12 : 0.2,
-      maxCurveStrength: isNewTier ? 0.28 : 0.38,
-      maxDirectionDelta: isNewTier ? Math.PI / 8 : Math.PI / 5,
-      minCurveTransitionDurationMs: isNewTier ? 16000 : 13000,
-      centerOffsetSmoothing: isNewTier ? 1.4 : 2.0,
+      centerOffsetMultiplier: isNewTier ? 0.04 : 0.2,
+      maxCurveStrength: isNewTier ? 0.12 : 0.38,
+      maxDirectionDelta: isNewTier ? Math.PI / 18 : Math.PI / 5,
+      minCurveTransitionDurationMs: isNewTier ? 17000 : 13000,
+      centerOffsetSmoothing: isNewTier ? 1.2 : 2.0,
       noDownwardTurns: true
     };
   }
@@ -62,13 +62,13 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
   return {
     tier,
     obstacleDensityMultiplier: isNewTier ? 0.5 : 0.7,
-    maxCurveAngleRad: isNewTier ? degToRad(6) : degToRad(10),
+    maxCurveAngleRad: isNewTier ? degToRad(1.5) : degToRad(10),
     curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
-    centerOffsetMultiplier: isNewTier ? 0.08 : 0.18,
-    maxCurveStrength: isNewTier ? 0.22 : 0.35,
-    maxDirectionDelta: isNewTier ? Math.PI / 10 : Math.PI / 6,
+    centerOffsetMultiplier: isNewTier ? 0.03 : 0.18,
+    maxCurveStrength: isNewTier ? 0.1 : 0.35,
+    maxDirectionDelta: isNewTier ? Math.PI / 20 : Math.PI / 6,
     minCurveTransitionDurationMs: isNewTier ? 18000 : 14000,
-    centerOffsetSmoothing: isNewTier ? 1.2 : 1.8,
+    centerOffsetSmoothing: isNewTier ? 1.1 : 1.8,
     noDownwardTurns: true
   };
 }

--- a/js/phaser/tunnel/TunnelOuterRing.js
+++ b/js/phaser/tunnel/TunnelOuterRing.js
@@ -26,6 +26,7 @@ const TUNNEL_OUTER_RING_INNER_RADIUS_X = LEGACY_RING_INNER_RADIUS * (TUNNEL_OUTE
 const TUNNEL_OUTER_RING_INNER_RADIUS_Y = LEGACY_RING_INNER_RADIUS * (TUNNEL_OUTER_RING_SOURCE_HEIGHT / LEGACY_RING_SOURCE_HEIGHT);
 const TUNNEL_OUTER_RING_FIT_SCALE = 1.0;
 const TUNNEL_OUTER_RING_VERTICAL_OFFSET = 17;
+const TUNNEL_OUTER_RING_HORIZONTAL_OFFSET = 3;
 const LIGHT_RING_BASE_ALPHA = 0.9;
 const LIGHT_RING_BRIGHT_MASK_ALPHA = 0.82;
 const LIGHT_RING_DIM_MASK_ALPHA = 0.82;
@@ -87,7 +88,7 @@ class TunnelOuterRing {
   }
 
   constructor(scene, config = {}) {
-    const centerX = scene.scale.width * 0.5;
+    const centerX = scene.scale.width * 0.5 + TUNNEL_OUTER_RING_HORIZONTAL_OFFSET;
     const centerY = scene.scale.height * 0.5 + TUNNEL_OUTER_RING_VERTICAL_OFFSET;
 
     this.scene = scene;
@@ -441,7 +442,7 @@ class TunnelOuterRing {
   }
 
   resize(width, height) {
-    const centerX = width * 0.5;
+    const centerX = width * 0.5 + TUNNEL_OUTER_RING_HORIZONTAL_OFFSET;
     const centerY = height * 0.5 + TUNNEL_OUTER_RING_VERTICAL_OFFSET;
     this.particleCenterX = centerX;
     this.particleCenterY = centerY;


### PR DESCRIPTION
### Motivation
- Replace the star icon next to the in-game multiplier with the lightning icon from `icon_atlas` to match product design while leaving other star usages untouched.
- Restore a very subtle, slow center drift for brand-new players so early runs feel less “dead” while keeping early mode no harder than standard. 
- Visually nudge the metallic outer tunnel ring 3px to the right to correct alignment without altering internal tunnel geometry.

### Description
- `index.html`: changed the multiplier HUD row (`#uiTopRight` / `#multiplierVal`) to use the lightning sprite from `icon_atlas` by updating the `background-position` only in that HUD row, leaving other icon usages intact. (file: `index.html`) 
- `js/game/adaptive-difficulty.js`: tuned the `new_0_6` adaptive profile to produce a very light, slow center drift while keeping `noDownwardTurns: true`; key parameter changes for `new_0_6` are: `0–1000m` -> `maxCurveAngleRad = degToRad(1.5)`, `1000–2000m` -> `maxCurveAngleRad = degToRad(2.0)`; also reduced `centerOffsetMultiplier`, `maxCurveStrength`, and `maxDirectionDelta`, increased `minCurveTransitionDurationMs` (long durations ~17–18s), and softened `centerOffsetSmoothing` to ensure very slow, smooth motion. (file: `js/game/adaptive-difficulty.js`) 
- `js/phaser/tunnel/TunnelOuterRing.js`: added `TUNNEL_OUTER_RING_HORIZONTAL_OFFSET = 3` and applied it to the ring placement in both constructor and `resize` so the metallic outer ring is rendered 3px to the right without touching inner tunnel geometry or other passes. (file: `js/phaser/tunnel/TunnelOuterRing.js`)
- Scope notes: changes are limited to gameplay HUD multiplier icon, the `new_0_6` adaptive tier behavior, and the outer ring overlay; standard difficulty and unrelated UI are unchanged.

### Testing
- Ran the production build with `npm run -s build` and the build completed successfully (dist produced). 
- Pre-commit/static checks executed as part of the workflow and passed (`check:syntax` and `check:static-analysis`).
- No automated test failures were observed during the build and static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07288a3d7483269ea354e321b3ef45)