### PR TITLE
Remove brightening filter from top-right HUD icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -985,7 +985,7 @@ body.start-launching #walletCorner {
 #uiTopRight .label .icon-atlas {
   transform: scale(1.1);
   transform-origin: center;
-  filter: brightness(1.35) saturate(1.2);
+  filter: none;
 }
 #uiTopRight .value {
   order: 1;


### PR DESCRIPTION
### Motivation
- Top-right HUD status icons (shield, magnet, invert, multiplier, spin) were rendered over-bright due to `filter: brightness(1.35) saturate(1.2);` on `#uiTopRight .label .icon-atlas`, so the change restores their native atlas colors while keeping layout intact.

### Description
- In `css/style.css` the rule for `#uiTopRight .label .icon-atlas` has been changed to use `filter: none;` instead of `filter: brightness(1.35) saturate(1.2);`, with `transform: scale(1.1);` and `transform-origin: center;` left unchanged.

### Testing
- Executed `npm run check`, which ran `check:syntax`, `check:static-analysis`, `check:ui-buttons`, `check:unused-code`, `check:no-window-assign`, `check:asset-paths`, `check:no-legacy-canvas-runtime`, `test:e2e-smoke`, and `test:request`, and all automated checks completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10aac772cc8326bcb0cfeea573b331)