### PR TITLE
Harden Telegram leaderboard save auth proof headers

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -332,10 +332,20 @@ async function saveResultToLeaderboard(options = {}) {
       };
     }
 
+    const requestHeaders = buildLeaderboardSaveHeaders(data);
+    if (isTelegramAuthMode()) {
+      const hasBearer = Boolean(String(requestHeaders.Authorization || '').trim());
+      const hasInitData = Boolean(String(requestHeaders['X-Telegram-Init-Data'] || '').trim());
+      if (!hasBearer && !hasInitData) {
+        logger.warn('⚠️ Telegram leaderboard save skipped: auth proof missing', saveDebugContext);
+        return { status: SAVE_RESULT_STATUS.FAILED, reason: 'telegram_auth_proof_missing' };
+      }
+    }
+
     logger.info('🚀 Leaderboard save request start', saveDebugContext);
     let response = await request(`${BACKEND_URL}/api/leaderboard/save`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-Wallet": data.wallet },
+      headers: requestHeaders,
       body: JSON.stringify(data)
     });
     logger.info('📬 Leaderboard save response received', { ...saveDebugContext, status: response.status, ok: response.ok });
@@ -374,6 +384,10 @@ async function saveResultToLeaderboard(options = {}) {
       await refreshPlayerStats({ source: 'saveResultToLeaderboard:already_submitted' }).catch((error) => logger.warn('⚠️ Post-save player stats refresh after 409 failed (non-fatal)', { ...saveDebugContext, error }));
       return { status: SAVE_RESULT_STATUS.SKIPPED, reason: 'already_submitted' };
     }
+    if (response.status === 401 && isTelegramAuthMode()) {
+      logger.warn('⚠️ Telegram leaderboard save unauthorized', saveDebugContext);
+      return { status: SAVE_RESULT_STATUS.FAILED, reason: 'telegram_auth_failed' };
+    }
 
     logger.error("❌ Save error:", response.status, errText);
     return { status: SAVE_RESULT_STATUS.FAILED, reason: `http_${response.status}` };
@@ -392,6 +406,13 @@ async function saveResultToLeaderboard(options = {}) {
       logger.info('🏁 Leaderboard save request completed', saveDebugContext);
     }
   });
+}
+
+function buildLeaderboardSaveHeaders(data) {
+  const headers = buildAuthHeaders();
+  headers['Content-Type'] = 'application/json';
+  if (data?.wallet) headers['X-Wallet'] = String(data.wallet);
+  return headers;
 }
 
 async function fetchGameOverPreview({ score, distance, isAuthenticated, runToken = null }) {

--- a/scripts/leaderboard-save-auth.test.mjs
+++ b/scripts/leaderboard-save-auth.test.mjs
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function mockBrowser({ initData = '', telegram = true } = {}) {
+  const previousWindow = globalThis.window;
+  const previousNavigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  const store = new Map();
+  const localStorage = {
+    getItem(key) { return store.has(key) ? store.get(key) : null; },
+    setItem(key, value) { store.set(key, String(value)); },
+    removeItem(key) { store.delete(key); }
+  };
+  const baseWindow = { localStorage, innerWidth: 390 };
+  if (telegram) {
+    baseWindow.Telegram = { WebApp: { initData } };
+  }
+  Object.defineProperty(globalThis, 'window', { value: baseWindow, configurable: true, writable: true });
+  Object.defineProperty(globalThis, 'navigator', { value: { userAgent: 'Telegram iOS' }, configurable: true });
+  return {
+    restore() {
+      if (previousWindow === undefined) delete globalThis.window;
+      else Object.defineProperty(globalThis, 'window', { value: previousWindow, configurable: true, writable: true });
+      if (!previousNavigatorDescriptor) delete globalThis.navigator;
+      else Object.defineProperty(globalThis, 'navigator', previousNavigatorDescriptor);
+    }
+  };
+}
+
+async function setupModules(caseId) {
+  const auth = await import(`../js/auth-state.js?case=${caseId}`);
+  const state = await import(`../js/state.js?case=${caseId}`);
+  const api = await import(`../js/api.js?case=${caseId}`);
+  state.gameState.score = 15;
+  state.gameState.distance = 200;
+  state.gameState.goldCoins = 3;
+  state.gameState.silverCoins = 5;
+  return { auth, api };
+}
+
+test('telegram save sends Bearer and Telegram initData', async () => {
+  const env = mockBrowser({ initData: 'query_id=abc&hash=xyz' });
+  const caseId = Date.now();
+  const { auth, api } = await setupModules(caseId);
+  auth.applyAuthSession({
+    nextAuthMode: 'telegram',
+    nextPrimaryId: 'tg:123',
+    nextTelegramUser: { id: 123 },
+    nextSessionToken: 'session-123'
+  });
+
+  const originalFetch = globalThis.fetch;
+  let headers;
+  globalThis.fetch = async (_url, options = {}) => {
+    headers = options.headers;
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  const result = await api.saveResultToLeaderboard({ runToken: 't-1' });
+  assert.equal(result.status, 'saved');
+  assert.equal(headers.Authorization, 'Bearer session-123');
+  assert.equal(headers['X-Telegram-Init-Data'], 'query_id=abc&hash=xyz');
+
+  globalThis.fetch = originalFetch;
+  env.restore();
+});
+
+test('telegram save fails fast when token and initData are both missing', async () => {
+  const env = mockBrowser({ telegram: false });
+  const caseId = Date.now() + 1;
+  const { auth, api } = await setupModules(caseId);
+  auth.applyAuthSession({
+    nextAuthMode: 'telegram',
+    nextPrimaryId: 'tg:123',
+    nextTelegramUser: { id: 123 },
+    nextSessionToken: null
+  });
+
+  const originalFetch = globalThis.fetch;
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return new Response('{}', { status: 200 });
+  };
+
+  const result = await api.saveResultToLeaderboard({ runToken: 't-2' });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.reason, 'telegram_auth_proof_missing');
+  assert.equal(called, false);
+
+  globalThis.fetch = originalFetch;
+  env.restore();
+});
+
+test('telegram save maps 401 to telegram_auth_failed', async () => {
+  const env = mockBrowser({ initData: 'query_id=abc&hash=xyz' });
+  const caseId = Date.now() + 2;
+  const { auth, api } = await setupModules(caseId);
+  auth.applyAuthSession({
+    nextAuthMode: 'telegram',
+    nextPrimaryId: 'tg:123',
+    nextTelegramUser: { id: 123 },
+    nextSessionToken: null
+  });
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 });
+
+  const result = await api.saveResultToLeaderboard({ runToken: 't-3' });
+  assert.equal(result.status, 'failed');
+  assert.equal(result.reason, 'telegram_auth_failed');
+
+  globalThis.fetch = originalFetch;
+  env.restore();
+});


### PR DESCRIPTION
### Motivation
- Ensure backend no longer trusts `telegramId` in request body by requiring a real proof-of-auth when saving leaderboard results in Telegram Mini App mode.
- Prefer `Authorization: Bearer <sessionToken>` and fallback to `X-Telegram-Init-Data` from `window.Telegram.WebApp.initData` to provide reliable server-verifiable auth proof.

### Description
- Update `saveResultToLeaderboard()` in `js/api.js` to build request headers via a new helper `buildLeaderboardSaveHeaders(data)` which reuses the existing `buildAuthHeaders()` and adds `Content-Type` + `X-Wallet` when applicable.
- In the Telegram branch require at least one proof: either `Authorization: Bearer <sessionToken>` or `X-Telegram-Init-Data`, and return `{ status: FAILED, reason: 'telegram_auth_proof_missing' }` if both are absent.
- Preserve existing Telegram payload shape (keep `authMode: "telegram"` and `telegramId`) and do not change wallet-signature flow for non-Telegram saves.
- Map backend `401` responses for Telegram saves to a stable failure reason `{ status: FAILED, reason: 'telegram_auth_failed' }` to avoid treating unauthorized responses as saved.
- Added `scripts/leaderboard-save-auth.test.mjs` with unit tests that assert header composition and failure mapping for Telegram saves.

### Testing
- Added tests `scripts/leaderboard-save-auth.test.mjs` exercising: presence of `Authorization` and `X-Telegram-Init-Data` when available, fail-fast when both proofs are missing, and mapping of backend `401` to `telegram_auth_failed`.
- Ran full project checks with `npm run check` which includes static analysis and the test suite, and the run completed successfully with all tests passing.
- Pre-commit quality checks and syntax/static-analysis guards passed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1097ae9ca0832686916627ef1905f2)