### PR TITLE
Add CSS size report

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:request": "node --test scripts/request.test.mjs scripts/auth-service.test.mjs scripts/donation-service.test.mjs scripts/upgrades-math.test.mjs scripts/runtime-lifecycle.test.mjs scripts/phaser-runtime-controller.test.mjs scripts/game-loop-controller.test.mjs scripts/analytics.test.mjs scripts/store-analytics.test.mjs scripts/analytics-metrics.test.mjs scripts/startup-performance.test.mjs scripts/entity-render-passes.test.mjs scripts/onboarding-hints.test.mjs scripts/tunnel-math-utils.test.mjs scripts/mobile-perf-gate.test.mjs scripts/observability-gate.test.mjs scripts/rollback-gate.test.mjs scripts/collision-reaction-metrics.test.mjs scripts/input-feedback-metrics.test.mjs scripts/difficulty-segmentation.test.mjs scripts/security-gate-report.test.mjs scripts/release-gates.test.mjs scripts/game-over-copy.test.mjs scripts/leaderboard-insights.test.mjs scripts/referral-code.test.mjs scripts/rides-service.test.mjs scripts/telegram-auth-lifecycle.test.mjs scripts/app-loading.test.mjs scripts/loading-ui-regression.test.mjs scripts/auth-callbacks.test.mjs scripts/player-menu-history-web.test.mjs",
     "report:metrics": "node scripts/build-product-metrics-report.mjs",
     "report:static-baselines": "node scripts/report-static-baselines.mjs",
+    "report:css-size": "node scripts/report-css-size.mjs",
     "check:syntax": "node scripts/check-syntax.mjs",
     "prepare": "node scripts/setup-hooks.mjs",
     "check:conflicts": "node scripts/check-no-conflict-markers.mjs",

--- a/scripts/report-css-size.mjs
+++ b/scripts/report-css-size.mjs
@@ -1,0 +1,46 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const roots = ['css', 'public/css'];
+
+function walk(dirPath, bucket) {
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, bucket);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.css')) continue;
+    bucket.push(fullPath);
+  }
+}
+
+const files = [];
+for (const root of roots) {
+  const absoluteRoot = path.join(rootDir, root);
+  try {
+    if (statSync(absoluteRoot).isDirectory()) walk(absoluteRoot, files);
+  } catch (_error) {}
+}
+
+const rows = files.map((absolutePath) => {
+  const source = readFileSync(absolutePath, 'utf8');
+  const lines = source.split('\n').length;
+  const loc = source.split('\n').filter((line) => line.trim() && !line.trim().startsWith('/*')).length;
+  const bytes = Buffer.byteLength(source, 'utf8');
+  return {
+    file: path.relative(rootDir, absolutePath).replaceAll(path.sep, '/'),
+    lines,
+    loc,
+    kb: Number((bytes / 1024).toFixed(1)),
+  };
+}).sort((a, b) => b.lines - a.lines || b.kb - a.kb);
+
+console.log('CSS size report');
+for (const row of rows) {
+  console.log(`- ${row.file}: ${row.lines} lines, ${row.loc} loc, ${row.kb} KB`);
+}


### PR DESCRIPTION
## Summary
- Adds `npm run report:css-size`.
- Reports CSS file size by lines, LOC, and KB.
- Prepares safe follow-up splitting of large UI styles.

Refs #1788.
Refs #1791.

Base: `dev2`.