### PR TITLE
Fix Telegram runtime detection hiding Connect Wallet button on web

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     (function () {
       try {
         var isTelegram =
-          !!(window.Telegram && window.Telegram.WebApp) ||
+          Boolean(window.Telegram?.WebApp?.initData) ||
           /Telegram/i.test(navigator.userAgent || '') ||
           new URLSearchParams(location.search).has('tgWebAppData');
 
@@ -50,7 +50,7 @@
   <script>
     (() => {
       const isTelegramRuntime =
-        Boolean(window.Telegram?.WebApp) ||
+        Boolean(window.Telegram?.WebApp?.initData) ||
         /Telegram/i.test(navigator.userAgent || '') ||
         new URLSearchParams(location.search).has('tgWebAppData');
       window.__URSASS_IS_TELEGRAM_RUNTIME__ = isTelegramRuntime;

--- a/js/config.js
+++ b/js/config.js
@@ -95,7 +95,7 @@ const hasWindow = typeof window !== 'undefined' && Number.isFinite(window.innerW
 const isMobileUserAgent = hasNavigator ? /Mobi|Android|iPhone/i.test(navigator.userAgent) : false;
 const isMobileViewport = hasWindow ? window.innerWidth <= 600 : false;
 const isTelegramRuntime = typeof window !== 'undefined'
-  ? Boolean(window.Telegram?.WebApp?.initData || window.Telegram?.WebApp)
+  ? Boolean(window.Telegram?.WebApp?.initData)
   : false;
 const isMobileWebRuntime = (isMobileUserAgent || isMobileViewport) && !isTelegramRuntime;
 const isMobileLightRuntime = isTelegramRuntime || isMobileWebRuntime;


### PR DESCRIPTION
### Motivation
- Prevent regular web sessions from being misclassified as Telegram runtime which caused the `Connect Wallet` button to be hidden after page load due to Telegram-only UI logic.

### Description
- Update runtime detection in `index.html` to require real Telegram Mini App init data by checking `window.Telegram?.WebApp?.initData` instead of the mere presence of `window.Telegram.WebApp`.
- Mirror the same stricter check in `js/config.js` so runtime flags and layout branches (including wallet UI hiding) are not applied for normal browser sessions.

### Testing
- Ran `npm run check:syntax` (the repository script `check:syntax`) and it completed successfully with no syntax errors.
- Pre-commit static analysis (`check:static-analysis`) ran as part of the commit hooks and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bfd2a5508326b76a8fca0e5f9694)