### PR TITLE
Lazy-load PostHog integration module

### DIFF
--- a/js/integrations/posthog/index.js
+++ b/js/integrations/posthog/index.js
@@ -1,6 +1,49 @@
+let postHogModulePromise = null;
+
+async function loadPostHogModule() {
+  if (!postHogModulePromise) {
+    postHogModulePromise = import('../../posthog.js')
+      .catch((error) => {
+        postHogModulePromise = null;
+        throw error;
+      });
+  }
+
+  return postHogModulePromise;
+}
+
+function callPostHog(fnName, args) {
+  return loadPostHogModule()
+    .then((module) => {
+      const fn = module?.[fnName];
+      if (typeof fn === 'function') return fn(...args);
+      return undefined;
+    })
+    .catch((error) => {
+      console.warn(`⚠️ PostHog ${fnName} failed`, error);
+      return undefined;
+    });
+}
+
+function initPostHog(...args) {
+  return callPostHog('initPostHog', args);
+}
+
+function capturePostHogEvent(...args) {
+  return callPostHog('capturePostHogEvent', args);
+}
+
+function identifyPostHogUser(...args) {
+  return callPostHog('identifyPostHogUser', args);
+}
+
+function resetPostHogUser(...args) {
+  return callPostHog('resetPostHogUser', args);
+}
+
 export {
   initPostHog,
   capturePostHogEvent,
   identifyPostHogUser,
   resetPostHogUser
-} from '../../posthog.js';
+};


### PR DESCRIPTION
## Summary
- Converts `js/integrations/posthog/index.js` from a static re-export of `posthog.js` into a lazy proxy.
- Keeps the exported API names unchanged: `initPostHog`, `capturePostHogEvent`, `identifyPostHogUser`, `resetPostHogUser`.
- Resets the cached dynamic import promise on load failure so later retries can work.

## Why
Roadmap item: reduce startup JavaScript. `posthog.js` imports `posthog-js`, so static re-exports from the integration barrel pull the SDK into startup/import evaluation. Lazy-loading from the barrel keeps existing callers stable while deferring the SDK until the first PostHog call.

## Validation
- Not run locally: connector-only change.
- Expected check: startup/menu still load; analytics calls still work after the dynamic PostHog module import resolves.