### PR TITLE
Stage gameplay CSS module

### DIFF
--- a/css/gameplay.css
+++ b/css/gameplay.css
@@ -1,0 +1,289 @@
+/* ===== GAME START ===== */
+#gameStart {
+  display: flex;
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  text-align: center;
+  align-items: center;
+  justify-content: flex-start;
+  z-index: 100;
+  flex-direction: column;
+  padding: 220px 20px 20px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+#gameStart.hidden { display: none; }
+
+#gameStart > :not(.bear-wrapper):not(.start-audio-nav) {
+  transform: translateY(var(--start-ui-offset-y));
+}
+
+.start-audio-nav {
+  display: none;
+}
+
+.start-hint {
+  margin-top: 20px;
+  opacity: 0.5;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+#walletCorner,
+#bear3d,
+#gameStart .new-title,
+#gameStart .new-buttons,
+#startLeaderboardWrap,
+#gameStart footer {
+  transition: transform 0.9s cubic-bezier(.22, .8, .2, 1), opacity 0.7s ease, margin 0.9s cubic-bezier(.22, .8, .2, 1);
+}
+
+body.start-launching #walletCorner {
+  transform: translateX(180%);
+  opacity: 0;
+}
+
+#gameStart.start-launching {
+  justify-content: center;
+  overflow: hidden;
+}
+
+#gameStart.start-launching #bear3d {
+  /* Desktop: keep bear exactly as on the start screen (no resize/shift). */
+  margin-top: -50px;
+  margin-bottom: -250px;
+  margin-left: auto;
+  margin-right: auto;
+  transform: none;
+}
+
+#gameStart.start-launching .new-title {
+  margin-top: 8px;
+  transform: translateY(calc(56px + var(--start-ui-offset-y)));
+}
+
+#gameStart.start-launching .new-buttons,
+#gameStart.start-launching #startLeaderboardWrap,
+#gameStart.start-launching footer {
+  transform: translateY(calc(220px + var(--start-ui-offset-y)));
+  opacity: 0;
+  pointer-events: none;
+}
+
+
+/* ===== GAME CONTAINER ===== */
+#gameContainer {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100vw;
+  height: 100vh;
+  height: -webkit-fill-available;
+  height: 100dvh; /* modern mobile fallback */
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  touch-action: none;
+  overscroll-behavior: none;
+}
+
+#gameContainer.active { display: flex; padding: var(--sat) var(--sar) var(--sab) var(--sal); z-index: 50; }
+
+#gameWrapper {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  height: -webkit-fill-available;
+  height: 100dvh;
+  background: #0a0a15;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  touch-action: none;
+  overscroll-behavior: none;
+}
+
+#gameContent {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #0a0a15 0%, #15080f 100%);
+  width: 100%;
+  min-height: 0; /* вместо height: 100% — позволяет flex работать */
+}
+
+#gameContent canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  touch-action: none;
+  image-rendering: crisp-edges;
+}
+
+/* ===== GAME HUD ===== */
+#uiTopLeft {
+  position: absolute;
+  top: 12px; left: 12px;
+  z-index: 10;
+  background: transparent;
+  backdrop-filter: none;
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  border: none;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 11px;
+  width: 138px;
+  box-sizing: border-box;
+}
+
+#uiTopLeft > div { margin: 3px 0; font-weight: 600; }
+#uiTopLeft > div:last-child { margin-bottom: 0; }
+#uiTopLeft .speed { color: rgba(255,255,255,.9); }
+#uiTopLeft .score { color: #c084fc; }
+#uiTopLeft .distance { color: rgba(255,255,255,.8); }
+#uiTopLeft .hud-main-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+#uiTopLeft .hud-main-value {
+  min-width: 52px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+#uiTopRight {
+  position: absolute;
+  top: 12px; right: 12px;
+  z-index: 10;
+  background: transparent;
+  backdrop-filter: none;
+  padding: 10px 14px;
+  border-radius: var(--radius);
+  border: none;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 11px;
+  width: 138px;
+  box-sizing: border-box;
+}
+
+#uiTopRight > div {
+  margin: 3px 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+#uiTopRight .label {
+  opacity: 1;
+  order: 2;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+#uiTopRight .label .icon-atlas {
+  transform: scale(1.1);
+  transform-origin: center;
+  filter: none;
+}
+#uiTopRight .value {
+  order: 1;
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+  color: #c084fc;
+  font-size: 1.1em;
+  min-width: 70px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+#uiBottomCenter {
+  position: absolute;
+  bottom: 15px;
+  left: 50%; transform: translateX(-50%);
+  z-index: 10;
+  background: var(--glass);
+  backdrop-filter: blur(12px);
+  padding: 10px 20px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-accent);
+  text-align: center;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+}
+
+#uiBottomCenter .coins-row {
+  display: flex;
+  justify-content: space-around;
+  margin: 6px 0;
+  font-size: 14px; font-weight: 700;
+}
+
+#uiBottomCenter .coin { display: flex; align-items: center; gap: 5px; }
+#uiBottomCenter .coin .count { color: #c084fc; }
+#uiBottomCenter .speed-info { opacity: .7; font-size: 11px; }
+
+#uiBottomLeft {
+  position: absolute;
+  left: 14px;
+  bottom: 14px;
+  z-index: 10;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255,255,255,.8);
+}
+
+#fpsVal { color: #4caf50; font-weight: bold; }
+#fpsVal.slow { color: #ff9800; }
+#fpsVal.critical { color: #ff5252; }
+
+/* ===== IN-GAME AUDIO ===== */
+.game-audio-nav {
+  position: absolute;
+  right: 14px; bottom: 70px;
+  z-index: 15;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.game-audio-btn {
+  width: 40px; height: 40px;
+  display: flex;
+  align-items: center; justify-content: center;
+  font-size: 16px;
+  color: var(--text);
+  background: var(--glass);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: .3s;
+  padding: 0; line-height: 1;
+}
+
+.game-audio-btn:active { transform: scale(0.88); }
+.game-audio-btn.muted { opacity: 0.35; border-color: rgba(255,255,255,.05); }
+
+
+/* Icon glyph centering for round nav buttons */
+.app-audio-btn,
+.game-audio-btn {
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.app-back-btn,
+.pm-back-btn {
+  font-family: "Inter", "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -19,6 +19,7 @@ import '../css/base.css';
 import '../css/background.css';
 import '../css/hero.css';
 import '../css/start-screen.css';
+import '../css/gameplay.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
 

--- a/scripts/check-css-staged-sections.mjs
+++ b/scripts/check-css-staged-sections.mjs
@@ -10,6 +10,7 @@ const IMPORT_ORDER = [
   "import '../css/background.css';",
   "import '../css/hero.css';",
   "import '../css/start-screen.css';",
+  "import '../css/gameplay.css';",
   "import '../css/style.css';",
 ];
 
@@ -31,6 +32,12 @@ const SECTION_SPECS = [
     path: 'css/leaderboard.css',
     startMarker: '/* ===== LEADERBOARD ===== */',
     nextMarker: '/* ===== GAME START ===== */',
+  },
+  {
+    name: 'gameplay',
+    path: 'css/gameplay.css',
+    startMarker: '/* ===== GAME START ===== */',
+    nextMarker: '/* ===== GAME OVER ===== */',
   },
 ];
 
@@ -55,6 +62,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     heroPath: readArg('hero', 'css/hero.css'),
     startScreenPath: readArg('start-screen', 'css/start-screen.css'),
     leaderboardPath: readArg('leaderboard', 'css/leaderboard.css'),
+    gameplayPath: readArg('gameplay', 'css/gameplay.css'),
   };
 }
 
@@ -89,7 +97,7 @@ function assertImportOrder(mainSource) {
       throw new Error(`js/main.js must include ${statement}`);
     }
     if (index <= previousIndex) {
-      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, style');
+      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, style');
     }
     previousIndex = index;
   }
@@ -167,6 +175,7 @@ function analyzeCssStagedSections({
   heroSource,
   startScreenSource,
   leaderboardSource,
+  gameplaySource,
 }) {
   assertImportOrder(mainSource);
 
@@ -174,6 +183,7 @@ function analyzeCssStagedSections({
     background: backgroundSource,
     hero: heroSource,
     leaderboard: leaderboardSource,
+    gameplay: gameplaySource,
   };
 
   const sections = {};
@@ -202,6 +212,7 @@ function runCssStagedSectionsCheck(options = parseArgs()) {
     heroSource: readFileSync(options.heroPath, 'utf8'),
     startScreenSource: readFileSync(options.startScreenPath, 'utf8'),
     leaderboardSource: readFileSync(options.leaderboardPath, 'utf8'),
+    gameplaySource: readFileSync(options.gameplayPath, 'utf8'),
   });
 
   console.log('CSS staged sections check');

--- a/scripts/css-staged-sections.test.mjs
+++ b/scripts/css-staged-sections.test.mjs
@@ -30,8 +30,20 @@ const HOOK = `/* ===== START HOOK ===== */
 const LEADERBOARD = `/* ===== LEADERBOARD ===== */
 .lb { width: 100%; }`;
 
-const GAME_START = `/* ===== GAME START ===== */
-#gameStart { display: flex; }`;
+const GAMEPLAY = `/* ===== GAME START ===== */
+#gameStart { display: flex; }
+
+/* ===== GAME CONTAINER ===== */
+#gameContainer { display: none; }
+
+/* ===== GAME HUD ===== */
+#uiTopLeft { position: absolute; }
+
+/* ===== IN-GAME AUDIO ===== */
+.game-audio-nav { display: flex; }`;
+
+const GAME_OVER = `/* ===== GAME OVER ===== */
+#gameOver { display: none; }`;
 
 function styleSource() {
   return `${BACKGROUND}
@@ -44,7 +56,9 @@ ${HOOK}
 
 ${LEADERBOARD}
 
-${GAME_START}
+${GAMEPLAY}
+
+${GAME_OVER}
 `;
 }
 
@@ -58,6 +72,7 @@ function stagedSources() {
     heroSource: `${HERO}\n`,
     startScreenSource: `${LEADERBOARD_IMPORT}\n\n${TITLE}\n\n${HOOK}\n`,
     leaderboardSource: `${LEADERBOARD}\n`,
+    gameplaySource: `${GAMEPLAY}\n`,
   };
 }
 
@@ -82,20 +97,21 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
     ...stagedSources(),
   });
 
-  assert.equal(result.stagedDuplicateCount, 4);
+  assert.equal(result.stagedDuplicateCount, 5);
   assert.equal(result.extractedCount, 0);
   assert.equal(result.sections.startScreen.state, 'staged-duplicate');
+  assert.equal(result.sections.gameplay.state, 'staged-duplicate');
 });
 
 test('analyzeCssStagedSections accepts sections after duplicate removal', () => {
   const result = analyzeCssStagedSections({
-    styleSource: GAME_START,
+    styleSource: GAME_OVER,
     mainSource: mainSource(),
     ...stagedSources(),
   });
 
   assert.equal(result.stagedDuplicateCount, 0);
-  assert.equal(result.extractedCount, 4);
+  assert.equal(result.extractedCount, 5);
 });
 
 test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
@@ -110,7 +126,7 @@ test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
 });
 
 test('analyzeCssStagedSections rejects a partial start-screen extraction', () => {
-  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAME_START}\n`;
+  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n`;
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: partialStyle,
@@ -121,7 +137,7 @@ test('analyzeCssStagedSections rejects a partial start-screen extraction', () =>
 
 test('analyzeCssStagedSections requires CSS import order', () => {
   const wrongOrder = [...IMPORT_ORDER];
-  [wrongOrder[1], wrongOrder[2]] = [wrongOrder[2], wrongOrder[1]];
+  [wrongOrder[3], wrongOrder[4]] = [wrongOrder[4], wrongOrder[3]];
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: styleSource(),

--- a/scripts/remove-css-staged-duplicates.mjs
+++ b/scripts/remove-css-staged-duplicates.mjs
@@ -46,6 +46,13 @@ const SECTION_SPECS = [
     nextMarker: '/* ===== GAME START ===== */',
     stagedMode: 'whole',
   },
+  {
+    name: 'gameplay',
+    stagedPath: 'css/gameplay.css',
+    startMarker: '/* ===== GAME START ===== */',
+    nextMarker: '/* ===== GAME OVER ===== */',
+    stagedMode: 'whole',
+  },
 ];
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -60,6 +67,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     heroPath: readArg('hero', 'css/hero.css'),
     startScreenPath: readArg('start-screen', 'css/start-screen.css'),
     leaderboardPath: readArg('leaderboard', 'css/leaderboard.css'),
+    gameplayPath: readArg('gameplay', 'css/gameplay.css'),
   };
 }
 
@@ -123,6 +131,7 @@ function resolveSpecPaths(options) {
     'title-buttons': options.startScreenPath,
     'start-hook': options.startScreenPath,
     leaderboard: options.leaderboardPath,
+    gameplay: options.gameplayPath,
   };
 
   return SECTION_SPECS.map((spec) => ({

--- a/scripts/remove-css-staged-duplicates.test.mjs
+++ b/scripts/remove-css-staged-duplicates.test.mjs
@@ -18,7 +18,8 @@ const HERO = '/* ===== HERO / BEAR ===== */\n.bear { display: block; }';
 const TITLE = '/* ===== TITLE / BUTTONS ===== */\n.title { display: block; }';
 const START_HOOK = '/* ===== START HOOK ===== */\n.start-hook { display: block; }';
 const LEADERBOARD = '/* ===== LEADERBOARD ===== */\n.lb { display: block; }';
-const GAME_START = '/* ===== GAME START ===== */\n#gameStart { display: flex; }';
+const GAMEPLAY = '/* ===== GAME START ===== */\n#gameStart { display: flex; }\n\n/* ===== GAME CONTAINER ===== */\n#gameContainer { display: none; }';
+const GAME_OVER = '/* ===== GAME OVER ===== */\n#gameOver { display: none; }';
 
 const SPECS = [
   { name: 'base', stagedPath: 'css/base.css', startMarker: '/* ===== TOKENS / BASE ===== */', nextMarker: '/* ===== WALLET CORNER ===== */', stagedMode: 'whole' },
@@ -27,10 +28,11 @@ const SPECS = [
   { name: 'title-buttons', stagedPath: 'css/start-screen.css', startMarker: '/* ===== TITLE / BUTTONS ===== */', nextMarker: '/* ===== START HOOK ===== */', stagedMode: 'bounded' },
   { name: 'start-hook', stagedPath: 'css/start-screen.css', startMarker: '/* ===== START HOOK ===== */', nextMarker: '/* ===== LEADERBOARD ===== */', stagedMode: 'to-end' },
   { name: 'leaderboard', stagedPath: 'css/leaderboard.css', startMarker: '/* ===== LEADERBOARD ===== */', nextMarker: '/* ===== GAME START ===== */', stagedMode: 'whole' },
+  { name: 'gameplay', stagedPath: 'css/gameplay.css', startMarker: '/* ===== GAME START ===== */', nextMarker: '/* ===== GAME OVER ===== */', stagedMode: 'whole' },
 ];
 
 function styleSource() {
-  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAME_START}\n`;
+  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n`;
 }
 
 function stagedSources(overrides = {}) {
@@ -40,6 +42,7 @@ function stagedSources(overrides = {}) {
     ['css/hero.css', `${HERO}\n`],
     ['css/start-screen.css', `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`],
     ['css/leaderboard.css', `${LEADERBOARD}\n`],
+    ['css/gameplay.css', `${GAMEPLAY}\n`],
     ...Object.entries(overrides),
   ]);
 }
@@ -71,10 +74,11 @@ test('analyzeAndRemoveSections removes all staged duplicates atomically', () => 
     'title-buttons',
     'start-hook',
     'leaderboard',
+    'gameplay',
   ]);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
-  assert.match(result.styleSource, /\/\* ===== GAME START ===== \*\//);
-  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD/);
+  assert.match(result.styleSource, /\/\* ===== GAME OVER ===== \*\//);
+  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER/);
 });
 
 test('analyzeAndRemoveSections rejects a staged mismatch before returning output', () => {
@@ -87,7 +91,7 @@ test('analyzeAndRemoveSections rejects a staged mismatch before returning output
 
 test('analyzeAndRemoveSections accepts already extracted sections', () => {
   const result = analyzeAndRemoveSections({
-    styleSource: `${WALLET}\n\n${GAME_START}\n`,
+    styleSource: `${WALLET}\n\n${GAME_OVER}\n`,
     stagedSources: stagedSources(),
     specs: SPECS,
   });
@@ -97,11 +101,11 @@ test('analyzeAndRemoveSections accepts already extracted sections', () => {
 });
 
 test('analyzeAndRemoveSections supports a partially extracted migration', () => {
-  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAME_START}\n`;
+  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n`;
   const result = analyzeAndRemoveSections({ styleSource: source, stagedSources: stagedSources(), specs: SPECS });
 
   assert.deepEqual(result.alreadyExtracted, ['base']);
-  assert.equal(result.removed.length, 5);
+  assert.equal(result.removed.length, 6);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
 });
 
@@ -115,6 +119,7 @@ test('CLI dry-run leaves style.css unchanged and reports removals', () => {
   writeFileSync(join(root, 'css/hero.css'), `${HERO}\n`);
   writeFileSync(join(root, 'css/start-screen.css'), `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`);
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
+  writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath, '--dry-run'], {
@@ -137,6 +142,7 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   writeFileSync(join(root, 'css/hero.css'), `${HERO}\n`);
   writeFileSync(join(root, 'css/start-screen.css'), `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`);
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
+  writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath], {
@@ -147,5 +153,5 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   assert.equal(result.status, 0, result.stderr);
   const nextStyle = readFileSync(join(root, 'css/style.css'), 'utf8');
   assert.match(nextStyle, /^\/\* ===== WALLET CORNER ===== \*\//);
-  assert.match(nextStyle, /\/\* ===== GAME START ===== \*\//);
+  assert.match(nextStyle, /\/\* ===== GAME OVER ===== \*\//);
 });


### PR DESCRIPTION
## What changed
- added `css/gameplay.css` with the contiguous `GAME START` → `GAME OVER` block from `css/style.css`;
- imported it after `start-screen.css` and before `style.css`, preserving the current cascade;
- extended `check:css-staged-sections` to validate gameplay parity and import order;
- extended the staged duplicate-removal codemod so gameplay can be removed atomically with the previously staged sections;
- updated both guard test suites.

## Scope
The staged module includes:
- game start/launch transition;
- game container and canvas wrapper;
- HUD;
- in-game audio/navigation glyph rules.

Responsive rules remain in `css/style.css` for a later dedicated extraction.

## Validation
- `node --test scripts/css-staged-sections.test.mjs scripts/remove-css-staged-duplicates.test.mjs` — 16/16 passed locally;
- syntax checks pass for the changed JS modules;
- `css/style.css` is unchanged in this PR, so runtime declarations still resolve through the existing monolith as the final cascade layer.

Refs #1788.
Refs #1791.