### PR TITLE
Fix mobile/Telegram audio loading and screen-scoped music behavior

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -29,9 +29,10 @@ const audioManager = {
   music: {},
   currentMusic: null,
   currentMusicName: null,
-  suspendedMusicName: null,
+  suspendedMusic: null,
   audioLocked: false,
   pendingMusicName: null,
+  currentScreen: 'menu',
   userGestureCaptured: false,
   retryUnlockHandlerAttached: false,
 
@@ -74,8 +75,26 @@ const audioManager = {
       duration: m?.duration,
       currentSrc: m?.currentSrc,
       error: m?.error?.message || m?.error?.code || null,
-      audioLocked: this.audioLocked
+      audioLocked: this.audioLocked,
+      currentScreen: this.currentScreen,
+      currentMusicName: this.currentMusicName,
+      pendingMusicName: this.pendingMusicName,
+      userGestureCaptured: this.userGestureCaptured,
+      musicEnabled: audioSettings.musicEnabled,
+      sfxEnabled: audioSettings.sfxEnabled
     });
+  },
+  getAllowedMusicForScreen(screen = this.currentScreen) {
+    if (screen === 'menu') return ['menu'];
+    if (screen === 'gameplay') return ['game1', 'game2', 'game3'];
+    return [];
+  },
+  setScreen(screen) {
+    this.currentScreen = screen;
+    if (screen !== 'gameplay' && this.currentMusicName && this.getAllowedMusicForScreen(screen).indexOf(this.currentMusicName) === -1) {
+      this.stopMusic();
+    }
+    this.ensureMusicForCurrentScreen();
   },
 
   attachRetryUnlockOnNextGesture() {
@@ -93,11 +112,27 @@ const audioManager = {
   markUserGesture() {
     this.userGestureCaptured = true;
     if (this.audioLocked && this.pendingMusicName) {
-      const pendingName = this.pendingMusicName;
+      const pending = this.pendingMusicName;
       this.pendingMusicName = null;
       this.audioLocked = false;
-      this.playMusic(pendingName);
+      if (pending?.screen === this.currentScreen) this.playMusic(pending.name);
     }
+  },
+  prepareMenuAudio() {
+    this.setScreen('menu');
+    this.preloadMenuMusic();
+    if (!this.isMobileAudioRuntime() && audioSettings.musicEnabled) this.playMusic('menu');
+  },
+  isMobileAudioRuntime() {
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent || '' : '';
+    const mobileUa = /Android|iPhone|iPad|iPod|Mobile/i.test(ua);
+    const narrowViewport = typeof window !== 'undefined' && Math.min(window.innerWidth || 0, window.innerHeight || 0) <= 900;
+    return mobileUa || narrowViewport || Boolean(window?.Telegram?.WebApp);
+  },
+  preloadMenuMusic() { try { this.music.menu?.load(); } catch (_e) {} },
+  preloadGameMusic() { ['game1', 'game2', 'game3'].forEach((n) => { try { this.music[n]?.load(); } catch (_e) {} }); },
+  preloadSfx() {
+    [...Object.values(this.sfx), ...Object.values(this.sfxPools).flat()].forEach((s) => { try { s.load(); } catch (_e) {} });
   },
 
   preloadMusic({ timeoutMs = 4000 } = {}) {
@@ -129,16 +164,18 @@ const audioManager = {
     this.markUserGesture();
     const tracks = [
       ...Object.entries(this.sfx),
-      ...Object.entries(this.music),
       ...Object.entries(this.sfxPools).flatMap(([name, pool]) => pool.map((track, index) => [`${name}#${index + 1}`, track]))
     ];
     for (const [name, track] of tracks) {
       const prevVolume = track.volume;
       try {
+        const prevMuted = track.muted;
         track.volume = 0;
+        track.muted = true;
         await track.play();
         track.pause();
         track.currentTime = 0;
+        track.muted = prevMuted;
         this.debug('unlock:ok', name, track);
       } catch (_error) {
         this.debug('unlock:fail', name, track);
@@ -146,6 +183,20 @@ const audioManager = {
         track.volume = prevVolume;
       }
     }
+    const allowed = this.getAllowedMusicForScreen();
+    const first = allowed[0];
+    if (first && this.music[first]) {
+      try {
+        const track = this.music[first];
+        track.volume = 0;
+        track.muted = true;
+        await track.play();
+        track.pause();
+        track.currentTime = 0;
+        track.muted = false;
+      } catch (_error) {}
+    }
+    this.ensureMusicForCurrentScreen();
   },
 
   ensureGameMusicReady({ timeoutMs = 800 } = {}) {
@@ -210,13 +261,13 @@ const audioManager = {
     m.currentTime = 0;
     this.currentMusic = m;
     this.currentMusicName = name;
-    this.suspendedMusicName = null;
+    this.suspendedMusic = null;
     if (!audioSettings.musicEnabled) return;
     const playPromise = m.play();
     if (playPromise && typeof playPromise.catch === 'function') {
       playPromise.catch(() => {
         this.audioLocked = true;
-        this.pendingMusicName = name;
+        this.pendingMusicName = { name, screen: this.currentScreen };
         this.debug('play:locked', name, m);
       });
     }
@@ -229,31 +280,33 @@ const audioManager = {
     }
     this.currentMusic = null;
     this.currentMusicName = null;
-    this.suspendedMusicName = null;
+    this.suspendedMusic = null;
   },
 
   suspendMusic() {
     if (this.currentMusic) {
       this.currentMusic.pause();
-      this.currentMusic.currentTime = 0;
-      this.suspendedMusicName = this.currentMusicName;
+      this.suspendedMusic = { name: this.currentMusicName, screen: this.currentScreen, currentTime: this.currentMusic.currentTime || 0 };
     }
   },
 
   resumeMusic() {
-    const nameToResume = this.suspendedMusicName || this.currentMusicName;
+    const nameToResume = this.suspendedMusic?.screen === this.currentScreen ? this.suspendedMusic?.name : this.currentMusicName;
     if (!nameToResume || !audioSettings.musicEnabled) return;
+    if (this.getAllowedMusicForScreen().indexOf(nameToResume) === -1) return;
     const music = this.music[nameToResume];
     if (!music) return;
     this.currentMusic = music;
     this.currentMusicName = nameToResume;
-    this.suspendedMusicName = null;
+    const resumeAt = this.suspendedMusic?.name === nameToResume ? this.suspendedMusic.currentTime : 0;
+    this.suspendedMusic = null;
     music.volume = 1;
-    music.currentTime = 0;
+    if (Number.isFinite(resumeAt) && resumeAt > 0) music.currentTime = resumeAt;
     music.play().catch(() => {});
   },
 
   playRandomGameMusic() {
+    if (this.currentScreen !== 'gameplay') return;
     const tracks = ['game1', 'game2', 'game3'];
     let pick;
     do { pick = tracks[Math.floor(Math.random() * tracks.length)]; }
@@ -265,6 +318,14 @@ const audioManager = {
     this.stopMusic();
     Object.values(this.sfx).forEach((s) => { s.pause(); s.currentTime = 0; });
     Object.values(this.sfxPools).forEach((pool) => pool.forEach((s) => { s.pause(); s.currentTime = 0; }));
+  },
+  ensureMusicForCurrentScreen() {
+    if (!audioSettings.musicEnabled) return;
+    const allowed = this.getAllowedMusicForScreen();
+    if (!allowed.length) return;
+    if (this.currentMusicName && allowed.indexOf(this.currentMusicName) !== -1 && this.currentMusic && !this.currentMusic.paused) return;
+    if (this.currentScreen === 'menu') this.playMusic('menu');
+    else if (this.currentScreen === 'gameplay') this.playRandomGameMusic();
   }
 };
 

--- a/js/core/runtime.js
+++ b/js/core/runtime.js
@@ -13,3 +13,11 @@ export {
   SCREEN_CHANGED_EVENT,
   SMOKE_STEP_COMPLETED_EVENT
 } from '../runtime-events.js';
+
+export function isMobileAudioRuntime() {
+  const hasTelegram = Boolean(window?.Telegram?.WebApp);
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent || '' : '';
+  const mobileUa = /Android|iPhone|iPad|iPod|Mobile/i.test(ua);
+  const narrowViewport = typeof window !== 'undefined' && Math.min(window.innerWidth || 0, window.innerHeight || 0) <= 900;
+  return hasTelegram || mobileUa || narrowViewport;
+}

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -6,7 +6,7 @@ import { updateGameOverLeaderboardNotice, getLeaderboardSnapshot } from '../ui.j
 import { loadPlayerUpgrades, updateRidesDisplay, resetStoreState, loadUnauthGameConfig, isStoreAvailable, isUnauthRuntimeMode } from '../features/store/index.js';
 import { perfMonitor } from '../perf.js';
 import { initAuth, isTelegramMiniApp, connectWalletAuth, disconnectAuth, hasWalletAuthSession, isWalletAuthMode, setAuthCallbacks, getAuthStateSnapshot, hideWalletButtonInTelegram } from '../features/auth/index.js';
-import { initializePingLifecycle, subscribeAppVisibilityLifecycle, SCREEN_CHANGED_EVENT } from '../core/runtime.js';
+import { initializePingLifecycle, subscribeAppVisibilityLifecycle, SCREEN_CHANGED_EVENT, isMobileAudioRuntime } from '../core/runtime.js';
 import { initializeTelegramIntegration } from './integrations/telegram.js';
 import { initializeMetaMaskIntegration } from './integrations/metamask.js';
 import { logger } from '../logger.js';
@@ -552,9 +552,13 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     updateRidesDisplay();
   }
 
-  audioManager.playMusic('menu');
-  if (isTelegramMiniApp()) {
-    audioManager.preloadMusic({ timeoutMs: 4000 }).catch(() => {});
+  audioManager.setScreen('menu');
+  audioManager.prepareMenuAudio();
+  audioManager.preloadSfx();
+  if (isMobileAudioRuntime()) {
+    audioManager.preloadMenuMusic();
+  } else {
+    audioManager.preloadGameMusic();
   }
   if (typeof prepareViewport === 'function') {
     prepareViewport();
@@ -565,6 +569,7 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
   window.addEventListener(SCREEN_CHANGED_EVENT, (event) => {
     hideWalletButtonInTelegram();
     const screen = event.detail?.screen;
+    audioManager.setScreen(screen);
     applyOnboardingForScreen(screen);
     if (screen === 'game-over') {
       invalidateProfileCache();

--- a/js/game/session.js
+++ b/js/game/session.js
@@ -50,6 +50,7 @@ function createGameSessionController({
   }
   function resetUiAfterRideFailure() {
     audioManager.stopSFX('gameover_screen');
+    audioManager.setScreen('menu');
     showMainMenuScreen();
     if (DOM.darkScreen) DOM.darkScreen.style.display = 'none'; updateRidesDisplay();
   }
@@ -232,6 +233,7 @@ function createGameSessionController({
       await renderFirstGameplayFrame();
       const firstGameplayFrameReadyAt = performance.now();
       showGameplayScreen();
+      audioManager.setScreen('gameplay');
       startGameplaySimulation(performance.now());
       const simulationStartedAt = performance.now();
       beginAiRun();
@@ -277,7 +279,7 @@ function createGameSessionController({
         runIndex: currentRunIndex,
         difficultySegment: getDifficultySegment(currentRunIndex),
       });
-      audioManager.playRandomGameMusic();
+      audioManager.ensureMusicForCurrentScreen();
       loopController.scheduleResizeStabilization();
       logger.info('[STARTUP PERF]', {
         clickToPreparingMs: Math.round(preparingStartedAt - startButtonClickedAt),
@@ -312,6 +314,7 @@ function createGameSessionController({
       }
     }
     logger.info('▶️ Starting game...');
+    audioManager.setScreen('gameplay');
     startTransitionInProgress = true;
     audioManager.stopAll();
     showMainMenuScreen();
@@ -370,6 +373,7 @@ function createGameSessionController({
   function endGame(reason = 'Unknown') {
     if (endGameInProgress) return;
     endGameInProgress = true;
+    audioManager.setScreen('game-over');
     finishAiRun();
     const { width: viewportW, height: viewportH } = getViewportDimensions();
     resetGameSessionState();
@@ -492,6 +496,7 @@ function createGameSessionController({
         trackAnalyticsEvent('game_over_insights_unavailable', { reason: 'no_wallet' });
       }
       showGameOverScreen();
+      audioManager.ensureMusicForCurrentScreen();
       maybeCelebrateMilestone({ dom: DOM, score: gameState.score, bestScoreBeforeRun, playerPosition: Number(getLeaderboardSnapshot()?.playerPosition || 0) });
       syncAllAudioUI();
       audioManager.playSFX('gameover_screen');
@@ -543,6 +548,7 @@ function createGameSessionController({
     audioManager.stopAll();
     stopMenuLaunchAnimation();
     showMainMenuScreen();
+    audioManager.setScreen('menu');
     refreshPlayerStatsAfterLatestSave();
     gameState.running = false;
     gameState.simulationRunning = false;
@@ -563,7 +569,7 @@ function createGameSessionController({
     gameState.spinProgress = 0;
     gameState.spinCooldown = 0;
     resetGameSessionState();
-    audioManager.playMusic('menu');
+    audioManager.ensureMusicForCurrentScreen();
     if (runStartedAt) { trackAnalyticsEvent('session_length', { seconds: Number(((Date.now() - runStartedAt) / 1000).toFixed(2)) }); runStartedAt = null; }
     if (hasWalletAuthSession() || isUnauthRuntimeMode()) loadPlayerRides().then(() => updateRidesDisplay());
     logger.info('✅ State reset');


### PR DESCRIPTION
### Motivation
- Mobile web and Telegram had inconsistent audio startup which caused menu music to fail to load or wrong game tracks and SFX to play on the main page.
- The global `unlockAudio()` and `preloadMusic()` flows could audibly trigger SFX/music or resume stale tracks after navigation or visibility changes.
- Music could disappear mid-run after visibility/focus changes because suspended/resume logic did not consider the current UI screen.

### Description
- Added explicit audio screen state to `audioManager` with `currentScreen` and `setScreen(screen)` and gated allowed tracks per-screen so menu and gameplay music cannot cross-play.
- Reworked pending/suspend state to include screen context so `pendingMusicName` is now `{ name, screen }` and suspended music stores `{ name, screen, currentTime }`, and resume only occurs when screens match.
- Replaced audible warmups with safe prewarm: `unlockAudio()` mutes/zeroes volume when playing for unlock and only prewarms the currently allowed music track, and added `preloadMenuMusic()`, `preloadGameMusic()`, and `preloadSfx()` which `load()` assets without forcing playback.
- Introduced `prepareMenuAudio()` and `ensureMusicForCurrentScreen()` to control menu startup and to restore appropriate music after unlock/visibility/screen changes, and added `isMobileAudioRuntime()` helper in `js/core/runtime.js` to align mobile web and Telegram behavior.
- Updated bootstrap and session flows to use `audioManager.setScreen(...)`, call `prepareMenuAudio()`/`preloadSfx()` at startup, and set the screen at transitions (`menu`, `gameplay`, `game-over`) so music is started/stopped deterministically.

### Testing
- Imported `js/audio.js` with `node -e "import('./js/audio.js')..."` to validate module load, which succeeded.
- Pre-commit hooks ran and `check:syntax` completed successfully.
- Static analysis (`check:static-analysis`) ran and passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073b0b70f0832694ee0a872bb14f89)