### PR TITLE
Use Canvas renderer in Telegram runtime

### DIFF
--- a/js/phaser/runtime.js
+++ b/js/phaser/runtime.js
@@ -7,21 +7,38 @@ async function loadPhaserModule() {
   return localModule.default || localModule;
 }
 
+function isTelegramRuntime() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+  return Boolean(
+    window.__URSASS_IS_TELEGRAM_RUNTIME__
+    || window.Telegram?.WebApp
+    || document.documentElement?.classList?.contains('telegram-runtime')
+    || document.body?.classList?.contains('telegram-runtime')
+  );
+}
+
+function getRendererType(Phaser) {
+  // Telegram iOS WebView may keep JavaScript running while a WebGL canvas stops presenting frames.
+  // The game uses Phaser Graphics/Sprites only, so Canvas is the safer Telegram renderer.
+  return isTelegramRuntime() ? Phaser.CANVAS : Phaser.AUTO;
+}
+
 async function createPhaserRuntime({ parent, snapshot, width, height, resolution }) {
   const Phaser = await loadPhaserModule();
   const MainScene = createMainSceneClass(Phaser);
+  const useTelegramCanvasRenderer = getRendererType(Phaser) === Phaser.CANVAS;
 
   const game = new Phaser.Game({
-    type: Phaser.AUTO,
+    type: getRendererType(Phaser),
     parent,
     width,
     height,
-    transparent: true,
+    transparent: !useTelegramCanvasRenderer,
     backgroundColor: '#000000',
     render: {
-      antialias: !LOW_PERF_MODE,
+      antialias: !LOW_PERF_MODE && !useTelegramCanvasRenderer,
       pixelArt: false,
-      transparent: true,
+      transparent: !useTelegramCanvasRenderer,
       roundPixels: LOW_PERF_MODE
     },
     scale: {


### PR DESCRIPTION
## Summary
- Forces Phaser to use `Phaser.CANVAS` inside Telegram runtime instead of `Phaser.AUTO`/WebGL.
- Keeps normal browser runtime on `Phaser.AUTO`.
- Disables transparent WebGL-style render settings for Telegram Canvas mode.

## Why
The freeze persists after visibility and resize fixes, while JS simulation and DOM HUD continue. That points to the Phaser/WebGL canvas presentation path in Telegram/iOS WebView. Since this game uses Phaser Graphics/Sprites, Canvas mode should be more stable for Telegram even if WebGL would normally be faster.

## Validation
- Not run locally: runtime hotfix applied through GitHub connector.
- Visual target is the Telegram report: Phaser picture freezes after ~3 seconds while gameplay continues.