### PR TITLE
Unify audio/music toggle icons across web, mobile web, and Telegram

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2337,6 +2337,30 @@ footer a:hover { color: #e0b0ff; }
   vertical-align: middle;
   flex-shrink: 0;
 }
+
+
+.audio-toggle-icon {
+  width: 24px;
+  height: 24px;
+  display: inline-block;
+  background-image: none;
+  background-size: 24px 24px;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.icon-sfx-on {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23e2e8f0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 5 6 9H3v6h3l5 4z'/%3E%3Cpath d='M15.5 8.5a5 5 0 0 1 0 7'/%3E%3Cpath d='M18.5 6a9 9 0 0 1 0 12'/%3E%3C/svg%3E");
+}
+.icon-sfx-off {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ef4444' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 5 6 9H3v6h3l5 4z'/%3E%3Cpath d='m16 9 5 5'/%3E%3Cpath d='m21 9-5 5'/%3E%3C/svg%3E");
+}
+.icon-music-on {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23e2e8f0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18V6l11-2v12'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Ccircle cx='17' cy='16' r='3'/%3E%3C/svg%3E");
+}
+.icon-music-off {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ef4444' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 18V6l11-2v12'/%3E%3Ccircle cx='6' cy='18' r='3'/%3E%3Ccircle cx='17' cy='16' r='3'/%3E%3Cpath d='m3 3 18 18'/%3E%3C/svg%3E");
+}
 /* === Icon atlas: unified 32px grid with scaling === */
 .icon32 {
   width: 32px;

--- a/index.html
+++ b/index.html
@@ -137,8 +137,8 @@
       </div>
 
       <div class="game-audio-nav" aria-label="In-game audio controls">
-        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameSfxBtn" data-action="toggle-sfx" title="Sound Effects"><span class="icon-atlas audio-toggle-icon icon-sfx-on" aria-hidden="true"></span></button>
+        <button class="game-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="gameMusicBtn" data-action="toggle-music" title="Music"><span class="icon-atlas audio-toggle-icon icon-music-on" aria-hidden="true"></span></button>
       </div>
 
     </div>
@@ -149,8 +149,8 @@
 <div id="gameStart">
 
   <div class="start-audio-nav app-fixed-nav">
-    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startSfxBtn" data-action="toggle-sfx" title="Sound Effects"><span class="icon-atlas audio-toggle-icon icon-sfx-on" aria-hidden="true"></span></button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="startMusicBtn" data-action="toggle-music" title="Music"><span class="icon-atlas audio-toggle-icon icon-music-on" aria-hidden="true"></span></button>
   </div>
 
   <div class="bear-wrapper" id="bear3d">
@@ -218,8 +218,8 @@
 
   <!-- Game Over audio toggles (same style as Store) -->
   <div class="go-audio-nav app-fixed-nav">
-    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="goSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="goMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="goSfxBtn" data-action="toggle-sfx" title="Sound Effects"><span class="icon-atlas audio-toggle-icon icon-sfx-on" aria-hidden="true"></span></button>
+    <button class="app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="goMusicBtn" data-action="toggle-music" title="Music"><span class="icon-atlas audio-toggle-icon icon-music-on" aria-hidden="true"></span></button>
   </div>
   <div id="goConfettiLayer" class="go-confetti-layer" aria-hidden="true"></div>
 
@@ -366,8 +366,8 @@
 
   <!-- Fixed nav: sfx, music, back -->
   <div class="store-fixed-nav app-fixed-nav">
-    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeSfxBtn" data-action="toggle-sfx" title="Sound Effects"><span class="icon-atlas audio-toggle-icon icon-sfx-on" aria-hidden="true"></span></button>
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeMusicBtn" data-action="toggle-music" title="Music"><span class="icon-atlas audio-toggle-icon icon-music-on" aria-hidden="true"></span></button>
     <button class="store-nav-btn app-nav-btn app-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="storeBackBtn" title="Back">←</button>
   </div>
 
@@ -728,8 +728,8 @@
 <!-- ===== RULES OVERLAY ===== -->
 <div id="rulesScreen">
   <div class="rules-fixed-nav app-fixed-nav">
-    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesSfxBtn" data-action="toggle-sfx" title="Sound Effects">🔊</button>
-    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesMusicBtn" data-action="toggle-music" title="Music">🎵</button>
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesSfxBtn" data-action="toggle-sfx" title="Sound Effects"><span class="icon-atlas audio-toggle-icon icon-sfx-on" aria-hidden="true"></span></button>
+    <button class="store-nav-btn app-nav-btn app-audio-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesMusicBtn" data-action="toggle-music" title="Music"><span class="icon-atlas audio-toggle-icon icon-music-on" aria-hidden="true"></span></button>
     <button class="store-nav-btn app-nav-btn app-back-btn ui-btn ui-btn--icon ui-btn--ghost" id="rulesBackBtn" title="Back">←</button>
   </div>
 

--- a/js/audio.js
+++ b/js/audio.js
@@ -271,16 +271,16 @@ const audioManager = {
 const audioSettings = { sfxEnabled: true, musicEnabled: true };
 
 const AUDIO_TOGGLE_BUTTONS = Object.freeze([
-  { id: 'storeSfxBtn', setting: 'sfxEnabled', enabledIcon: '🔊', disabledIcon: '🔇', toggle: toggleSfxMute },
-  { id: 'storeMusicBtn', setting: 'musicEnabled', enabledIcon: '🎵', disabledIcon: '🔇', toggle: toggleMusicMute },
-  { id: 'gameSfxBtn', setting: 'sfxEnabled', enabledIcon: '🔊', disabledIcon: '🔇', toggle: toggleSfxMute },
-  { id: 'gameMusicBtn', setting: 'musicEnabled', enabledIcon: '🎵', disabledIcon: '🔇', toggle: toggleMusicMute },
-  { id: 'startSfxBtn', setting: 'sfxEnabled', enabledIcon: '🔊', disabledIcon: '🔇', toggle: toggleSfxMute },
-  { id: 'startMusicBtn', setting: 'musicEnabled', enabledIcon: '🎵', disabledIcon: '🔇', toggle: toggleMusicMute },
-  { id: 'goSfxBtn', setting: 'sfxEnabled', enabledIcon: '🔊', disabledIcon: '🔇', toggle: toggleSfxMute },
-  { id: 'goMusicBtn', setting: 'musicEnabled', enabledIcon: '🎵', disabledIcon: '🔇', toggle: toggleMusicMute },
-  { id: 'rulesSfxBtn', setting: 'sfxEnabled', enabledIcon: '🔊', disabledIcon: '🔇', toggle: toggleSfxMute },
-  { id: 'rulesMusicBtn', setting: 'musicEnabled', enabledIcon: '🎵', disabledIcon: '🔇', toggle: toggleMusicMute }
+  { id: 'storeSfxBtn', setting: 'sfxEnabled', onClass: 'icon-sfx-on', offClass: 'icon-sfx-off', onLabel: 'SFX on', offLabel: 'SFX muted', toggle: toggleSfxMute },
+  { id: 'storeMusicBtn', setting: 'musicEnabled', onClass: 'icon-music-on', offClass: 'icon-music-off', onLabel: 'Music on', offLabel: 'Music muted', toggle: toggleMusicMute },
+  { id: 'gameSfxBtn', setting: 'sfxEnabled', onClass: 'icon-sfx-on', offClass: 'icon-sfx-off', onLabel: 'SFX on', offLabel: 'SFX muted', toggle: toggleSfxMute },
+  { id: 'gameMusicBtn', setting: 'musicEnabled', onClass: 'icon-music-on', offClass: 'icon-music-off', onLabel: 'Music on', offLabel: 'Music muted', toggle: toggleMusicMute },
+  { id: 'startSfxBtn', setting: 'sfxEnabled', onClass: 'icon-sfx-on', offClass: 'icon-sfx-off', onLabel: 'SFX on', offLabel: 'SFX muted', toggle: toggleSfxMute },
+  { id: 'startMusicBtn', setting: 'musicEnabled', onClass: 'icon-music-on', offClass: 'icon-music-off', onLabel: 'Music on', offLabel: 'Music muted', toggle: toggleMusicMute },
+  { id: 'goSfxBtn', setting: 'sfxEnabled', onClass: 'icon-sfx-on', offClass: 'icon-sfx-off', onLabel: 'SFX on', offLabel: 'SFX muted', toggle: toggleSfxMute },
+  { id: 'goMusicBtn', setting: 'musicEnabled', onClass: 'icon-music-on', offClass: 'icon-music-off', onLabel: 'Music on', offLabel: 'Music muted', toggle: toggleMusicMute },
+  { id: 'rulesSfxBtn', setting: 'sfxEnabled', onClass: 'icon-sfx-on', offClass: 'icon-sfx-off', onLabel: 'SFX on', offLabel: 'SFX muted', toggle: toggleSfxMute },
+  { id: 'rulesMusicBtn', setting: 'musicEnabled', onClass: 'icon-music-on', offClass: 'icon-music-off', onLabel: 'Music on', offLabel: 'Music muted', toggle: toggleMusicMute }
 ]);
 
 /* ===== AUDIO TOGGLE SYSTEM ===== */
@@ -320,12 +320,16 @@ function toggleSfxMute() { setSfxEnabled(!audioSettings.sfxEnabled); }
 function toggleMusicMute() { setMusicEnabled(!audioSettings.musicEnabled); }
 
 function syncAllAudioUI() {
-  AUDIO_TOGGLE_BUTTONS.forEach(({ id, setting, enabledIcon, disabledIcon }) => {
+  AUDIO_TOGGLE_BUTTONS.forEach(({ id, setting, onClass, offClass, onLabel, offLabel }) => {
     const button = document.getElementById(id);
     if (!button) return;
 
     const isEnabled = audioSettings[setting];
-    button.textContent = isEnabled ? enabledIcon : disabledIcon;
+    const iconClass = isEnabled ? onClass : offClass;
+    const label = isEnabled ? onLabel : offLabel;
+    button.innerHTML = `<span class="icon-atlas audio-toggle-icon ${iconClass}" aria-hidden="true"></span>`;
+    button.setAttribute('aria-label', label);
+    button.setAttribute('title', label);
     button.classList.toggle('muted', !isEnabled);
   });
 }


### PR DESCRIPTION
### Motivation
- Mobile and Telegram rendered emoji differently from desktop, producing inconsistent audio toggle visuals; the UI should use a stable, project-controlled icon instead of emoji glyphs.
- Audio toggle buttons across screens (`store*`, `game*`, `start*`, `go*`, `rules*`) must show identical icons and accessible labels on all runtimes.

### Description
- Replaced emoji-based toggle rendering in `js/audio.js` by switching from `button.textContent = ...` to `button.innerHTML = `<span class="icon-atlas audio-toggle-icon ${iconClass}" aria-hidden="true"></span>``, and added per-state `aria-label` and `title` updates. (`js/audio.js`)
- Standardized runtime classes for states: `icon-sfx-on` / `icon-sfx-off` and `icon-music-on` / `icon-music-off`, and kept `button.classList.toggle('muted', !isEnabled)` behavior. (`js/audio.js`)
- Updated markup in `index.html` for all audio buttons to remove emoji and include the initial icon span so markup is consistent at load time. (`index.html`)
- Added `.audio-toggle-icon` sizing (24×24) and icon classes to `css/style.css`, implementing inline SVG background images as a fallback because the existing `public/assets/icon_atlas_map.json` has no dedicated SFX/music frames; the classes still use `icon-atlas` for consistent button markup. (`css/style.css`)

### Testing
- Ran the repository syntax check via `npm run check:syntax` which executed `node scripts/check-syntax.mjs` and passed. (success)
- Attempted `npm run check-syntax` (missing script) which failed due to script name mismatch. (expected failure)
- Pre-commit hooks ran during the change and executed `check:syntax` and `check:static-analysis` as part of the commit flow, both of which completed successfully. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073f45b3d483269d3bbb1f20a60044)