### PR TITLE
Fix Telegram FPS regression with adaptive render-quality fallback

### DIFF
--- a/js/perf.js
+++ b/js/perf.js
@@ -3,6 +3,8 @@ import { request } from './request.js';
 import { gameState } from './state.js';
 import { logger } from './logger.js';
 import { PERF_SAMPLE_EVENT } from './core/runtime.js';
+import { isMobileLightRuntime, isTelegramRuntime } from './config.js';
+import { CONFIG } from './config.js';
 
 /**
  * LOW_PERF_MODE – detected once at module load time.
@@ -26,6 +28,7 @@ class PerformanceMonitor {
     this.lastPingTime = 0;
     this.currentPing = 0;
     this.qualityCooldown = 0;
+    this.lastQualityChangeAt = 0;
     this.thirtyFpsCapStreak = 0;
   }
 
@@ -60,12 +63,53 @@ class PerformanceMonitor {
 
   updateAdaptiveQuality() {
     if (!gameState || !gameState.running) return;
+    const isMobileLike = isTelegramRuntime || isMobileLightRuntime;
+    const now = performance.now();
+    const cooldownMs = 6000;
 
-    // Keep visual quality stable: adaptive high/low switching is disabled.
-    gameState.renderQuality = 'high';
-    gameState.lowFpsStreak = 0;
-    gameState.highFpsStreak = 0;
-    this.qualityCooldown = 0;
+    if (!isMobileLike) {
+      gameState.renderQuality = 'high';
+      gameState.heavyRenderEnabled = true;
+      gameState.lowFpsStreak = 0;
+      gameState.highFpsStreak = 0;
+      return;
+    }
+
+    if (!['low', 'medium', 'high'].includes(gameState.renderQuality)) {
+      gameState.renderQuality = isTelegramRuntime ? 'medium' : 'high';
+    }
+    if (isTelegramRuntime && gameState.renderQuality === 'high') {
+      gameState.renderQuality = 'medium';
+    }
+
+    if (this.avgFps < 45) {
+      gameState.lowFpsStreak = (gameState.lowFpsStreak || 0) + 1;
+      gameState.highFpsStreak = 0;
+    } else if (this.avgFps > 55) {
+      gameState.highFpsStreak = (gameState.highFpsStreak || 0) + 1;
+      gameState.lowFpsStreak = 0;
+    } else {
+      gameState.lowFpsStreak = 0;
+      gameState.highFpsStreak = 0;
+    }
+
+    if (now - this.lastQualityChangeAt < cooldownMs) return;
+    let nextQuality = gameState.renderQuality;
+
+    if (gameState.lowFpsStreak >= 3) {
+      nextQuality = gameState.renderQuality === 'high' ? 'medium' : 'low';
+    } else if (gameState.highFpsStreak >= 8 && gameState.renderQuality !== 'high') {
+      nextQuality = gameState.renderQuality === 'low' ? 'medium' : 'high';
+    }
+
+    if (nextQuality !== gameState.renderQuality) {
+      gameState.renderQuality = nextQuality;
+      gameState.heavyRenderEnabled = nextQuality !== 'low';
+      this.lastQualityChangeAt = now;
+      logger.info(`[perf] Adaptive quality -> ${nextQuality} (avgFps=${this.avgFps})`);
+    } else {
+      gameState.heavyRenderEnabled = gameState.renderQuality !== 'low';
+    }
   }
 
   updateFpsUI() {
@@ -119,6 +163,21 @@ class PerformanceMonitor {
   }
 
   publishPerfSample() {
+    const stats = gameState?.debugStats || {};
+    const debugFpsEnabled = (() => {
+      try {
+        return window.localStorage?.getItem('DEBUG_FPS') === '1';
+      } catch {
+        return false;
+      }
+    })();
+    if (debugFpsEnabled) {
+      const frameMs = Number(stats.frameMs || 0);
+      const possible30Cap = this.fps >= 28 && this.fps <= 32 && frameMs > 0 && frameMs < 22;
+      logger.info(
+        `[DEBUG_FPS] fps=${this.fps} avgFps=${this.avgFps} resolution=${window.devicePixelRatio || 1} renderQuality=${gameState?.renderQuality || 'unknown'} tubeSegments=${CONFIG.TUBE_SEGMENTS} tubeDepthSteps=${CONFIG.TUBE_DEPTH_STEPS} drawMs=${Number(stats.drawMs || 0).toFixed(1)} updateMs=${Number(stats.updateMs || 0).toFixed(1)} frameMs=${frameMs.toFixed(1)}${possible30Cap ? ' possible 30 cap' : ''}`
+      );
+    }
     window.dispatchEvent(new CustomEvent(PERF_SAMPLE_EVENT, {
       detail: {
         timestamp: Date.now(),

--- a/js/state.js
+++ b/js/state.js
@@ -1,6 +1,9 @@
 import { CONFIG } from './config.js';
 
 // @ts-check
+const INITIAL_RENDER_QUALITY = typeof window !== 'undefined' && window.Telegram?.WebApp
+  ? 'medium'
+  : 'high';
 
 /**
  * @typedef {Object} GameState
@@ -305,7 +308,7 @@ const gameState = {
   inputLatencySampleCount: 0,
   inputTimestampQueue: [],
 
-  renderQuality: 'high',
+  renderQuality: INITIAL_RENDER_QUALITY,
   lowFpsStreak: 0,
   highFpsStreak: 0,
   activeSilverCoins: 0,


### PR DESCRIPTION
### Motivation
- Telegram WebView already forces DPR=1 but the code unconditionally forced `renderQuality='high'`, preventing quality fallback and causing FPS drops on constrained devices.
- Restore adaptive quality on mobile/Telegram so the renderer can reduce expensive passes and recover FPS while keeping desktop/web at high quality.

### Description
- Re-enabled adaptive quality in `js/perf.js` for mobile/Telegram runtimes with hysteresis and cooldown by tracking `avgFps`, `lowFpsStreak` (degrade when `<45` for several samples), `highFpsStreak` (recover when `>55` for sustained samples), and a `6s` cooldown using a new `lastQualityChangeAt` timestamp. 
- Tie low-quality mode to the heavy render path by setting `gameState.heavyRenderEnabled = false` when quality is `low`, and preserve high-quality for non-mobile runtimes; initial Telegram runtime quality is set to `medium` at bootstrap in `js/state.js`.
- Added detailed `DEBUG_FPS` logging in `js/perf.js` that emits `fps`, `avgFps`, `resolution`, `renderQuality`, `tubeSegments`, `tubeDepthSteps`, `drawMs`, `updateMs`, `frameMs`, and a `possible 30 cap` hint when signatures match an environment/VSync cap.
- Modified files: `js/perf.js` (adaptive logic, debug logging) and `js/state.js` (initial quality for Telegram), while keeping the existing DPR cap logic intact in the Phaser bridge.

### Testing
- Ran a production build with `npm run -s build` which completed successfully and produced the app bundle.
- Project static checks and pre-commit scripts ran and passed, including `check:syntax` and `check:static-analysis`.
- Verified that `DEBUG_FPS` logging is emitted when `localStorage.DEBUG_FPS` is enabled and that messages include the requested fields and the `possible 30 cap` hint when detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0992b3d4a48326a79df3cea8a91976)