### PR TITLE
Tune beginner tube curvature to be visible but smooth in first 2000m

### DIFF
--- a/js/game/adaptive-difficulty.js
+++ b/js/game/adaptive-difficulty.js
@@ -48,13 +48,13 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
     return {
       tier,
       obstacleDensityMultiplier: isNewTier ? 0.65 : 0.84,
-      maxCurveAngleRad: isNewTier ? degToRad(2.0) : degToRad(12),
+      maxCurveAngleRad: isNewTier ? degToRad(3.0) : degToRad(12),
       curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
-      centerOffsetMultiplier: isNewTier ? 0.04 : 0.2,
-      maxCurveStrength: isNewTier ? 0.12 : 0.38,
-      maxDirectionDelta: isNewTier ? Math.PI / 18 : Math.PI / 5,
+      centerOffsetMultiplier: isNewTier ? 0.10 : 0.2,
+      maxCurveStrength: isNewTier ? 0.26 : 0.38,
+      maxDirectionDelta: isNewTier ? Math.PI / 16 : Math.PI / 5,
       minCurveTransitionDurationMs: isNewTier ? 17000 : 13000,
-      centerOffsetSmoothing: isNewTier ? 1.2 : 2.0,
+      centerOffsetSmoothing: isNewTier ? 0.9 : 2.0,
       noDownwardTurns: true
     };
   }
@@ -62,13 +62,13 @@ function getAdaptiveDifficultyProfile({ completedRuns, distance }) {
   return {
     tier,
     obstacleDensityMultiplier: isNewTier ? 0.5 : 0.7,
-    maxCurveAngleRad: isNewTier ? degToRad(1.5) : degToRad(10),
+    maxCurveAngleRad: isNewTier ? degToRad(2.2) : degToRad(10),
     curveTransitionMultiplier: isNewTier ? 1.8 : 1.5,
-    centerOffsetMultiplier: isNewTier ? 0.03 : 0.18,
-    maxCurveStrength: isNewTier ? 0.1 : 0.35,
-    maxDirectionDelta: isNewTier ? Math.PI / 20 : Math.PI / 6,
+    centerOffsetMultiplier: isNewTier ? 0.08 : 0.18,
+    maxCurveStrength: isNewTier ? 0.22 : 0.35,
+    maxDirectionDelta: isNewTier ? Math.PI / 18 : Math.PI / 6,
     minCurveTransitionDurationMs: isNewTier ? 18000 : 14000,
-    centerOffsetSmoothing: isNewTier ? 1.1 : 1.8,
+    centerOffsetSmoothing: isNewTier ? 0.8 : 1.8,
     noDownwardTurns: true
   };
 }


### PR DESCRIPTION
### Motivation
- New players experienced almost-static tube center; the goal is a small, slow visible center deviation (~2–3°) without making turns fast or jerky.

### Description
- Updated `js/game/adaptive-difficulty.js` `new_0_6` profile for `0–1000m` to `maxCurveAngleRad: degToRad(2.2)`, `centerOffsetMultiplier: 0.08`, `maxCurveStrength: 0.22`, `maxDirectionDelta: Math.PI / 18`, `minCurveTransitionDurationMs: 18000`, `centerOffsetSmoothing: 0.8`, and `noDownwardTurns: true`.
- Updated `js/game/adaptive-difficulty.js` `new_0_6` profile for `1000–2000m` to `maxCurveAngleRad: degToRad(3.0)`, `centerOffsetMultiplier: 0.10`, `maxCurveStrength: 0.26`, `maxDirectionDelta: Math.PI / 16`, `minCurveTransitionDurationMs: 17000`, `centerOffsetSmoothing: 0.9`, and `noDownwardTurns: true`.
- Did not change `js/physics.js`; camera shake suppression (`suppressShake`) for non-standard tiers before `2000m` remains in place and direction change logic still uses limited `maxDirectionDelta` and long transition durations.

### Testing
- Ran pre-commit quality checks which executed `npm run check:syntax` and `npm run check:static-analysis`, and both checks passed.
- Verified the diff for `js/game/adaptive-difficulty.js` reflects the new parameter values and no changes were made to `js/physics.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0992d6e5e8832686cc997a86d5f83a)