### PR TITLE
Do not block app-ready on `gameRuntimeReady` marker

### DIFF
--- a/js/app-loading.js
+++ b/js/app-loading.js
@@ -41,11 +41,11 @@ function setAppLoadingProgress(value, label = '') {
 }
 
 function shouldBecomeReady() {
-  return state.flags.shellReady && state.flags.authReady && state.flags.gameRuntimeReady && !state.flags.authFailed;
+  return state.flags.shellReady && state.flags.authReady && !state.flags.authFailed;
 }
 
 function hasCriticalReadiness() {
-  return state.flags.authReady && state.flags.gameRuntimeReady && !state.flags.authFailed;
+  return state.flags.shellReady && state.flags.authReady && !state.flags.authFailed;
 }
 
 function finalizeReady() {
@@ -106,7 +106,10 @@ function initAppLoading() {
     }
   }, FALLBACK_TIMEOUT_MS);
   state.criticalStallTimerId = window.setTimeout(() => {
-    if (!state.appReady) failLoading('Loading failed: game runtime or auth not ready. Please reload.');
+    if (!state.appReady) {
+      const reason = state.flags.authReady ? 'startup did not finish' : 'auth did not finish';
+      failLoading(`Loading failed: ${reason}. Please reload.`);
+    }
   }, CRITICAL_STALL_TIMEOUT_MS);
 }
 


### PR DESCRIPTION
### Motivation
- The app loading gate previously required `gameRuntimeReady` in `shouldBecomeReady()`, which delayed `app-ready` until an optional backend sync finished and caused the loading bar to stall. 
- The intent is to let the UI finish loading once the shell and auth are ready while preserving the runtime marker for backwards compatibility.

### Description
- Changed `shouldBecomeReady()` to depend on `shellReady && authReady && !authFailed` and removed the strict `gameRuntimeReady` requirement. 
- Updated `hasCriticalReadiness()` to the same critical criteria: `shellReady && authReady && !authFailed`. 
- Kept `markGameRuntimeReady()` exported and still setting `state.flags.gameRuntimeReady = true` so existing imports remain valid, but it is no longer required for `app-ready`. 
- Replaced the critical stall timeout message with a clearer reason that picks between `auth did not finish` and `startup did not finish`.

### Testing
- Ran `npm run check:syntax` as part of pre-commit checks and it passed. 
- Ran `npm run check:static-analysis` as part of pre-commit checks and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bcf3f8b88326be1c258b9b98bd8d)