### PR TITLE
Cut over runtime SDK loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">
-  <!-- Intentional external runtime dependency for Telegram Mini App APIs -->
-  <script src="https://telegram.org/js/telegram-web-app.js" defer></script>
   <script>
     (() => {
       const isTelegramRuntime =


### PR DESCRIPTION
### Motivation
- Remove the static Telegram WebApp SDK script from `index.html` to complete Phase 1 runtime SDK cutover while preserving the inline runtime bootstrap and Telegram analytics behavior.

### Description
- Removed the comment and the `<script src="https://telegram.org/js/telegram-web-app.js" defer></script>` block from `index.html` using the existing codemod, leaving the inline runtime bootstrap and body markup unchanged.
- Did not modify any analytics-related files or the Telegram analytics bootstrap path in `js/main.js`, and `js/telegram-analytics.js` remains untouched.
- Change is limited to `index.html` only and references `#1787` and `#1791`.

### Testing
- Ran `npm run cutover:runtime-sdk:dry-run` and `npm run cutover:runtime-sdk`, with the dry-run reporting the block could be removed and the cutover script removing the two-line static SDK block from `index.html`.
- Verified `node scripts/check-no-static-runtime-script.mjs` and `npm run report:runtime-sdk-loading`, which reported no static SDK marker and `sdk_occurrences: 0`.
- Executed `npm run check`, which ran the full checks and tests but failed in `check:static-analysis` due to pre-existing unused-export violations unrelated to this `index.html` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a502eaa4c908329bef25a66bfd101b9)