### PR TITLE
Add static baseline report

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:e2e-smoke": "npm run check:mig08-smoke",
     "test:request": "node --test scripts/request.test.mjs scripts/auth-service.test.mjs scripts/donation-service.test.mjs scripts/upgrades-math.test.mjs scripts/runtime-lifecycle.test.mjs scripts/phaser-runtime-controller.test.mjs scripts/game-loop-controller.test.mjs scripts/analytics.test.mjs scripts/store-analytics.test.mjs scripts/analytics-metrics.test.mjs scripts/startup-performance.test.mjs scripts/entity-render-passes.test.mjs scripts/onboarding-hints.test.mjs scripts/tunnel-math-utils.test.mjs scripts/mobile-perf-gate.test.mjs scripts/observability-gate.test.mjs scripts/rollback-gate.test.mjs scripts/collision-reaction-metrics.test.mjs scripts/input-feedback-metrics.test.mjs scripts/difficulty-segmentation.test.mjs scripts/security-gate-report.test.mjs scripts/release-gates.test.mjs scripts/game-over-copy.test.mjs scripts/leaderboard-insights.test.mjs scripts/referral-code.test.mjs scripts/rides-service.test.mjs scripts/telegram-auth-lifecycle.test.mjs scripts/app-loading.test.mjs scripts/loading-ui-regression.test.mjs scripts/auth-callbacks.test.mjs scripts/player-menu-history-web.test.mjs",
     "report:metrics": "node scripts/build-product-metrics-report.mjs",
+    "report:static-baselines": "node scripts/report-static-baselines.mjs",
     "check:syntax": "node scripts/check-syntax.mjs",
     "prepare": "node scripts/setup-hooks.mjs",
     "check:conflicts": "node scripts/check-no-conflict-markers.mjs",

--- a/scripts/report-static-baselines.mjs
+++ b/scripts/report-static-baselines.mjs
@@ -1,0 +1,47 @@
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const staticAnalysisPath = path.join(rootDir, 'scripts/check-static-analysis.mjs');
+const staticAnalysisSource = readFileSync(staticAnalysisPath, 'utf8');
+
+function parseSet(name) {
+  const match = staticAnalysisSource.match(new RegExp(`const ${name} = new Set\\(\\[([\\s\\S]*?)\\]\\);`));
+  if (!match) return [];
+  return [...match[1].matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
+}
+
+function getLineCount(file) {
+  const absolutePath = path.join(rootDir, file);
+  if (!existsSync(absolutePath)) return null;
+  return readFileSync(absolutePath, 'utf8').split('\n').length;
+}
+
+function printSection(title, lines) {
+  console.log(`\n${title}`);
+  if (lines.length === 0) {
+    console.log('- none');
+    return;
+  }
+  for (const line of lines) console.log(`- ${line}`);
+}
+
+const oversized = parseSet('BASELINE_OVERSIZED');
+const unusedExports = parseSet('BASELINE_UNUSED_EXPORTS');
+const implicitGlobalWrites = parseSet('BASELINE_IMPLICIT_GLOBAL_WRITES');
+
+printSection('Oversized baseline', oversized.map((file) => {
+  const lineCount = getLineCount(file);
+  return lineCount === null ? `${file}: missing file` : `${file}: ${lineCount} lines`;
+}));
+
+printSection('Unused export baseline', unusedExports);
+printSection('Implicit global-write baseline', implicitGlobalWrites);
+
+console.log('\nReview notes');
+console.log('- Remove baseline entries only after `npm run check:static-analysis` passes without them.');
+console.log('- If an oversized file drops below the guard threshold, remove it from BASELINE_OVERSIZED.');
+console.log('- If an implicit global write no longer reproduces, remove it from BASELINE_IMPLICIT_GLOBAL_WRITES.');


### PR DESCRIPTION
## Summary
- Adds `npm run report:static-baselines`.
- Reports current static-analysis baseline entries.
- Does not change existing CI gates.

Refs #1790.
Refs #1791.

Base: `dev2`.