### PR TITLE
Make onboarding init non-blocking during bootstrap

### DIFF
--- a/js/game/bootstrap.js
+++ b/js/game/bootstrap.js
@@ -517,8 +517,14 @@ async function initGameBootstrapFlow({ startGame, restartFromGameOver, goToMainM
   await initAuth();
   hideWalletButtonInTelegram();
   enforceTelegramWalletUiHidden();
-  await initOnboardingFeature();
-  refreshOnboardingState({ reason: 'auth' }).catch(() => {});
+  initOnboardingFeature()
+    .then(() => {
+      refreshOnboardingState({ reason: 'auth' }).catch(() => {});
+      applyOnboardingForScreen();
+    })
+    .catch((error) => {
+      logger.warn('⚠️ Onboarding init failed, continuing without onboarding:', error);
+    });
   updateStartHook().catch(() => {});
   syncFirstRunOnboardingUiState();
 


### PR DESCRIPTION
### Motivation
- Убрать блокировку старта приложения из-за onboarding, чтобы загрузочный прогресс и кнопка START GAME не ждали запроса `/api/onboarding/state`, а оверлеи/подарки могли появляться позже по мере подгрузки данных.

### Description
- В `js/game/bootstrap.js` заменил `await initOnboardingFeature()` на неблокирующую цепочку: `initOnboardingFeature().then(() => { refreshOnboardingState({ reason: 'auth' }).catch(() => {}); applyOnboardingForScreen(); }).catch((error) => { logger.warn('⚠️ Onboarding init failed, continuing without onboarding:', error); });` so startup continues immediately and onboarding initializes in background.

### Testing
- Пре-commit проверки прошли успешно, включая `check:syntax` и `check:static-analysis` (статический анализ не выявил ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10be74b6248326b0c649bc47be00d1)