### PR TITLE
Tighten Phaser Telegram runtime check

### DIFF
--- a/js/phaser/runtime.js
+++ b/js/phaser/runtime.js
@@ -9,11 +9,17 @@ async function loadPhaserModule() {
 
 function isTelegramRuntime() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+
+  const params = new URLSearchParams(window.location?.search || '');
+  const userAgent = navigator?.userAgent || '';
+
   return Boolean(
-    window.__URSASS_IS_TELEGRAM_RUNTIME__
-    || window.Telegram?.WebApp
+    window.__URSASS_IS_TELEGRAM_RUNTIME__ === true
+    || window.Telegram?.WebApp?.initData
+    || params.has('tgWebAppData')
     || document.documentElement?.classList?.contains('telegram-runtime')
     || document.body?.classList?.contains('telegram-runtime')
+    || /Telegram/i.test(userAgent)
   );
 }
 


### PR DESCRIPTION
## Summary
- Aligns Phaser runtime Telegram detection with the stricter app metadata check from #1777.
- Stops treating the mere presence of `window.Telegram.WebApp` as Telegram runtime.
- Keeps Telegram Canvas renderer gated to real Telegram signals: `initData`, `tgWebAppData`, runtime class, or Telegram user agent.

## Issue
Refs #1744.

## Validation
- Not run locally: connector-only change.
- Expected check: normal web runtime can use Phaser.AUTO again; Telegram runtime still uses Canvas renderer for freeze mitigation.