### PR TITLE
Tighten Telegram menu spacing

### DIFF
--- a/css/menu-layout.css
+++ b/css/menu-layout.css
@@ -3,8 +3,8 @@
   body.telegram-runtime #gameStart {
     align-items: center;
     justify-content: flex-start;
-    gap: 12px;
-    padding: clamp(300px, 43dvh, 390px) 20px max(28px, env(safe-area-inset-bottom));
+    gap: 8px;
+    padding: clamp(220px, 30dvh, 292px) 20px max(28px, env(safe-area-inset-bottom));
     overflow-y: auto;
     overflow-x: hidden;
   }
@@ -46,8 +46,8 @@
     max-width: min(86vw, 420px);
     min-height: 0;
     margin: 0 auto;
-    padding: 0;
-    gap: 12px;
+    padding: 0 0 10px;
+    gap: 8px;
     z-index: 12;
   }
 
@@ -55,8 +55,8 @@
   body.telegram-runtime #ridesInfo {
     order: 1;
     width: 100%;
-    min-height: 28px;
-    margin: 0 0 2px;
+    min-height: 24px;
+    margin: 0 0 4px;
     padding: 0;
   }
 
@@ -93,6 +93,18 @@
     margin-top: 0;
   }
 
+  body.telegram-mini-app .btn-new,
+  body.telegram-runtime .btn-new {
+    min-height: 46px;
+    padding: 10px 20px;
+  }
+
+  body.telegram-mini-app #startBtn,
+  body.telegram-runtime #startBtn {
+    min-height: 56px;
+    padding: 13px 20px;
+  }
+
   body.telegram-mini-app #startLeaderboardWrap,
   body.telegram-runtime #startLeaderboardWrap {
     display: none !important;
@@ -102,15 +114,18 @@
   body.telegram-runtime #gameStart footer {
     order: 4;
     width: min(90vw, 420px);
-    margin: 2px auto 0;
+    margin: 10px auto 0;
     padding: 0 0 max(20px, env(safe-area-inset-bottom));
     opacity: .62;
     z-index: 12;
+    font-size: 10px;
+    line-height: 1.45;
   }
 
   body.telegram-mini-app #gameStart .footer-socials,
   body.telegram-runtime #gameStart .footer-socials {
-    margin: 0 0 8px;
+    margin: 0 0 10px;
+    gap: 18px;
   }
 
   body.telegram-mini-app #gameStart .footer-rules-link,
@@ -118,50 +133,69 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 34px;
-    margin: 0 auto 8px;
+    min-height: 32px;
+    margin: 0 auto 10px;
+    padding: 5px 14px;
   }
 
   body.telegram-mini-app #gameStart .footer-legal-links,
   body.telegram-runtime #gameStart .footer-legal-links {
-    margin: 0 0 8px;
+    margin: 0 0 10px;
   }
 }
 
 @media (max-width: 480px) {
   body.telegram-mini-app #gameStart,
   body.telegram-runtime #gameStart {
-    padding-top: clamp(286px, 41dvh, 354px);
-    gap: 10px;
+    padding-top: clamp(204px, 29dvh, 268px);
+    gap: 7px;
   }
 
   body.telegram-mini-app #gameStart .new-buttons,
   body.telegram-runtime #gameStart .new-buttons {
     width: min(84vw, 420px);
     max-width: min(84vw, 420px);
-    gap: 10px;
+    gap: 8px;
+    padding-bottom: 10px;
   }
 
   body.telegram-mini-app .btn-new,
   body.telegram-runtime .btn-new {
-    min-height: 48px;
+    min-height: 44px;
+    padding: 9px 18px;
   }
 
   body.telegram-mini-app #startBtn,
   body.telegram-runtime #startBtn {
-    min-height: 60px;
+    min-height: 54px;
+    padding: 12px 18px;
+  }
+
+  body.telegram-mini-app #gameStart footer,
+  body.telegram-runtime #gameStart footer {
+    margin-top: 12px;
   }
 }
 
 @media (max-width: 360px) {
   body.telegram-mini-app #gameStart,
   body.telegram-runtime #gameStart {
-    padding-top: clamp(260px, 39dvh, 326px);
+    padding-top: clamp(188px, 27dvh, 240px);
   }
 
   body.telegram-mini-app #gameStart .new-buttons,
   body.telegram-runtime #gameStart .new-buttons {
     width: min(86vw, 390px);
     max-width: min(86vw, 390px);
+  }
+
+  body.telegram-mini-app .btn-new,
+  body.telegram-runtime .btn-new {
+    min-height: 42px;
+  }
+
+  body.telegram-mini-app #startBtn,
+  body.telegram-runtime #startBtn {
+    min-height: 52px;
   }
 }


### PR DESCRIPTION
## Summary
- Reduces Telegram main-menu top padding so `URSASS TUBE` sits closer to the audio toggles and frees vertical space.
- Compacts the button stack and removes extra gaps that caused footer/social/rules elements to overlap Store and Leaderboard.
- Adds explicit footer spacing so social buttons, Rules, and legal links stay below the main buttons instead of crossing them.

## Validation
- Not run locally: CSS-only adjustment applied through GitHub connector.
- Visual target is the Telegram screenshot showing X/Telegram/Rules overlapping Store/Leaderboard.