### PR TITLE
Fix Telegram media artwork and suppress music widget

### DIFF
--- a/js/app-metadata.js
+++ b/js/app-metadata.js
@@ -1,0 +1,108 @@
+import { audioManager } from './audio.js';
+
+const APP_ICON_PATH = '/img/app-icon.svg';
+const MANIFEST_PATH = '/site.webmanifest';
+
+function isTelegramRuntime() {
+  if (typeof window === 'undefined') return false;
+  return Boolean(
+    window.__URSASS_IS_TELEGRAM_RUNTIME__
+    || window.Telegram?.WebApp
+    || document?.documentElement?.classList?.contains('telegram-runtime')
+    || document?.body?.classList?.contains('telegram-runtime')
+    || /Telegram/i.test(navigator?.userAgent || '')
+  );
+}
+
+function ensureLink(rel, href, attrs = {}) {
+  if (typeof document === 'undefined') return null;
+  let link = document.querySelector(`link[rel="${rel}"]`);
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = rel;
+    document.head?.append(link);
+  }
+  link.href = href;
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) link.setAttribute(key, String(value));
+  });
+  return link;
+}
+
+function ensureMeta(name, content) {
+  if (typeof document === 'undefined') return null;
+  let meta = document.querySelector(`meta[name="${name}"]`);
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.name = name;
+    document.head?.append(meta);
+  }
+  meta.content = content;
+  return meta;
+}
+
+function configureMediaSessionMetadata() {
+  if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+  try {
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: 'URSASS TUBE',
+      artist: 'URSASS TUBE',
+      album: 'Telegram mini app',
+      artwork: [
+        { src: APP_ICON_PATH, sizes: 'any', type: 'image/svg+xml' },
+      ],
+    });
+    navigator.mediaSession.playbackState = 'none';
+  } catch (_error) {}
+}
+
+function clearTelegramMediaSessionPlayback() {
+  if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+  try {
+    navigator.mediaSession.playbackState = 'none';
+  } catch (_error) {}
+}
+
+function installTelegramMediaPolicy() {
+  if (!isTelegramRuntime()) return;
+  if (audioManager.__telegramMediaPolicyInstalled) return;
+  audioManager.__telegramMediaPolicyInstalled = true;
+
+  const originalPrepareMenuAudio = audioManager.prepareMenuAudio.bind(audioManager);
+  const originalPreloadMenuMusic = audioManager.preloadMenuMusic.bind(audioManager);
+  const originalStopMusic = audioManager.stopMusic.bind(audioManager);
+
+  audioManager.getAllowedMusicForScreen = () => [];
+  audioManager.playMusic = () => {
+    originalStopMusic();
+    clearTelegramMediaSessionPlayback();
+  };
+  audioManager.ensureMusicForCurrentScreen = () => {
+    originalStopMusic();
+    clearTelegramMediaSessionPlayback();
+  };
+  audioManager.prepareMenuAudio = () => {
+    audioManager.setScreen('menu');
+    originalPreloadMenuMusic();
+    originalStopMusic();
+    clearTelegramMediaSessionPlayback();
+  };
+
+  originalPrepareMenuAudio.cancelledByTelegramMediaPolicy = true;
+  originalStopMusic();
+  clearTelegramMediaSessionPlayback();
+}
+
+function configureAppMetadata() {
+  ensureLink('icon', APP_ICON_PATH, { type: 'image/svg+xml' });
+  ensureLink('mask-icon', APP_ICON_PATH, { color: '#050611' });
+  ensureLink('apple-touch-icon', APP_ICON_PATH);
+  ensureLink('manifest', MANIFEST_PATH);
+  ensureMeta('theme-color', '#050611');
+  ensureMeta('apple-mobile-web-app-title', 'URSASS TUBE');
+  ensureMeta('application-name', 'URSASS TUBE');
+  configureMediaSessionMetadata();
+  installTelegramMediaPolicy();
+}
+
+export { configureAppMetadata, installTelegramMediaPolicy };

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,7 @@ import { bootstrapGameFeature } from './features/game/bootstrap.js';
 import { initTelegramAnalytics } from './telegram-analytics.js';
 import { installStartupPerformanceTelemetry } from './startup-performance.js';
 import { installLeaderboardOverlay } from './leaderboard-overlay.js';
+import { configureAppMetadata } from './app-metadata.js';
 import {
   initPostHog,
   capturePostHogEvent,
@@ -68,6 +69,7 @@ function renderBootstrapFallback(error) {
 async function bootstrap() {
   try {
     initLogger();
+    configureAppMetadata();
     installStartupPerformanceTelemetry();
     installLeaderboardOverlay();
     try {

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "URSASS TUBE",
+  "short_name": "URSASS TUBE",
+  "description": "URSASS TUBE Telegram mini app",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#050611",
+  "theme_color": "#050611",
+  "icons": [
+    {
+      "src": "/img/app-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds runtime app metadata that replaces the atlas-derived favicon with the standalone `/img/app-icon.svg` artwork.
- Adds `site.webmanifest` using the standalone app icon, not the icon atlas.
- Configures Media Session metadata with the standalone app icon.
- Installs a Telegram media policy that prevents background music from starting through HTML audio in Telegram runtime, so iOS should not show URSASS TUBE as a lock-screen music track.
- SFX remains unaffected.

## Why
In Telegram/iOS, the current soundtrack is played by HTML `<audio>`, which iOS surfaces as a system media track. The current static favicon also points at `/assets/icon_atlas.webp`, so the phone media UI can show the whole atlas or the wrong atlas cell.

## Notes
- This intentionally suppresses background music playback in Telegram runtime. With HTML audio, iOS lock-screen media controls cannot be reliably hidden while music is actively playing.
- The old static atlas favicon in `index.html` is overridden at runtime to avoid a risky large HTML rewrite in this PR.

## Validation
- Not run locally: applied through GitHub connector.
- Visual target is the iOS lock-screen media widget screenshot shared in chat.