### PR TITLE
Lazy-load WalletConnect provider

### DIFF
--- a/js/walletconnect.js
+++ b/js/walletconnect.js
@@ -1,8 +1,22 @@
-import EthereumProvider from '@walletconnect/ethereum-provider';
 import { WC_PROJECT_ID } from './config.js';
 import { createCenteredOverlay, createElement } from './dom-render.js';
 import { logger } from './logger.js';
 import { notifyError } from './notifier.js';
+
+let ethereumProviderPromise = null;
+
+async function loadEthereumProvider() {
+  if (!ethereumProviderPromise) {
+    ethereumProviderPromise = import('@walletconnect/ethereum-provider')
+      .then((module) => module.default || module)
+      .catch((error) => {
+        ethereumProviderPromise = null;
+        throw error;
+      });
+  }
+
+  return ethereumProviderPromise;
+}
 
 // WalletConnect v2 integration — fallback for environments without window.ethereum (e.g. Telegram Mini App)
 const WC = {
@@ -11,6 +25,7 @@ const WC = {
 
   async connect() {
     try {
+      const EthereumProvider = await loadEthereumProvider();
       if (typeof EthereumProvider?.init !== 'function') {
         notifyError('❌ WalletConnect dependency failed to load. Please refresh and try again.');
         return false;


### PR DESCRIPTION
## Summary
- Replaces the static `@walletconnect/ethereum-provider` import with a dynamic import inside `WC.connect()`.
- Keeps the existing WalletConnect API and modal flow unchanged.
- Resets the cached import promise if the provider chunk fails to load so a later retry can work.

## Why
Roadmap item: lazy-load WalletConnect. The WalletConnect provider is only needed when a user actually connects through WalletConnect, but the previous static import pulled it into startup parsing/evaluation. Telegram startup should not pay that cost unless the wallet flow is used.

## Validation
- Not run locally: connector-only change.
- Expected check: app/menu startup still works; injected-wallet flow unchanged; WalletConnect provider chunk loads only when `WC.connect()` is called.