### PR TITLE
Add render diagnostics snapshot

### DIFF
--- a/js/game/loop.js
+++ b/js/game/loop.js
@@ -39,6 +39,17 @@ function createGameLoopController({
     loopActive = false;
   }
 
+  function updateRenderTimingStats(now = performance.now()) {
+    const debugStats = gameState.debugStats;
+    const lastRenderAt = Number(gameState.lastGameplayRenderAtMs) || 0;
+    const lastSimulationAt = Number(gameState.lastSimulationUpdateAtMs) || 0;
+    debugStats.lastRenderAgeMs = lastRenderAt > 0 ? Math.max(0, now - lastRenderAt) : 0;
+    debugStats.lastSimulationAgeMs = lastSimulationAt > 0 ? Math.max(0, now - lastSimulationAt) : 0;
+    debugStats.renderBehindMs = lastRenderAt > 0 && lastSimulationAt > 0
+      ? Math.max(0, lastSimulationAt - lastRenderAt)
+      : 0;
+  }
+
   function gameLoop(time) {
     if (!loopActive) return;
     const frameStart = performance.now();
@@ -81,7 +92,8 @@ function createGameLoopController({
       try {
         const drawStart = performance.now();
         renderFrame();
-        debugStats.drawMs = performance.now() - drawStart;
+        gameState.lastGameplayRenderAtMs = performance.now();
+        debugStats.drawMs = gameState.lastGameplayRenderAtMs - drawStart;
       } catch (error) {
         logger.error("❌ Draw error:", error);
       }
@@ -91,11 +103,13 @@ function createGameLoopController({
       try {
         const updateStart = performance.now();
         updateFrame(delta);
-        debugStats.updateMs = performance.now() - updateStart;
+        gameState.lastSimulationUpdateAtMs = performance.now();
+        debugStats.updateMs = gameState.lastSimulationUpdateAtMs - updateStart;
       } catch (error) {
         logger.error("❌ Update error:", error);
         onUpdateError(error);
         debugStats.frameMs = performance.now() - frameStart;
+        updateRenderTimingStats();
         if (loopActive) requestAnimationFrame(gameLoop);
         return;
       }
@@ -110,6 +124,7 @@ function createGameLoopController({
     }
 
     debugStats.frameMs = performance.now() - frameStart;
+    updateRenderTimingStats();
     if (loopActive) requestAnimationFrame(gameLoop);
   }
 

--- a/js/game/loop.js
+++ b/js/game/loop.js
@@ -10,7 +10,10 @@ function createGameLoopController({
   onUpdateError,
   logger
 }) {
+  const RENDER_DRIFT_WARN_MS = 1600;
+  const RENDER_DRIFT_LOG_COOLDOWN_MS = 12000;
   let loopActive = false;
+  let lastRenderDriftLogAt = 0;
 
   function runAfterLayoutStabilizes(callback) {
     requestAnimationFrame(() => {
@@ -43,11 +46,33 @@ function createGameLoopController({
     const debugStats = gameState.debugStats;
     const lastRenderAt = Number(gameState.lastGameplayRenderAtMs) || 0;
     const lastSimulationAt = Number(gameState.lastSimulationUpdateAtMs) || 0;
-    debugStats.lastRenderAgeMs = lastRenderAt > 0 ? Math.max(0, now - lastRenderAt) : 0;
-    debugStats.lastSimulationAgeMs = lastSimulationAt > 0 ? Math.max(0, now - lastSimulationAt) : 0;
-    debugStats.renderBehindMs = lastRenderAt > 0 && lastSimulationAt > 0
+    const renderBehindMs = lastRenderAt > 0 && lastSimulationAt > 0
       ? Math.max(0, lastSimulationAt - lastRenderAt)
       : 0;
+
+    debugStats.lastRenderAgeMs = lastRenderAt > 0 ? Math.max(0, now - lastRenderAt) : 0;
+    debugStats.lastSimulationAgeMs = lastSimulationAt > 0 ? Math.max(0, now - lastSimulationAt) : 0;
+    debugStats.renderBehindMs = renderBehindMs;
+
+    const shouldLogRenderDrift = Boolean(
+      (gameState.simulationRunning || gameState.running)
+      && gameState.heavyRenderEnabled !== false
+      && renderBehindMs >= RENDER_DRIFT_WARN_MS
+      && now - lastRenderDriftLogAt >= RENDER_DRIFT_LOG_COOLDOWN_MS
+    );
+
+    if (shouldLogRenderDrift) {
+      lastRenderDriftLogAt = now;
+      logger.warn('[render diagnostics] render is behind simulation', {
+        renderBehindMs: Math.round(renderBehindMs),
+        runtimeScreen: gameState.screen || 'unknown',
+        renderQuality: gameState.renderQuality || 'unknown',
+        heavyRenderEnabled: Boolean(gameState.heavyRenderEnabled),
+        frameMs: Number(debugStats.frameMs || 0),
+        drawMs: Number(debugStats.drawMs || 0),
+        updateMs: Number(debugStats.updateMs || 0)
+      });
+    }
   }
 
   function gameLoop(time) {

--- a/js/render-snapshot.js
+++ b/js/render-snapshot.js
@@ -11,6 +11,28 @@ function collectLampEntries(items, predicate = () => true) {
     .map((item) => ({ z: item.z }));
 }
 
+function getNowMs() {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now();
+  return Date.now();
+}
+
+function createRenderDiagnostics() {
+  const now = getNowMs();
+  const lastRenderAt = Number(gameState.lastGameplayRenderAtMs) || 0;
+  const lastSimulationAt = Number(gameState.lastSimulationUpdateAtMs) || 0;
+  const renderBehindMs = lastRenderAt > 0 && lastSimulationAt > 0
+    ? Math.max(0, lastSimulationAt - lastRenderAt)
+    : 0;
+
+  return {
+    lastGameplayRenderAtMs: lastRenderAt,
+    lastSimulationUpdateAtMs: lastSimulationAt,
+    lastRenderAgeMs: lastRenderAt > 0 ? Math.max(0, now - lastRenderAt) : null,
+    lastSimulationAgeMs: lastSimulationAt > 0 ? Math.max(0, now - lastSimulationAt) : null,
+    renderBehindSimulationMs: renderBehindMs,
+  };
+}
+
 function createRenderSnapshot({ width, height, backend = 'phaser' }) {
   const viewportWidth = Math.max(1, Math.round(width || 1));
   const viewportHeight = Math.max(1, Math.round(height || 1));
@@ -29,7 +51,8 @@ function createRenderSnapshot({ width, height, backend = 'phaser' }) {
     gameState.collectAnimations.length = 0;
   }
 
-  return {
+  const renderDiagnostics = createRenderDiagnostics();
+  const snapshot = {
     backend,
     viewport: {
       width: viewportWidth,
@@ -82,9 +105,21 @@ function createRenderSnapshot({ width, height, backend = 'phaser' }) {
       preparingGameplay: Boolean(gameState.preparingGameplay),
       simulationRunning: Boolean(gameState.simulationRunning || gameState.running),
       firstFrameMode: Boolean(gameState.firstFrameMode),
-      heavyRenderEnabled: Boolean(gameState.heavyRenderEnabled)
+      heavyRenderEnabled: Boolean(gameState.heavyRenderEnabled),
+      renderQuality: gameState.renderQuality || 'unknown',
+      renderDiagnostics
     }
   };
+
+  if (typeof window !== 'undefined') {
+    window.__URSASS_RENDER_SNAPSHOT__ = () => ({
+      runtime: { ...snapshot.runtime },
+      debugStats: gameState.debugStats ? { ...gameState.debugStats } : null,
+      timestamp: Date.now(),
+    });
+  }
+
+  return snapshot;
 }
 
-export { createRenderSnapshot };
+export { createRenderSnapshot, createRenderDiagnostics };


### PR DESCRIPTION
## Summary
- Tracks last gameplay render and simulation update timestamps in the main loop.
- Adds throttled render-drift diagnostics when simulation continues but render timestamps lag.
- Extends render snapshots with `renderQuality`, `heavyRenderEnabled`, and render/simulation timing data.
- Adds QA helper `window.__URSASS_RENDER_SNAPSHOT__()` for quick runtime inspection.

## Issue
Refs #1743.

## Notes
- `perf.js` full-file update was blocked by connector safety checks, so this PR keeps the implementation in loop/snapshot paths.
- Existing `DEBUG_FPS=1` perf logs still report FPS, quality, draw/update/frame times; this PR adds the missing render-vs-simulation timing source.

## Validation
- Not run locally: connector-only change.
- Expected check: during gameplay QA can run `window.__URSASS_RENDER_SNAPSHOT__()` and inspect renderer/simulation timing without log spam.