### PR TITLE
Restore web soundtrack playback

### DIFF
--- a/js/app-metadata.js
+++ b/js/app-metadata.js
@@ -6,12 +6,17 @@ const WEB_MENU_STYLES_PATH = '/css/web-menu-layout.css';
 
 function isTelegramRuntime() {
   if (typeof window === 'undefined') return false;
+
+  const params = new URLSearchParams(window.location?.search || '');
+  const userAgent = navigator?.userAgent || '';
+
   return Boolean(
-    window.__URSASS_IS_TELEGRAM_RUNTIME__
-    || window.Telegram?.WebApp
+    window.__URSASS_IS_TELEGRAM_RUNTIME__ === true
+    || window.Telegram?.WebApp?.initData
+    || params.has('tgWebAppData')
     || document?.documentElement?.classList?.contains('telegram-runtime')
     || document?.body?.classList?.contains('telegram-runtime')
-    || /Telegram/i.test(navigator?.userAgent || '')
+    || /Telegram/i.test(userAgent)
   );
 }
 


### PR DESCRIPTION
## Summary
- Tightens Telegram runtime detection used by the media policy.
- Stops treating the mere presence of `window.Telegram.WebApp` as Telegram runtime.
- Keeps the Telegram media policy gated to real Telegram signals such as initData, tgWebAppData, Telegram user agent, or runtime classes.

## Issue
Refs #1766.

## Validation
- Not run locally: connector-only change.
- Expected check: web soundtracks play again; Telegram still suppresses the system media widget behavior.