### PR TITLE
Player menu: show income-only coin history and exclude spendings

### DIFF
--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -70,16 +70,36 @@ function buildReferralSuccessMessage(data) {
 const COIN_HISTORY_TYPE_LABELS = {
   share: 'Share result',
   share_reward: 'Share result',
-  ride: 'Ride',
-  buy: 'Purchase reward',
-  purchase_reward: 'Purchase reward',
   referral: 'Referral bonus',
   referral_bonus: 'Referral bonus',
   refer: 'Friend joined',
   onboarding_bonus: 'Onboarding bonus',
   onboarding: 'Onboarding bonus',
-  task: 'Task'
+  task: 'Task',
+  race_reward: 'Race reward',
+  game_reward: 'Game reward'
 };
+
+const INCOME_HISTORY_TYPES = new Set([
+  'share',
+  'share_reward',
+  'referral',
+  'referral_bonus',
+  'refer',
+  'task',
+  'onboarding_bonus',
+  'onboarding',
+  'race_reward',
+  'game_reward'
+]);
+
+const EXCLUDED_HISTORY_TYPES = new Set([
+  'buy',
+  'ride',
+  'purchase',
+  'store_purchase',
+  'upgrade_purchase'
+]);
 
 function escapeHtml(value) {
   return String(value)
@@ -94,7 +114,7 @@ function escapeHtml(value) {
 function toPositiveNumber(value) {
   const num = Number(value);
   if (!Number.isFinite(num)) return 0;
-  return Math.max(0, Math.abs(Math.trunc(num)));
+  return Math.max(0, Math.trunc(num));
 }
 
 function pickCoinAmount(entry, keys = []) {
@@ -139,7 +159,16 @@ function renderCoinHistory(history, options = {}) {
   if (!tbody) return;
 
   const { loadFailed = false } = options;
-  const rows = Array.isArray(history) ? history : [];
+  const rows = (Array.isArray(history) ? history : []).filter((entry) => {
+    const typeKey = String(entry?.type || entry?.rewardType || '').toLowerCase();
+    const direction = String(entry?.direction || '').toLowerCase();
+    if (EXCLUDED_HISTORY_TYPES.has(typeKey)) return false;
+    const allowedByType = INCOME_HISTORY_TYPES.has(typeKey);
+    const allowedByDirection = direction === 'income';
+    if (!allowedByType && !allowedByDirection) return false;
+    const { gold, silver } = resolveEntryCoins(entry);
+    return gold > 0 || silver > 0;
+  });
   if (!rows.length) {
     const emptyMessage = loadFailed ? 'Could not load history' : 'No rewards yet';
     tbody.innerHTML = `<tr><td colspan="3" class="pm-history-empty">${emptyMessage}</td></tr>`;


### PR DESCRIPTION
### Motivation
- Player Menu was displaying spending/purchase transactions as positive entries, which should not be visible to players in the rewards view.  
- The menu should show only positive income/accrual events (share, referral, onboarding, task, race/game rewards, etc.) and never flip negative deltas to positive values.

### Description
- Added an explicit frontend allowlist `INCOME_HISTORY_TYPES` and denylist `EXCLUDED_HISTORY_TYPES` and used them to filter history entries in `renderCoinHistory()` in `js/player-menu/controller.js`.  
- Updated `renderCoinHistory()` to keep entries only when the entry is an allowed income type or `direction === 'income'`, and only when `gold > 0` or `silver > 0`.  
- Removed `Math.abs` from `toPositiveNumber()` so negative coin deltas are no longer shown as positive values and now use `Math.max(0, Math.trunc(num))`.  
- Adjusted `COIN_HISTORY_TYPE_LABELS` to remove purchase-as-reward labels and added `race_reward` and `game_reward` labels.

### Testing
- Ran pre-commit checks which include `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.  
- Verified the code committed successfully (`git commit` pre-commit hooks passed).  
- Note: Backend route/model changes and backend tests were not modified here because the backend repo was not present in the current workspace, so server-side filters/tests were not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074344d4a08326af4d8aa7351c506c)