### PR TITLE
Defer icon atlas asset preload

### DIFF
--- a/js/assets.js
+++ b/js/assets.js
@@ -19,13 +19,13 @@ class AssetManager {
       ['character_right_idle', 'assets/character_right_idle.png'],
       ['character_left_swipe', 'assets/character_left_swipe.png'],
       ['character_right_swipe', 'assets/character_right_swipe.png'],
-      ['character_spin', 'assets/character_spin.png'],
-      ['icon_atlas', 'assets/icon_atlas.webp']
+      ['character_spin', 'assets/character_spin.png']
     ];
   }
 
   static getDeferredManifest() {
     return [
+      ['icon_atlas', 'assets/icon_atlas.webp'],
       ['bezel_light', ['img/construct blazer/light-full.webp', 'img/construct blazer/light-small.webp']],
       ['bezel_metal', ['img/construct blazer/metal-blazer.webp']]
     ];


### PR DESCRIPTION
## Summary
- Moves `icon_atlas` from the critical asset manifest to the deferred asset manifest.
- Keeps gameplay-critical atlases and character sprites in the blocking load path.
- Leaves existing `loadDeferred()` scheduling unchanged.

## Why
Roadmap item: reduce Telegram startup payload. `icon_atlas` is used for UI/icon decoration and is not part of the gameplay readiness check, while critical startup waits for every asset in `getCriticalManifest()`. Deferring it removes one image from the blocking asset phase without touching gameplay renderer logic.

## Validation
- Not run locally: connector-only change.
- Expected check: menu/gameplay still render; startup `assets_ready` should complete after one fewer image request, while icon atlas loads during the existing deferred phase.