### PR TITLE
Fix radar gift tier price restoration after gift claim

### DIFF
--- a/js/store/radar-gift-ui.js
+++ b/js/store/radar-gift-ui.js
@@ -90,6 +90,24 @@ async function claimOnboardingGiftReward(rewardKeyOrTarget) {
   }
 }
 
+
+function rememberOriginalPrice(tierEl) {
+  const priceEl = tierEl.querySelector('.store-tier-price');
+  if (!priceEl) return;
+  if (!tierEl.dataset.originalPriceHtml) {
+    tierEl.dataset.originalPriceHtml = priceEl.innerHTML;
+  }
+}
+
+function restoreOriginalPrice(tierEl) {
+  const priceEl = tierEl.querySelector('.store-tier-price');
+  if (!priceEl) return;
+  const originalHtml = tierEl.dataset.originalPriceHtml;
+  if (originalHtml) {
+    priceEl.innerHTML = originalHtml;
+  }
+}
+
 function applyPendingClaimUi(reward) {
   const tierConfig = RADAR_GIFT_TIERS.find((entry) => entry.reward === reward);
   if (!tierConfig) return;
@@ -126,7 +144,7 @@ function applyImmediateClaimedUi(reward, until) {
   tierEl.removeAttribute('aria-busy');
   if ('disabled' in tierEl) tierEl.disabled = true;
   const priceEl = tierEl.querySelector('.store-tier-price');
-  if (priceEl) priceEl.textContent = '';
+  if (priceEl) priceEl.innerHTML = '';
 }
 
 function restoreGiftAvailableUi(reward) {
@@ -144,7 +162,7 @@ function restoreGiftAvailableUi(reward) {
   tierEl.removeAttribute('aria-busy');
   if ('disabled' in tierEl) tierEl.disabled = false;
   const priceEl = tierEl.querySelector('.store-tier-price');
-  if (priceEl) priceEl.textContent = 'FREE 24H';
+  if (priceEl) priceEl.innerHTML = 'FREE 24H';
 }
 
 async function handleGiftClaimAction(rewardKeyOrTarget, handlers) {
@@ -246,6 +264,8 @@ export function applyRadarGiftStoreUi(onboardingState, handlers) {
     const isGiftAvailable = giftState.available === true && giftState.claimed !== true;
     const priceEl = tierEl.querySelector('.store-tier-price');
 
+    rememberOriginalPrice(tierEl);
+
     tierEl.classList.remove('is-gift-free', 'is-gift-active', 'is-gift-pending');
     delete tierEl.dataset.onboardingGift;
     delete tierEl.dataset.giftClaimPending;
@@ -259,17 +279,20 @@ export function applyRadarGiftStoreUi(onboardingState, handlers) {
       tierEl.classList.add('is-gift-active');
       tierEl.classList.remove('available');
       tierEl.dataset.giftTimer = giftTimerText;
-      if (priceEl) priceEl.textContent = '';
+      if (priceEl) priceEl.innerHTML = '';
       return;
     }
 
-    if (!isGiftAvailable) return;
+    if (!isGiftAvailable) {
+      restoreOriginalPrice(tierEl);
+      return;
+    }
 
     tierEl.classList.add('is-gift-free', 'available');
     tierEl.classList.remove('locked', 'purchased');
     tierEl.dataset.onboardingGift = reward;
     tierEl.style.pointerEvents = 'auto';
     tierEl.style.opacity = '';
-    if (priceEl) priceEl.textContent = 'FREE 24H';
+    if (priceEl) priceEl.innerHTML = 'FREE 24H';
   });
 }


### PR DESCRIPTION
### Motivation
- Claiming one radar gift could leave the other tier with an empty price because the code overwrote `.store-tier-price` without preserving its original markup. 
- The normal price may include icon markup, so using `textContent` and not restoring the original HTML caused visual regressions. 

### Description
- Add `rememberOriginalPrice(tierEl)` and `restoreOriginalPrice(tierEl)` helpers that save and restore the `.store-tier-price` element's `innerHTML` on the tier's `dataset.originalPriceHtml`. 
- Call `rememberOriginalPrice` for each tier in `applyRadarGiftStoreUi()` before any modifications, and call `restoreOriginalPrice` when a tier is neither active nor free. 
- Use `innerHTML` instead of `textContent` for gift UI changes and limit clearing of the price only to the active-gift branch so other tiers keep their original price. 
- Keep existing accessibility and pending/available state handling unchanged while preventing global clearing of prices. 

### Testing
- Ran a quick syntax check with `node --check js/store/radar-gift-ui.js` which succeeded. 
- Ran pre-commit checks including `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed. 
- No automated unit tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0730acc5b88326b8e73f8c794a14fe)