### PR TITLE
Restore atlas favicon

### DIFF
--- a/js/favicon-atlas.js
+++ b/js/favicon-atlas.js
@@ -1,0 +1,61 @@
+const ICON_ATLAS_PATH = '/assets/icon_atlas.webp';
+const FAVICON_SOURCE = {
+  x: 0,
+  y: 192,
+  width: 64,
+  height: 64,
+};
+
+function getOrCreateIconLink() {
+  let link = document.querySelector('link[rel="icon"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head?.append(link);
+  }
+  return link;
+}
+
+function setAtlasImageFallback() {
+  const link = getOrCreateIconLink();
+  link.type = 'image/webp';
+  link.href = ICON_ATLAS_PATH;
+}
+
+function installAtlasFavicon() {
+  if (typeof document === 'undefined' || typeof Image === 'undefined') return;
+
+  setAtlasImageFallback();
+
+  const atlas = new Image();
+  atlas.decoding = 'async';
+  atlas.onload = () => {
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = FAVICON_SOURCE.width;
+      canvas.height = FAVICON_SOURCE.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(
+        atlas,
+        FAVICON_SOURCE.x,
+        FAVICON_SOURCE.y,
+        FAVICON_SOURCE.width,
+        FAVICON_SOURCE.height,
+        0,
+        0,
+        FAVICON_SOURCE.width,
+        FAVICON_SOURCE.height,
+      );
+      const link = getOrCreateIconLink();
+      link.type = 'image/png';
+      link.href = canvas.toDataURL('image/png');
+    } catch (_error) {
+      setAtlasImageFallback();
+    }
+  };
+  atlas.onerror = () => setAtlasImageFallback();
+  atlas.src = ICON_ATLAS_PATH;
+}
+
+export { installAtlasFavicon };

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,7 @@ import { installStartupPerformanceTelemetry } from './startup-performance.js';
 import { installLeaderboardOverlay } from './leaderboard-overlay.js';
 import { installSilentLeaderboardPreload } from './leaderboard-cache.js';
 import { installStartGameLoadingIndicator } from './start-game-loading-indicator.js';
+import { installAtlasFavicon } from './favicon-atlas.js';
 import { configureAppMetadata } from './app-metadata.js';
 import {
   initPostHog,
@@ -93,6 +94,7 @@ async function bootstrap() {
   try {
     initLogger();
     configureAppMetadata();
+    installAtlasFavicon();
     installStartupPerformanceTelemetry();
     installLeaderboardOverlay();
     installSilentLeaderboardPreload();


### PR DESCRIPTION
## Summary
- Restores favicon from the existing `icon_atlas.webp` source.
- Reuses the same 64x64 atlas region that `index.html` already used.
- Reapplies the atlas favicon after app metadata setup so it is not overwritten.

## Issue
Refs #1768.

## Validation
- Not run locally: connector-only change.
- Expected check: hard-refresh web version and confirm the browser tab shows the atlas favicon again.