### PR TITLE
Fix Player Menu History visibility and reward filtering regression

### DIFF
--- a/js/player-menu/controller.js
+++ b/js/player-menu/controller.js
@@ -80,25 +80,12 @@ const COIN_HISTORY_TYPE_LABELS = {
   game_reward: 'Game reward'
 };
 
-const INCOME_HISTORY_TYPES = new Set([
-  'share',
-  'share_reward',
-  'referral',
-  'referral_bonus',
-  'refer',
-  'task',
-  'onboarding_bonus',
-  'onboarding',
-  'race_reward',
-  'game_reward'
-]);
-
-const EXCLUDED_HISTORY_TYPES = new Set([
-  'buy',
-  'ride',
-  'purchase',
+const SPENDING_HISTORY_TYPES = new Set([
   'store_purchase',
-  'upgrade_purchase'
+  'upgrade_purchase',
+  'purchase_spend',
+  'spend',
+  'cost'
 ]);
 
 function escapeHtml(value) {
@@ -113,9 +100,9 @@ function ensureHistoryTemplate() {
   const overlay = DOM.playerMenuOverlay;
   if (!overlay) return null;
   if (!overlay.querySelector('.pm-history')) {
-    const center = overlay.querySelector('.pm-center');
-    if (!center) return null;
-    center.insertAdjacentHTML('beforeend', '<section class="pm-history" aria-label="Coin rewards history"><div class="pm-history-title">History</div><div class="pm-history-table-wrap"><table class="pm-history-table"><thead><tr><th>Source</th><th>Gold</th><th>Silver</th></tr></thead><tbody id="pmHistoryBody"><tr><td colspan="3" class="pm-history-empty">No rewards yet</td></tr></tbody></table></div></section>');
+    const stableContainer = overlay.querySelector('.pm-content') || overlay;
+    if (!stableContainer) return null;
+    stableContainer.insertAdjacentHTML('beforeend', '<section class="pm-history" aria-label="Coin rewards history"><div class="pm-history-title">History</div><div class="pm-history-table-wrap"><table class="pm-history-table"><thead><tr><th>Source</th><th>Gold</th><th>Silver</th></tr></thead><tbody id="pmHistoryBody"><tr><td colspan="3" class="pm-history-empty">No rewards yet</td></tr></tbody></table></div></section>');
   }
   const tbody = overlay.querySelector('#pmHistoryBody');
   if (tbody && DOM.pmHistoryBody !== tbody) DOM.pmHistoryBody = tbody;
@@ -174,10 +161,8 @@ function renderCoinHistory(history, options = {}) {
   const rows = (Array.isArray(history) ? history : []).filter((entry) => {
     const typeKey = String(entry?.type || entry?.rewardType || '').toLowerCase();
     const direction = String(entry?.direction || '').toLowerCase();
-    if (EXCLUDED_HISTORY_TYPES.has(typeKey)) return false;
-    const allowedByType = INCOME_HISTORY_TYPES.has(typeKey);
-    const allowedByDirection = direction === 'income';
-    if (!allowedByType && !allowedByDirection) return false;
+    if (direction === 'spending') return false;
+    if (SPENDING_HISTORY_TYPES.has(typeKey)) return false;
     const { gold, silver } = resolveEntryCoins(entry);
     return gold > 0 || silver > 0;
   });


### PR DESCRIPTION
### Motivation
- Restore the Player Menu History view that regressed: the history section could disappear when `.pm-center` was missing and legacy positive reward rows (race/bonus/referral/share) were being hidden by a strict allowlist. 
- Ensure spending/purchase records remain excluded while preserving legacy income rows that contain positive gold/silver.

### Description
- Change the history fallback mount to append the history template into a stable container (`#playerMenuOverlay .pm-content`) or the overlay root instead of relying on `.pm-center` only. 
- Replace the strict income allowlist and broad exclusions with a spending-focused filter that excludes entries where `direction === 'spending'` or where `type` is in a `SPENDING_HISTORY_TYPES` set (`store_purchase`, `upgrade_purchase`, `purchase_spend`, `spend`, `cost`).
- Keep the empty-state rendering and table frame so the history table is always visible and shows `No rewards yet` when no rows are present.
- The only modified file is `js/player-menu/controller.js`. 

### Testing
- Ran `npm run -s lint` and static analysis checks which completed successfully. 
- Pre-commit syntax and static checks (`check-syntax`, `check-static-analysis`) ran as part of the commit hooks and passed. 
- No backend changes were made in this PR; backend validation was not run in this workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09926dbab0832698c7990c8aec2b48)