### PR TITLE
Stop all music tracks when stopping music

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -274,10 +274,10 @@ const audioManager = {
   },
 
   stopMusic() {
-    if (this.currentMusic) {
-      this.currentMusic.pause();
-      this.currentMusic.currentTime = 0;
-    }
+    Object.values(this.music).forEach((track) => {
+      track.pause();
+      track.currentTime = 0;
+    });
     this.currentMusic = null;
     this.currentMusicName = null;
     this.suspendedMusic = null;


### PR DESCRIPTION
### Motivation
- На главной странице включённая музыка могла продолжать играть при переходе на другие экраны, потому что `audioManager.stopMusic()` останавливала только `currentMusic`, оставляя другие треки активными.

### Description
- В `js/audio.js` изменено поведение `audioManager.stopMusic()` — теперь метод выполняет `pause()` и `currentTime = 0` для всех треков в `this.music`, после чего очищаются `currentMusic`, `currentMusicName` и `suspendedMusic`.

### Testing
- Запущены автоматические проверки `npm run -s check:syntax` и статический анализ `check:static-analysis`, оба прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c36ef14c8326a83c222a323e1a57)