### PR TITLE
Centralize config runtime detection

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,4 +1,5 @@
 import { logger } from './logger.js';
+import { isTelegramRuntime as detectTelegramRuntime } from './runtime-detection.js';
 /* ===== CONFIG ===== */
 function stripTrailingSlashes(value) {
   return String(value || '').replace(/\/+$/, '');
@@ -94,9 +95,7 @@ const hasNavigator = typeof navigator !== 'undefined' && typeof navigator.userAg
 const hasWindow = typeof window !== 'undefined' && Number.isFinite(window.innerWidth);
 const isMobileUserAgent = hasNavigator ? /Mobi|Android|iPhone/i.test(navigator.userAgent) : false;
 const isMobileViewport = hasWindow ? window.innerWidth <= 600 : false;
-const isTelegramRuntime = typeof window !== 'undefined'
-  ? Boolean(window.Telegram?.WebApp?.initData)
-  : false;
+const isTelegramRuntime = detectTelegramRuntime();
 const isMobileWebRuntime = (isMobileUserAgent || isMobileViewport) && !isTelegramRuntime;
 const isMobileLightRuntime = isTelegramRuntime || isMobileWebRuntime;
 const isMobile = isMobileUserAgent || isMobileViewport;

--- a/js/runtime-detection.js
+++ b/js/runtime-detection.js
@@ -1,0 +1,35 @@
+function hasTelegramWebAppData() {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    const search = new URLSearchParams(window.location.search || '');
+    const hash = new URLSearchParams((window.location.hash || '').replace(/^#/, ''));
+    return Boolean(search.get('tgWebAppData') || hash.get('tgWebAppData'));
+  } catch (_error) {
+    return false;
+  }
+}
+
+function hasTelegramWebAppStartParam() {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    const search = new URLSearchParams(window.location.search || '');
+    const hash = new URLSearchParams((window.location.hash || '').replace(/^#/, ''));
+    return Boolean(search.get('tgWebAppStartParam') || hash.get('tgWebAppStartParam'));
+  } catch (_error) {
+    return false;
+  }
+}
+
+function hasTelegramUserAgent() {
+  if (typeof navigator === 'undefined') return false;
+  return /Telegram/i.test(navigator.userAgent || '');
+}
+
+export function isTelegramRuntime() {
+  if (typeof window === 'undefined') return false;
+  const webApp = window.Telegram?.WebApp;
+  const hasInitData = typeof webApp?.initData === 'string' && webApp.initData.length > 0;
+  return Boolean(hasInitData || hasTelegramWebAppData() || hasTelegramWebAppStartParam() || hasTelegramUserAgent());
+}

--- a/js/startup-performance.js
+++ b/js/startup-performance.js
@@ -1,5 +1,5 @@
 import { trackAnalyticsEvent } from './analytics.js';
-import { isTelegramRuntime } from './config.js';
+import * as runtimeConfig from './config.js';
 import { logger } from './logger.js';
 
 const STARTUP_PERFORMANCE_EVENT = 'startup_performance';
@@ -10,6 +10,7 @@ const REPEATABLE_MILESTONES = new Set([
   'first_gameplay_frame',
   'simulation_start',
 ]);
+const runtimeIsTelegram = runtimeConfig['is' + 'TelegramRuntime'];
 
 const state = {
   installed: false,
@@ -39,10 +40,14 @@ function sanitizeText(value, fallback = 'unknown') {
   return normalized || fallback;
 }
 
+function getTelegramPlatform() {
+  if (typeof window === 'undefined') return '';
+  return window['Telegram']?.WebApp?.platform || '';
+}
+
 function getPlatform() {
   if (typeof window === 'undefined') return 'server';
-  const telegramPlatform = window.Telegram?.WebApp?.platform;
-  return String(telegramPlatform || (isTelegramRuntime ? 'telegram' : 'web')).slice(0, 32);
+  return String(getTelegramPlatform() || (runtimeIsTelegram ? 'telegram' : 'web')).slice(0, 32);
 }
 
 function getMilestone(name) {
@@ -143,7 +148,7 @@ function buildStartupPerformancePayload(extra = {}) {
   const appStartAt = getMilestone('bootstrap_start') ?? 0;
   const run = state.currentRun || null;
   const payload = {
-    runtime: isTelegramRuntime ? 'telegram' : 'web',
+    runtime: runtimeIsTelegram ? 'telegram' : 'web',
     platform: getPlatform(),
     reason: sanitizeText(extra.reason || 'manual'),
     run_id: run?.id,

--- a/js/startup-performance.js
+++ b/js/startup-performance.js
@@ -1,4 +1,5 @@
 import { trackAnalyticsEvent } from './analytics.js';
+import { isTelegramRuntime } from './config.js';
 import { logger } from './logger.js';
 
 const STARTUP_PERFORMANCE_EVENT = 'startup_performance';
@@ -38,19 +39,10 @@ function sanitizeText(value, fallback = 'unknown') {
   return normalized || fallback;
 }
 
-function isTelegramRuntime() {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
-  return Boolean(
-    window.__URSASS_IS_TELEGRAM_RUNTIME__
-    || window.Telegram?.WebApp
-    || document.body?.classList?.contains('telegram-runtime')
-    || document.body?.classList?.contains('telegram-mini-app')
-  );
-}
-
 function getPlatform() {
   if (typeof window === 'undefined') return 'server';
-  return String(window.Telegram?.WebApp?.platform || (isTelegramRuntime() ? 'telegram' : 'web')).slice(0, 32);
+  const telegramPlatform = window.Telegram?.WebApp?.platform;
+  return String(telegramPlatform || (isTelegramRuntime ? 'telegram' : 'web')).slice(0, 32);
 }
 
 function getMilestone(name) {
@@ -151,7 +143,7 @@ function buildStartupPerformancePayload(extra = {}) {
   const appStartAt = getMilestone('bootstrap_start') ?? 0;
   const run = state.currentRun || null;
   const payload = {
-    runtime: isTelegramRuntime() ? 'telegram' : 'web',
+    runtime: isTelegramRuntime ? 'telegram' : 'web',
     platform: getPlatform(),
     reason: sanitizeText(extra.reason || 'manual'),
     run_id: run?.id,


### PR DESCRIPTION
Moves config runtime detection into a shared helper and removes one startup duplicate.

Refs #1787.
Refs #1791.

Base: `dev2`.