### PR TITLE
Align web main menu layout

### DIFF
--- a/css/web-menu-layout.css
+++ b/css/web-menu-layout.css
@@ -1,0 +1,42 @@
+@media (min-width: 769px) {
+  html:not(.telegram-runtime) #gameStart {
+    justify-content: flex-start;
+    padding-top: clamp(72px, 8vh, 112px);
+    padding-bottom: 44px;
+  }
+
+  html:not(.telegram-runtime) #gameStart > :not(.bear-wrapper):not(.start-audio-nav) {
+    transform: none;
+  }
+
+  html:not(.telegram-runtime) #gameStart .new-title {
+    margin-top: clamp(36px, 7vh, 84px);
+  }
+
+  html:not(.telegram-runtime) #gameStart .new-buttons {
+    width: min(420px, 80vw);
+    max-width: min(420px, 80vw);
+    min-height: 0;
+    margin-top: 28px;
+    gap: 14px;
+  }
+
+  html:not(.telegram-runtime) #ridesInfo {
+    order: 1;
+    min-height: 30px;
+    margin: 0 0 6px;
+    padding: 0;
+  }
+
+  html:not(.telegram-runtime) .start-btn-wrap { order: 2; width: 100%; }
+  html:not(.telegram-runtime) #storeBtn { order: 3; top: auto; margin: 0; }
+  html:not(.telegram-runtime) #leaderboardBtn { order: 4; min-width: 0; margin-top: 0; }
+  html:not(.telegram-runtime) #startBtn { margin-top: 0; }
+
+  html:not(.telegram-runtime) #gameStart footer {
+    width: min(90vw, 420px);
+    margin: clamp(22px, 4vh, 38px) auto 0;
+    padding-bottom: 34px;
+    line-height: 1.45;
+  }
+}

--- a/js/app-metadata.js
+++ b/js/app-metadata.js
@@ -2,6 +2,7 @@ import { audioManager } from './audio.js';
 
 const APP_ICON_PATH = '/img/app-icon.svg';
 const MANIFEST_PATH = '/site.webmanifest';
+const WEB_MENU_STYLES_PATH = '/css/web-menu-layout.css';
 
 function isTelegramRuntime() {
   if (typeof window === 'undefined') return false;
@@ -26,6 +27,19 @@ function ensureLink(rel, href, attrs = {}) {
   Object.entries(attrs).forEach(([key, value]) => {
     if (value !== undefined && value !== null) link.setAttribute(key, String(value));
   });
+  return link;
+}
+
+function ensureStylesheet(href) {
+  if (typeof document === 'undefined') return null;
+  let link = document.querySelector(`link[data-ursass-stylesheet="${href}"]`);
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.dataset.ursassStylesheet = href;
+    document.head?.append(link);
+  }
+  link.href = href;
   return link;
 }
 
@@ -135,6 +149,7 @@ function configureAppMetadata() {
   ensureLink('mask-icon', APP_ICON_PATH, { color: '#050611' });
   ensureLink('apple-touch-icon', APP_ICON_PATH);
   ensureLink('manifest', MANIFEST_PATH);
+  ensureStylesheet(WEB_MENU_STYLES_PATH);
   ensureMeta('theme-color', '#050611');
   ensureMeta('apple-mobile-web-app-title', 'URSASS TUBE');
   ensureMeta('application-name', 'URSASS TUBE');

--- a/public/css/web-menu-layout.css
+++ b/public/css/web-menu-layout.css
@@ -1,0 +1,42 @@
+@media (min-width: 769px) {
+  html:not(.telegram-runtime) #gameStart {
+    justify-content: flex-start;
+    padding-top: clamp(72px, 8vh, 112px);
+    padding-bottom: 44px;
+  }
+
+  html:not(.telegram-runtime) #gameStart > :not(.bear-wrapper):not(.start-audio-nav) {
+    transform: none;
+  }
+
+  html:not(.telegram-runtime) #gameStart .new-title {
+    margin-top: clamp(36px, 7vh, 84px);
+  }
+
+  html:not(.telegram-runtime) #gameStart .new-buttons {
+    width: min(420px, 80vw);
+    max-width: min(420px, 80vw);
+    min-height: 0;
+    margin-top: 28px;
+    gap: 14px;
+  }
+
+  html:not(.telegram-runtime) #ridesInfo {
+    order: 1;
+    min-height: 30px;
+    margin: 0 0 6px;
+    padding: 0;
+  }
+
+  html:not(.telegram-runtime) .start-btn-wrap { order: 2; width: 100%; }
+  html:not(.telegram-runtime) #storeBtn { order: 3; top: auto; margin: 0; }
+  html:not(.telegram-runtime) #leaderboardBtn { order: 4; min-width: 0; margin-top: 0; }
+  html:not(.telegram-runtime) #startBtn { margin-top: 0; }
+
+  html:not(.telegram-runtime) #gameStart footer {
+    width: min(90vw, 420px);
+    margin: clamp(22px, 4vh, 38px) auto 0;
+    padding-bottom: 34px;
+    line-height: 1.45;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a web-only menu layout stylesheet served from `public/css`.
- Loads it from app metadata bootstrap.
- Reorders desktop web menu to match Telegram order: rides, Start Game, Store, Leaderboard.
- Reduces vertical offset so footer/legal block is not clipped on desktop web.

## Issue
Refs #1765.

## Validation
- Not run locally: connector-only change.
- Expected check: desktop web menu matches Telegram button order and footer is fully visible.