### PR TITLE
Apply Telegram-style lightweight main menu behavior to mobile web runtime

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -361,14 +361,37 @@ body.ui-stable #gameStart {
 
 body.is-telegram #gameStart .glow,
 body.telegram-mini-app #gameStart .glow,
+body.telegram-runtime #gameStart .glow,
+body.mobile-runtime #gameStart .glow,
+body.mobile-light-runtime #gameStart .glow,
 body.is-telegram #gameStart .eyes,
-body.telegram-mini-app #gameStart .eyes {
+body.telegram-mini-app #gameStart .eyes,
+body.telegram-runtime #gameStart .eyes,
+body.mobile-runtime #gameStart .eyes,
+body.mobile-light-runtime #gameStart .eyes {
   animation: none;
 }
 
 body.is-telegram #gameStart .particle,
-body.telegram-mini-app #gameStart .particle {
+body.telegram-mini-app #gameStart .particle,
+body.telegram-runtime #gameStart .particle,
+body.mobile-runtime #gameStart .particle,
+body.mobile-light-runtime #gameStart .particle {
   display: none;
+}
+
+body.mobile-light-runtime[data-screen="menu"] .glow,
+body.mobile-light-runtime[data-screen="menu"] .eyes,
+body.mobile-light-runtime[data-screen="menu"] .particle,
+body.mobile-light-runtime[data-screen="menu"] .start-transition-glow,
+body.mobile-light-runtime[data-screen="menu"] .start-transition-bear-wrapper,
+body.mobile-light-runtime[data-screen="menu"] .new-title,
+body.mobile-light-runtime[data-screen="menu"] .new-buttons,
+body.mobile-light-runtime[data-screen="menu"] .menu-wrap::before,
+body.mobile-light-runtime[data-screen="menu"] .menu-wrap::after {
+  animation: none !important;
+  transform: none !important;
+  transition: none !important;
 }
 
 .particle {

--- a/js/config.js
+++ b/js/config.js
@@ -93,11 +93,13 @@ const CONFIG = {
 const hasNavigator = typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string';
 const hasWindow = typeof window !== 'undefined' && Number.isFinite(window.innerWidth);
 const isMobileUserAgent = hasNavigator ? /Mobi|Android|iPhone/i.test(navigator.userAgent) : false;
-const isMobileViewport = hasWindow ? window.innerWidth < 600 : false;
-const isMobile = isMobileUserAgent || isMobileViewport;
+const isMobileViewport = hasWindow ? window.innerWidth <= 600 : false;
 const isTelegramRuntime = typeof window !== 'undefined'
   ? Boolean(window.Telegram?.WebApp?.initData || window.Telegram?.WebApp)
   : false;
+const isMobileWebRuntime = (isMobileUserAgent || isMobileViewport) && !isTelegramRuntime;
+const isMobileLightRuntime = isTelegramRuntime || isMobileWebRuntime;
+const isMobile = isMobileUserAgent || isMobileViewport;
 if (isMobile) {
   CONFIG.TUBE_SEGMENTS = 24;
   CONFIG.TUBE_DEPTH_STEPS = 60;
@@ -123,4 +125,13 @@ const BONUS_TYPES = {
   SCORE_MINUS_500: "score_minus_500"
 };
 
-export { BACKEND_URL, buildBackendUrl, WC_PROJECT_ID, CONFIG, BONUS_TYPES };
+export {
+  BACKEND_URL,
+  buildBackendUrl,
+  WC_PROJECT_ID,
+  CONFIG,
+  BONUS_TYPES,
+  isTelegramRuntime,
+  isMobileWebRuntime,
+  isMobileLightRuntime
+};

--- a/js/game-runtime.js
+++ b/js/game-runtime.js
@@ -3,6 +3,7 @@ import { initInputHandlers } from './input.js';
 import { initGame } from './game.js';
 import { initializeCoreLifecycle } from './core/runtime.js';
 import { logger } from './logger.js';
+import { isTelegramRuntime, isMobileWebRuntime, isMobileLightRuntime } from './config.js';
 import { setupPostHogBridge } from './posthog-bridge.js';
 import { setupTelegramAnalyticsBridge } from './telegram-analytics.js';
 
@@ -22,11 +23,34 @@ function initializeRuntimeDependencies() {
   setupTelegramAnalyticsBridge();
 }
 
+
+function applyRuntimeClasses() {
+  if (typeof document === 'undefined') return;
+
+  document.documentElement?.classList.toggle('mobile-runtime', isMobileWebRuntime);
+  document.documentElement?.classList.toggle('mobile-light-runtime', isMobileLightRuntime);
+  document.documentElement?.classList.toggle('telegram-runtime', isTelegramRuntime);
+
+  const applyToBody = () => {
+    document.body?.classList.toggle('mobile-runtime', isMobileWebRuntime);
+    document.body?.classList.toggle('mobile-light-runtime', isMobileLightRuntime);
+    document.body?.classList.toggle('telegram-runtime', isTelegramRuntime);
+  };
+
+  if (document.body) {
+    applyToBody();
+    return;
+  }
+
+  document.addEventListener('DOMContentLoaded', applyToBody, { once: true });
+}
+
 let gameBootstrapInitialized = false;
 
 function initGameBootstrap() {
   if (gameBootstrapInitialized) return;
 
+  applyRuntimeClasses();
   initializeRuntimeDependencies();
 
   onDomReady(() => {


### PR DESCRIPTION
### Motivation
- Mobile web was not receiving the same lightweight main-menu behavior as Telegram, causing heavy animations and visual work on small devices.
- The goal is to reduce visual load and disable expensive menu effects on regular mobile web while keeping desktop and Telegram behavior intact.

### Description
- Added shared runtime detection in `js/config.js`: `isTelegramRuntime`, `isMobileWebRuntime` (viewport `<= 600` or mobile UA but not Telegram), and `isMobileLightRuntime = isTelegramRuntime || isMobileWebRuntime`, and exported them for reuse.
- Applied runtime classes early in bootstrap in `js/game-runtime.js` by toggling `mobile-runtime`, `mobile-light-runtime`, and preserving `telegram-runtime` on both `<html>` and `<body>` so CSS can react immediately.
- Extended menu animation reduction rules in `css/style.css` to include `body.telegram-runtime`, `body.mobile-runtime`, and `body.mobile-light-runtime` selectors and added `mobile-light-runtime[data-screen="menu"]` rules to disable animated backgrounds, glows, particles, transforms and transitions on the main menu.
- Kept existing Telegram-specific runtime handling intact and limited changes to mobile-light runtime so core UI controls remain available.

### Testing
- Ran syntax and unit/request checks with `npm run -s check:syntax` and `npm run -s test:request`, both completed successfully.
- Pre-commit/static analysis checks executed as part of commit hooks and passed (`check:static-analysis`).
- All automated tests passed (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073ae6cf0c832694b2dd6523237844)