### PR TITLE
Shift gift indicator 5px left and update to blue-themed styling

### DIFF
--- a/js/features/onboarding/gift-indicator.js
+++ b/js/features/onboarding/gift-indicator.js
@@ -7,17 +7,19 @@ function ensureStyles() {
   const style = document.createElement('style');
   style.id = 'onboardingGiftIndicatorStyles';
   style.textContent = `
-    #${GIFT_INDICATOR_ID}{position:fixed;top:138px;right:20px;z-index:9001;display:flex;flex-direction:column;gap:8px;align-items:flex-end;}
+    #${GIFT_INDICATOR_ID}{position:fixed;top:138px;right:25px;z-index:9001;display:flex;flex-direction:column;gap:8px;align-items:flex-end;}
     #${GIFT_INDICATOR_ID} .boost-indicator{height:34px;background:rgba(8,10,24,.32);border:1px solid rgba(255,255,255,.08);border-radius:999px;display:flex;align-items:center;gap:8px;padding:2px 8px 2px 4px;animation:none;cursor:default;pointer-events:none;}
     #${GIFT_INDICATOR_ID} .boost-indicator .boost-icon{width:28px;height:28px;display:flex;align-items:center;justify-content:center;background:transparent;border:none;border-radius:0;box-shadow:none;flex:0 0 28px;}
     #${GIFT_INDICATOR_ID} .boost-indicator .icon-atlas{width:24px;height:24px;display:inline-block;}
     #${GIFT_INDICATOR_ID} .boost-radar-obstacles .icon-atlas{filter:drop-shadow(0 0 6px rgba(59,130,246,.35));}
     #${GIFT_INDICATOR_ID} .boost-radar-gold .icon-atlas{filter:drop-shadow(0 0 6px rgba(168,85,247,.35));}
     #${GIFT_INDICATOR_ID} .boost-timer{font-size:13px;font-weight:800;color:#f8fafc;text-shadow:0 0 8px rgba(125,211,252,.35);letter-spacing:.02em;min-width:30px;text-align:left;}
-    #${GIFT_INDICATOR_ID} .gift-btn{width:42px;height:42px;border:0;border-radius:999px;padding:0;background:linear-gradient(135deg,#fbbf24,#f97316);box-shadow:0 0 0 0 rgba(251,191,36,.8);animation:giftPulse 1.6s infinite;cursor:pointer;display:flex;align-items:center;justify-content:center;}
+    #${GIFT_INDICATOR_ID} .gift-btn{width:42px;height:42px;border:0;border-radius:999px;padding:0;background:linear-gradient(180deg,#4da8ff 0%,#2f7bff 100%);box-shadow:0 0 0 0 rgba(77,168,255,.65),0 0 14px rgba(56,189,248,.32);animation:giftPulse 1.6s infinite;cursor:pointer;display:flex;align-items:center;justify-content:center;}
     #${GIFT_INDICATOR_ID} .gift-btn .icon-atlas.icon-gift{width:22px;height:22px;background-size:110px 88px;background-position:-66px -66px;filter:saturate(1.1) brightness(1.08);}
-    @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:132px;right:14px;}html.telegram-runtime #${GIFT_INDICATOR_ID},body.telegram-runtime #${GIFT_INDICATOR_ID}{top:128px;right:14px;}}
-    @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(251,191,36,.7)}70%{box-shadow:0 0 0 12px rgba(251,191,36,0)}100%{box-shadow:0 0 0 0 rgba(251,191,36,0)}}`;
+    #${GIFT_INDICATOR_ID} .gift-btn:hover{background:linear-gradient(180deg,#63b8ff 0%,#3b82f6 100%);box-shadow:0 0 0 0 rgba(99,184,255,.6),0 0 16px rgba(56,189,248,.4);}
+    #${GIFT_INDICATOR_ID} .gift-btn:active{background:linear-gradient(180deg,#4598f0 0%,#2c6ff0 100%);}
+    @media (max-width: 600px){#${GIFT_INDICATOR_ID}{top:132px;right:19px;}html.telegram-runtime #${GIFT_INDICATOR_ID},body.telegram-runtime #${GIFT_INDICATOR_ID}{top:128px;right:19px;}}
+    @keyframes giftPulse{0%{box-shadow:0 0 0 0 rgba(77,168,255,.58),0 0 14px rgba(56,189,248,.3)}70%{box-shadow:0 0 0 12px rgba(77,168,255,0),0 0 18px rgba(56,189,248,.08)}100%{box-shadow:0 0 0 0 rgba(77,168,255,0),0 0 14px rgba(56,189,248,.2)}}`;
   document.head.appendChild(style);
 }
 


### PR DESCRIPTION
### Motivation
- Исправить визуальную позицию HUD кнопки подарка, так как элемент слишком близко к правой границе. 
- Заменить конфликтный оранжевый фон на сине / cyan-палитру, чтобы лучше сочетаться с синей иконкой подарка и общим sci‑fi UI.
- Обеспечить одинаковое отображение в Web и Telegram вариантах интерфейса.

### Description
- Обновлён файл `js/features/onboarding/gift-indicator.js`, в функции `ensureStyles` изменены inline-стили индикатора. 
- Сдвинут контейнер HUD с `right:20px` на `right:25px` (desktop) и с `right:14px` на `right:19px` в `@media`/Telegram breakpoint, что даёт визуальный сдвиг всего кругового элемента на 5px влево. 
- Оранжевый фон кнопки заменён на сине‑cyan градиент `linear-gradient(180deg,#4da8ff 0%,#2f7bff 100%)`, добавлен мягкий голубой свечащий `box-shadow` и обновлён `giftPulse` анимационный glow в синих тонах. 
- Добавлены состояние `:hover` и `:active` с градиентами `#63b8ff→#3b82f6` и `#4598f0→#2c6ff0` соответственно, при этом внутренняя `icon-atlas.icon-gift` не менялась и её позиционирование сохранено.

### Testing
- Запущена проверка синтаксиса `npm run check:syntax`, результат — успешно (все файлы отмечены как валидные). 
- Выполнена статическая проверка через `node scripts/check-static-analysis.mjs`, результат — успешно (static analysis passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072f9850e8832693a806d6fcc8a30c)