### PR TITLE
Fix loading deadlock when runtime readiness marker is missing

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -329,8 +329,18 @@ const sessionController = createGameSessionController({
 
 async function initGame() {
   bindRendererReadinessEvents();
-  await ensureRendererReady();
-  const sceneReadyResult = waitForPhaserSceneReady({ timeoutMs: 3000 });
+  let rendererReady = true;
+  try {
+    await ensureRendererReady();
+  } catch (error) {
+    rendererReady = false;
+    logger.error('❌ Phaser renderer initialization failed, falling back to degraded mode:', error);
+    showRendererPlaceholder();
+  }
+
+  const sceneReadyResult = rendererReady
+    ? waitForPhaserSceneReady({ timeoutMs: 3000 })
+    : Promise.resolve({ ok: false, reason: 'phaser_renderer_unavailable' });
   await initGameBootstrapFlow({
     startGame: sessionController.startGame,
     restartFromGameOver: sessionController.restartFromGameOver,
@@ -345,7 +355,9 @@ async function initGame() {
   });
   const sceneReady = await sceneReadyResult;
   gameState.rendererReady = Boolean(sceneReady?.ok);
-  await prewarmRenderer();
+  if (rendererReady) {
+    await prewarmRenderer();
+  }
 }
 
 const { endGame } = sessionController;

--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -19,6 +19,7 @@ import { initOnboardingFeature, refreshOnboardingState, applyOnboardingForScreen
 import { performShare, startXConnectFlow } from '../share/shareFlow.js';
 import { identifyPostHogUser, resetPostHogUser } from '../integrations/posthog/index.js';
 import { trackTelegramEvent } from '../telegram-analytics.js';
+import { markGameRuntimeReady } from '../app-loading.js';
 let cleanupPingLifecycle = () => {};
 let uiEventHandlersBound = false;
 let visibilityAudioLifecycleBound = false;
@@ -613,7 +614,11 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
     measurePing: () => perfMonitor.measurePing()
   });
 
-  markGameRuntimeReady();
+  try {
+    markGameRuntimeReady();
+  } catch (error) {
+    logger.warn('Game runtime readiness marker failed', error);
+  }
   logger.info('✅ Game fully initialized!');
 }
 


### PR DESCRIPTION
### Motivation
- Resolve a startup regression where `ReferenceError: markGameRuntimeReady is not defined` left the app stuck on the loading screen. 
- Eliminate reliance on an implicit global readiness marker and ensure readiness functions are imported explicitly. 
- Make renderer/Phaser initialization failures (for example WebGL/framebuffer unsupported) degrade gracefully instead of blocking bootstrap. 

### Description
- Explicitly import `markGameRuntimeReady` in `js/game/bootstrap.js` and replace the direct call with a guarded invocation wrapped in `try { markGameRuntimeReady(); } catch (error) { logger.warn(...) }` so readiness marker failures cannot crash bootstrap. 
- Add a renderer initialization fallback in `js/game.js` that wraps `await ensureRendererReady()` in `try/catch`, logs the error, displays a renderer placeholder via `showRendererPlaceholder()`, and continues bootstrap in a degraded mode. 
- Make scene readiness waiting and `prewarmRenderer()` conditional on successful renderer initialization so a failed Phaser runtime does not block app readiness. 
- Remove dependency on implicit globals for readiness markers by ensuring the function is a proper module export/import. 

### Testing
- Ran the project check suite via `npm run check` which includes `check:syntax`, `check:static-analysis`, `check:ui-buttons`, `check:unused-code`, `check:no-window-assign`, `check:asset-paths`, `check:no-legacy-canvas-runtime`, the MIG-08 smoke (`test:e2e-smoke`) and the request/unit test collection (`test:request`), and observed these stages complete successfully in the run logs. 
- Verified loading/progress-related tests in the test run (loading UI/regression assertions and readiness behavior) passed. 
- No remaining `ReferenceError: markGameRuntimeReady is not defined` should occur and loading no longer hangs on renderer or leaderboard timeouts based on the guarded flows and conditional fallbacks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ab9b0d3c8326998a235d9b619e9a)