### PR TITLE
Fix rides timer overlap on Telegram menu

### DIFF
--- a/css/menu-layout.css
+++ b/css/menu-layout.css
@@ -63,9 +63,14 @@
   body.telegram-mini-app #ridesInfo,
   body.telegram-runtime #ridesInfo {
     order: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
     width: 100%;
-    min-height: 24px;
-    margin: 0 0 4px;
+    min-height: 52px;
+    margin: 0 0 8px;
     padding: 0;
   }
 
@@ -75,6 +80,20 @@
     align-items: center;
     justify-content: center;
     width: 100%;
+    line-height: 1.2;
+  }
+
+  body.telegram-mini-app #ridesTimer,
+  body.telegram-runtime #ridesTimer {
+    min-height: 20px;
+    margin-top: 0;
+    white-space: nowrap;
+  }
+
+  body.telegram-mini-app #ridesInfo:has(#ridesTimer[style*="display: none"]),
+  body.telegram-runtime #ridesInfo:has(#ridesTimer[style*="display: none"]) {
+    min-height: 30px;
+    margin-bottom: 6px;
   }
 
   body.telegram-mini-app .start-btn-wrap,


### PR DESCRIPTION
## Summary
- Gives the Telegram `#ridesInfo` block enough vertical space for both the rides counter and the recharge timer.
- Stacks rides text and reset timer in a column with a small gap.
- Adds spacing below the timer before `START GAME` so the timer no longer overlaps the button.
- Keeps a smaller compact height when the timer is hidden.

## Validation
- Not run locally: CSS-only adjustment applied through GitHub connector.
- Visual target is the Telegram screenshot showing `Resets in...` overlapping the Start Game button.