### PR TITLE
Restore web favicon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="URSASS TUBE">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="35%" r="75%">
+      <stop offset="0%" stop-color="#203b79"/>
+      <stop offset="48%" stop-color="#11152f"/>
+      <stop offset="100%" stop-color="#050611"/>
+    </radialGradient>
+    <linearGradient id="ring" x1="24" y1="24" x2="232" y2="232" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#26d5ff"/>
+      <stop offset="0.52" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#ffcf33"/>
+    </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="256" height="256" rx="54" fill="url(#bg)"/>
+  <rect x="13" y="13" width="230" height="230" rx="47" fill="none" stroke="url(#ring)" stroke-width="7" opacity=".9"/>
+  <g filter="url(#glow)">
+    <circle cx="88" cy="88" r="26" fill="#f8fbff"/>
+    <circle cx="168" cy="88" r="26" fill="#f8fbff"/>
+    <ellipse cx="128" cy="138" rx="66" ry="62" fill="#f8fbff"/>
+    <ellipse cx="104" cy="126" rx="11" ry="14" fill="#050611"/>
+    <ellipse cx="152" cy="126" rx="11" ry="14" fill="#050611"/>
+    <ellipse cx="128" cy="147" rx="18" ry="13" fill="#050611"/>
+  </g>
+  <text x="128" y="216" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="31" font-weight="800" letter-spacing="4" fill="#f8fbff">UT</text>
+</svg>

--- a/js/app-metadata.js
+++ b/js/app-metadata.js
@@ -1,6 +1,7 @@
 import { audioManager } from './audio.js';
 
 const APP_ICON_PATH = '/img/app-icon.svg';
+const FAVICON_PATH = '/favicon.svg';
 const MANIFEST_PATH = '/site.webmanifest';
 const WEB_MENU_STYLES_PATH = '/css/web-menu-layout.css';
 
@@ -145,7 +146,7 @@ function installTelegramMediaPolicy() {
 }
 
 function configureAppMetadata() {
-  ensureLink('icon', APP_ICON_PATH, { type: 'image/svg+xml' });
+  ensureLink('icon', FAVICON_PATH, { type: 'image/svg+xml' });
   ensureLink('mask-icon', APP_ICON_PATH, { color: '#050611' });
   ensureLink('apple-touch-icon', APP_ICON_PATH);
   ensureLink('manifest', MANIFEST_PATH);


### PR DESCRIPTION
## Summary
- Adds a canonical `/favicon.svg` fallback for browser favicon discovery.
- Points runtime favicon metadata at `/favicon.svg`.
- Keeps app/MediaSession artwork on `/img/app-icon.svg`.

## Issue
Refs #1768.

## Validation
- Not run locally: connector-only change.
- Expected check: hard-refresh web version and favicon should appear in the browser tab.