### PR TITLE
Prevent Telegram Phaser resize freeze

### DIFF
--- a/js/game/loop.js
+++ b/js/game/loop.js
@@ -20,9 +20,10 @@ function createGameLoopController({
     });
   }
 
-  function scheduleResizeStabilization(delays = [100, 300, 600, 1000, 2000, 3000]) {
+  function scheduleResizeStabilization(delays = [100, 300, 600, 1000]) {
     delays.forEach((delay) => {
       setTimeout(() => {
+        if (delay >= 1000 && (gameState.running || gameState.simulationRunning)) return;
         syncViewport();
       }, delay);
     });

--- a/js/phaser/runtime-controller.js
+++ b/js/phaser/runtime-controller.js
@@ -1,18 +1,41 @@
 function createRuntimeController({ game, sceneKey }) {
+  let currentWidth = Number(game.scale?.width || game.scale?.gameSize?.width || 0) || null;
+  let currentHeight = Number(game.scale?.height || game.scale?.gameSize?.height || 0) || null;
+  let currentResolution = Number(game.renderer?.resolution || 0) || null;
+
+  function getScene() {
+    return game.scene.getScene(sceneKey);
+  }
+
+  function hasViewportChanged(nextWidth, nextHeight, nextResolution) {
+    const width = Math.max(1, Math.round(Number(nextWidth) || 0));
+    const height = Math.max(1, Math.round(Number(nextHeight) || 0));
+    const resolution = Number.isFinite(Number(nextResolution)) ? Number(nextResolution) : currentResolution;
+
+    return width !== currentWidth || height !== currentHeight || resolution !== currentResolution;
+  }
+
+  function rememberViewport(nextWidth, nextHeight, nextResolution) {
+    currentWidth = Math.max(1, Math.round(Number(nextWidth) || 0));
+    currentHeight = Math.max(1, Math.round(Number(nextHeight) || 0));
+    if (Number.isFinite(Number(nextResolution))) currentResolution = Number(nextResolution);
+  }
+
   return {
     game,
-    getScene() {
-      return game.scene.getScene(sceneKey);
-    },
+    getScene,
     applySnapshot(nextSnapshot) {
       const scene = this.getScene();
       scene?.applySnapshot(nextSnapshot);
     },
     resize(nextWidth, nextHeight, nextResolution) {
-      game.scale.resize(nextWidth, nextHeight);
-      game.renderer?.resize?.(nextWidth, nextHeight);
-      if (typeof nextResolution === 'number' && Number.isFinite(nextResolution)) {
-        game.renderer.resolution = nextResolution;
+      if (hasViewportChanged(nextWidth, nextHeight, nextResolution)) {
+        game.scale.resize(nextWidth, nextHeight);
+        game.renderer?.resize?.(nextWidth, nextHeight);
+        if (typeof nextResolution === 'number' && Number.isFinite(nextResolution)) {
+          game.renderer.resolution = nextResolution;
+        }
+        rememberViewport(nextWidth, nextHeight, nextResolution);
       }
       this.applySnapshot({
         ...this.getScene()?.controller?.snapshot,


### PR DESCRIPTION
## Summary
- Skips real Phaser `scale.resize()` / `renderer.resize()` calls when viewport width, height, and resolution did not change.
- Removes late gameplay resize stabilization calls that were firing around 2–3 seconds into a run.
- Keeps early stabilization before gameplay settles, but avoids touching the WebGL/canvas resize path once the simulation is already running.

## Why
The remaining Telegram freeze happens about 3 seconds after the run starts. That lines up with `scheduleResizeStabilization([100, 300, 600, 1000, 2000, 3000])`, which triggers `syncViewport()`. The Phaser runtime then resized the renderer every time, even when the viewport did not actually change. In Telegram/iOS WebView this can freeze the canvas while the game simulation and HUD continue.

## Validation
- Not run locally: hotfix applied through GitHub connector.
- Visual target is the Telegram report: simulation continues, but the Phaser picture freezes after ~3 seconds.