### PR TITLE
Keep Telegram live rendering enabled at low quality

### DIFF
--- a/js/perf.js
+++ b/js/perf.js
@@ -64,6 +64,7 @@ class PerformanceMonitor {
   updateAdaptiveQuality() {
     if (!gameState || !gameState.running) return;
     const isMobileLike = isTelegramRuntime || isMobileLightRuntime;
+    const keepLiveRender = Boolean(isTelegramRuntime);
     const now = performance.now();
     const cooldownMs = 6000;
 
@@ -93,7 +94,10 @@ class PerformanceMonitor {
       gameState.highFpsStreak = 0;
     }
 
-    if (now - this.lastQualityChangeAt < cooldownMs) return;
+    if (now - this.lastQualityChangeAt < cooldownMs) {
+      gameState.heavyRenderEnabled = keepLiveRender || gameState.renderQuality !== 'low';
+      return;
+    }
     let nextQuality = gameState.renderQuality;
 
     if (gameState.lowFpsStreak >= 3) {
@@ -104,11 +108,11 @@ class PerformanceMonitor {
 
     if (nextQuality !== gameState.renderQuality) {
       gameState.renderQuality = nextQuality;
-      gameState.heavyRenderEnabled = nextQuality !== 'low';
+      gameState.heavyRenderEnabled = keepLiveRender || nextQuality !== 'low';
       this.lastQualityChangeAt = now;
-      logger.info(`[perf] Adaptive quality -> ${nextQuality} (avgFps=${this.avgFps})`);
+      logger.info(`[perf] Adaptive quality -> ${nextQuality} (avgFps=${this.avgFps}, liveRender=${gameState.heavyRenderEnabled})`);
     } else {
-      gameState.heavyRenderEnabled = gameState.renderQuality !== 'low';
+      gameState.heavyRenderEnabled = keepLiveRender || gameState.renderQuality !== 'low';
     }
   }
 


### PR DESCRIPTION
## Summary
- Keeps Telegram adaptive quality degradation, but prevents `low` quality from disabling live gameplay rendering.
- Updates the adaptive-quality cooldown path so `heavyRenderEnabled` is refreshed consistently.
- Adds the current `liveRender` value to the adaptive-quality log line.

## Why
The freeze report matches a path where simulation and UI continue, but the Phaser picture stops updating. FPS can still change because FPS is measured by the main requestAnimationFrame loop, not necessarily by successful Phaser scene presentation. In `perf.js`, low FPS can set `renderQuality = low`, then set `heavyRenderEnabled = false`; the game loop uses that flag to skip live rendering while still running update/UI.

## Validation
- Not run locally: draft hypothesis PR for Telegram runtime verification.
- Expected test: in Telegram, start a run on a device that previously froze after a few seconds and confirm the tunnel/scene keeps changing even after FPS turns red/low.