### PR TITLE
Fix audio lifecycle regression across menu/gameplay screens

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -84,14 +84,29 @@ const audioManager = {
       sfxEnabled: audioSettings.sfxEnabled
     });
   },
+  normalizeAudioScreen(screen) {
+    if (!screen) return this.currentScreen || 'menu';
+    if (['store', 'player-menu', 'rules'].includes(screen)) return screen;
+    if (screen === 'game-over') return 'game-over';
+    if (screen === 'gameplay') return 'gameplay';
+    return 'menu';
+  },
   getAllowedMusicForScreen(screen = this.currentScreen) {
-    if (screen === 'menu') return ['menu'];
-    if (screen === 'gameplay') return ['game1', 'game2', 'game3'];
+    const normalized = this.normalizeAudioScreen(screen);
+    const MENU_MUSIC_SCREENS = new Set(['menu', 'store', 'player-menu', 'rules']);
+    if (MENU_MUSIC_SCREENS.has(normalized)) return ['menu'];
+    if (normalized === 'gameplay') return ['game1', 'game2', 'game3'];
     return [];
   },
   setScreen(screen) {
-    this.currentScreen = screen;
-    if (screen !== 'gameplay' && this.currentMusicName && this.getAllowedMusicForScreen(screen).indexOf(this.currentMusicName) === -1) {
+    const nextScreen = this.normalizeAudioScreen(screen);
+    const nextAllowed = this.getAllowedMusicForScreen(nextScreen);
+    this.currentScreen = nextScreen;
+    if (this.pendingMusicName && this.pendingMusicName.screen !== nextScreen) {
+      this.pendingMusicName = null;
+    }
+    const canKeepCurrent = this.currentMusicName && nextAllowed.indexOf(this.currentMusicName) !== -1;
+    if (!canKeepCurrent && this.currentMusicName) {
       this.stopMusic();
     }
     this.ensureMusicForCurrentScreen();
@@ -162,25 +177,17 @@ const audioManager = {
 
   async unlockAudio() {
     this.markUserGesture();
-    const tracks = [
+    const sfxTracks = [
       ...Object.entries(this.sfx),
       ...Object.entries(this.sfxPools).flatMap(([name, pool]) => pool.map((track, index) => [`${name}#${index + 1}`, track]))
     ];
-    for (const [name, track] of tracks) {
-      const prevVolume = track.volume;
+    for (const [name, track] of sfxTracks) {
       try {
-        const prevMuted = track.muted;
-        track.volume = 0;
-        track.muted = true;
-        await track.play();
-        track.pause();
-        track.currentTime = 0;
-        track.muted = prevMuted;
-        this.debug('unlock:ok', name, track);
+        track.preload = 'auto';
+        track.load();
+        this.debug('unlock:loaded', name, track);
       } catch (_error) {
-        this.debug('unlock:fail', name, track);
-      } finally {
-        track.volume = prevVolume;
+        this.debug('unlock:load-fail', name, track);
       }
     }
     const allowed = this.getAllowedMusicForScreen();
@@ -291,6 +298,9 @@ const audioManager = {
   },
 
   resumeMusic() {
+    if (this.pendingMusicName && this.pendingMusicName.screen !== this.currentScreen) {
+      this.pendingMusicName = null;
+    }
     const nameToResume = this.suspendedMusic?.screen === this.currentScreen ? this.suspendedMusic?.name : this.currentMusicName;
     if (!nameToResume || !audioSettings.musicEnabled) return;
     if (this.getAllowedMusicForScreen().indexOf(nameToResume) === -1) return;
@@ -323,8 +333,11 @@ const audioManager = {
     if (!audioSettings.musicEnabled) return;
     const allowed = this.getAllowedMusicForScreen();
     if (!allowed.length) return;
+    if (this.pendingMusicName && this.pendingMusicName.screen !== this.currentScreen) {
+      this.pendingMusicName = null;
+    }
     if (this.currentMusicName && allowed.indexOf(this.currentMusicName) !== -1 && this.currentMusic && !this.currentMusic.paused) return;
-    if (this.currentScreen === 'menu') this.playMusic('menu');
+    if (allowed.indexOf('menu') !== -1) this.playMusic('menu');
     else if (this.currentScreen === 'gameplay') this.playRandomGameMusic();
   }
 };
@@ -371,7 +384,7 @@ function setMusicEnabled(enabled) {
   if (!enabled) {
     audioManager.suspendMusic();
   } else {
-    audioManager.resumeMusic();
+    audioManager.ensureMusicForCurrentScreen();
   }
   localStorage.setItem('musicEnabled', String(enabled));
   syncAllAudioUI();

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -394,7 +394,7 @@ function bindVisibilityAudioLifecycle() {
       return;
     }
 
-    audioManager.resumeMusic();
+    audioManager.ensureMusicForCurrentScreen();
   }, { emitInitial: false });
 
   visibilityAudioLifecycleBound = true;


### PR DESCRIPTION
### Motivation
- Menu soundtrack was stopping when navigating to non-gameplay screens (`store`, `player-menu`, `rules`) and game music could resume outside gameplay on resume or screen changes.  
- Unlocking/toggling audio triggered clipped SFX on mobile/Telegram because SFX were being played during unlock.  
- A stale pending music entry and blind `resumeMusic()` calls caused audio to leak across screens and environments (web, mobile web, Telegram).

### Description
- Updated `js/audio.js` to add `normalizeAudioScreen()` and expanded `getAllowedMusicForScreen()` so menu music is allowed on `menu`, `store`, `player-menu`, and `rules` while gameplay music stays limited to `gameplay`.  
- Reworked `audioManager.setScreen()` and `ensureMusicForCurrentScreen()` to preserve currently playing music when it remains allowed on the next screen, clear stale `pendingMusicName` when screens change, and only start allowed tracks for the current screen.  
- Modified `unlockAudio()` in `js/audio.js` to stop playing SFX during unlock (now it only preloads/loads SFX) and to only unlock/play the currently allowed music track to avoid clipped artifacts.  
- Adjusted music enable/visibility resume flows by calling `ensureMusicForCurrentScreen()` (in `js/audio.js` and `js/game/bootstrap.js`) so resuming or enabling music never revives disallowed/stale tracks; also verified `isMobileAudioRuntime` import is present to avoid undefined-call regressions.

### Testing
- Ran linting with `npm run -s lint` and the repository checks which passed.  
- Pre-commit checks including `check:syntax` and `check:static-analysis` executed during the commit and passed.  
- Updated files: `js/audio.js` and `js/game/bootstrap.js`, and local static checks showed no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09929387888326a28257090cea2f9b)