### PR TITLE
Fix web auth restore session regression

### DIFF
--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -133,7 +133,15 @@ async function initAuthFlow({
   document.body.classList.remove('telegram-mini-app');
   document.body.classList.remove('is-telegram');
   document.body.classList.add('is-web');
-  clearAuthSessionState();
+
+  if (authState.sessionToken && authState.primaryId) {
+    logger.info('🌐 Browser mode — restored auth session');
+    updateAuthUI();
+    markAuthReady();
+    runPostAuthSync().catch((error) => logger.warn('Post-auth sync failed after restore', error));
+    return;
+  }
+
   logger.info('🌐 Browser mode — wallet auth');
   updateAuthUI();
   markAuthReady();


### PR DESCRIPTION
### Motivation
- A web startup regression cleared a restored `sessionToken` via `clearAuthSessionState()` which broke private API calls that now require `Authorization: Bearer` headers.
- The app should preserve a previously restored web session and only clear session state on explicit disconnect or confirmed 401, while still handling expired tokens via the existing 401 flow.

### Description
- Updated `js/auth-lifecycle.js` to skip automatic `clearAuthSessionState()` on browser init and add a restored-session branch that checks `authState.sessionToken && authState.primaryId`.
- When a restored session is present the code now logs `🌐 Browser mode — restored auth session`, calls `updateAuthUI()`, `markAuthReady()`, runs `runPostAuthSync()` with a `.catch` that logs warnings, and returns early.
- When no restored session exists the previous browser wallet-auth path remains unchanged and `clearAuthSessionState()` is retained only for explicit disconnect/logout flows.

### Testing
- Ran pre-commit syntax checks with `npm run check:syntax`, which passed.
- Ran static analysis with `npm run check:static-analysis`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bd8a5c7c8326a8a5d5ffa88a608f)