### PR TITLE
Fix intermittent disappearance of player menu coin history

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -482,21 +482,20 @@ async function fetchMyProfile() {
 async function fetchCoinHistory(limit = 50) {
   const primaryId = getPrimaryAuthIdentifier();
   if (!primaryId) return [];
-  try {
-    const url = `${BACKEND_URL}/api/account/me/coin-history?limit=${encodeURIComponent(limit)}`;
-    const { ok, data } = await requestJsonResult(url, {
-      ...REQUEST_PROFILE_LEADERBOARD_READ,
-      headers: buildAuthHeaders()
-    });
-    if (!ok) return [];
-    if (Array.isArray(data)) return data;
-    if (Array.isArray(data?.history)) return data.history;
-    if (Array.isArray(data?.items)) return data.items;
-    return [];
-  } catch (e) {
-    logger.warn('⚠️ fetchCoinHistory error:', e);
-    return [];
+  const url = `${BACKEND_URL}/api/account/me/coin-history?limit=${encodeURIComponent(limit)}`;
+  const { ok, data } = await requestJsonResult(url, {
+    ...REQUEST_PROFILE_LEADERBOARD_READ,
+    headers: buildAuthHeaders()
+  });
+  if (!ok) {
+    const error = new Error('Failed to fetch coin history');
+    error.status = data?.status;
+    throw error;
   }
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.history)) return data.history;
+  if (Array.isArray(data?.items)) return data.items;
+  return [];
 }
 
 async function startShare() {

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -109,6 +109,18 @@ function escapeHtml(value) {
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
 }
+function ensureHistoryTemplate() {
+  const overlay = DOM.playerMenuOverlay;
+  if (!overlay) return null;
+  if (!overlay.querySelector('.pm-history')) {
+    const center = overlay.querySelector('.pm-center');
+    if (!center) return null;
+    center.insertAdjacentHTML('beforeend', '<section class="pm-history" aria-label="Coin rewards history"><div class="pm-history-title">History</div><div class="pm-history-table-wrap"><table class="pm-history-table"><thead><tr><th>Source</th><th>Gold</th><th>Silver</th></tr></thead><tbody id="pmHistoryBody"><tr><td colspan="3" class="pm-history-empty">No rewards yet</td></tr></tbody></table></div></section>');
+  }
+  const tbody = overlay.querySelector('#pmHistoryBody');
+  if (tbody && DOM.pmHistoryBody !== tbody) DOM.pmHistoryBody = tbody;
+  return tbody;
+}
 
 
 function toPositiveNumber(value) {
@@ -155,7 +167,7 @@ function resolveEntryCoins(entry) {
 }
 
 function renderCoinHistory(history, options = {}) {
-  const tbody = DOM.pmHistoryBody;
+  const tbody = DOM.pmHistoryBody || ensureHistoryTemplate();
   if (!tbody) return;
 
   const { loadFailed = false } = options;
@@ -281,8 +293,6 @@ function updateWalletBlock(profile) {
     btn.classList.remove('pm-side-btn--connected');
   }
 }
-
-
 function applyResponsivePlayerMenuLayout() {
   const xBlock = DOM.pmXBlock;
   if (!xBlock) return;
@@ -339,11 +349,7 @@ function fillProfileData(profile) {
 }
 
 async function loadProfile() {
-  console.info('Player menu history nodes', {
-    historySection: document.querySelector('.pm-history'),
-    body: document.getElementById('pmHistoryBody')
-  });
-
+  ensureHistoryTemplate();
   const [profileResult, coinHistoryResult] = await Promise.allSettled([
     fetchMyProfile(),
     fetchCoinHistory(50)

--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -565,8 +565,12 @@ async function openPlayerMenu() {
 
 async function refreshCoinHistory() {
   if (!menuOpen) return;
-  const coinHistory = await fetchCoinHistory(50);
-  renderCoinHistory(coinHistory);
+  try {
+    const coinHistory = await fetchCoinHistory(50);
+    renderCoinHistory(coinHistory);
+  } catch (_error) {
+    renderCoinHistory([], { loadFailed: true });
+  }
 }
 
 function closePlayerMenu() {


### PR DESCRIPTION
### Motivation
- The player menu history could intermittently show as empty because transient API/auth/network failures were swallowed and treated as a successful empty result.

### Description
- Make `fetchCoinHistory` in `js/api.js` throw when the backend response is not `ok` instead of returning an empty array, so failures are observable by callers.
- Harden `refreshCoinHistory` in `js/player-menu/controller.js` with a `try/catch` that renders the explicit error state via `renderCoinHistory([], { loadFailed: true })` when fetching fails.
- This change lets the existing `loadProfile()` `Promise.allSettled` handling surface coin-history load failures so the UI can show "Could not load history" instead of silently clearing the table.

### Testing
- Ran `npm run check:syntax` and it completed successfully.
- Pre-commit static analysis (`check:static-analysis`) executed as part of the commit hooks and passed.
- Syntax/static checks covering the modified files passed (no additional runtime tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c7eb5d108326bea2a67f0b635925)