### PR TITLE
Stage game over CSS module

### DIFF
--- a/css/game-over.css
+++ b/css/game-over.css
@@ -1,0 +1,315 @@
+/* ===== GAME OVER ===== */
+#gameOver {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  overflow-y: auto;
+}
+
+#gameOver.visible {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 40px 20px;
+}
+
+.go-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 3, 11, .92);
+  z-index: -1;
+}
+
+.go-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 42px;
+  font-weight: 800;
+  background: var(--grad);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 10px;
+  animation: fadeUp 0.8s ease forwards;
+  opacity: 0;
+}
+
+.go-reason {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 20px;
+  padding: 10px 24px;
+  background: rgba(255, 255, 255, .04);
+  border: 1px solid rgba(140, 80, 255, .25);
+  border-radius: var(--radius-pill);
+  animation: fadeUp 0.8s ease 0.1s forwards;
+  opacity: 0;
+}
+
+.go-reason-text {
+  background: linear-gradient(90deg, #ff6b6b, #ff8e8e, #c084ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.go-score-hero {
+  margin: 0 0 16px;
+  text-align: center;
+  animation: fadeUp 0.8s ease 0.15s forwards;
+  opacity: 0;
+}
+
+.go-score-label {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 1.8px;
+  color: rgba(255, 255, 255, 0.72);
+  margin-bottom: 4px;
+}
+
+.go-score-value {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 48px;
+  font-weight: 800;
+  line-height: 1;
+  color: #f8fafc;
+}
+
+.go-hook {
+  width: 100%;
+  max-width: 440px;
+  text-align: center;
+  margin-bottom: 18px;
+  border-radius: 14px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, rgba(251, 191, 36, .16), rgba(74, 222, 128, .16));
+  border: 1px solid rgba(251, 191, 36, .45);
+  box-shadow: 0 0 22px rgba(251, 191, 36, .18);
+  animation: fadeUp 0.8s ease 0.18s forwards;
+  opacity: 0;
+}
+
+.go-boost,
+.go-comparison,
+.go-next-target {
+  width: 100%;
+  text-align: center;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 15px;
+  font-family: 'Orbitron', sans-serif;
+}
+
+.go-boost {
+  color: #fde68a;
+  font-size: 26px;
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: .6px;
+  margin-bottom: 4px;
+  text-shadow: 0 0 16px rgba(251, 191, 36, .45);
+}
+
+.go-next-target {
+  margin-top: 6px;
+  color: #fef3c7;
+  font-weight: 700;
+  letter-spacing: .3px;
+}
+
+.go-next-target {
+  white-space: pre-line;
+  cursor: pointer;
+}
+
+.go-hook-loading .go-boost,
+.go-hook-loading .go-comparison,
+.go-hook-loading .go-next-target {
+  color: transparent;
+  border-radius: 8px;
+  background: linear-gradient(90deg, rgba(255,255,255,.08) 0%, rgba(255,255,255,.18) 50%, rgba(255,255,255,.08) 100%);
+  background-size: 240% 100%;
+  animation: shimmer 1.2s infinite;
+  min-height: 20px;
+}
+
+.go-hook-loading .go-next-target {
+  margin-top: 8px;
+}
+
+.go-stats {
+  width: 100%;
+  max-width: 400px;
+  background: transparent;
+  border-radius: 15px;
+  border: none;
+  padding: 6px 0 0;
+  margin-bottom: 25px;
+  animation: fadeUp 0.8s ease 0.2s forwards;
+  opacity: 0;
+}
+
+.go-stat-row {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 18px;
+  padding: 0;
+  border-bottom: none;
+  font-family: 'Orbitron', sans-serif;
+}
+
+.go-stat-row-coins {
+  justify-content: center;
+}
+
+.go-coins-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 20px;
+}
+
+.go-coins-pill-gold {
+  color: #fef3c7;
+  border: 1px solid rgba(251, 191, 36, .52);
+  background: rgba(251, 191, 36, .16);
+}
+
+.go-coins-pill-silver {
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, .58);
+  background: rgba(148, 163, 184, .16);
+}
+
+.go-buttons {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 320px;
+  gap: 12px;
+  justify-content: center;
+  margin-bottom: 30px;
+  animation: fadeUp 0.8s ease 0.3s forwards;
+  opacity: 0;
+}
+
+.go-btn {
+  padding: 14px 35px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  border: none;
+  border-radius: var(--radius);
+  color: var(--text);
+  cursor: pointer;
+  transition: .4s;
+  position: relative;
+  overflow: hidden;
+  backdrop-filter: blur(10px);
+}
+
+.go-btn:active { transform: scale(0.95); }
+
+.go-btn-restart {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background: var(--glass2);
+  border: 1px solid rgba(34, 211, 238, .85);
+  box-shadow: none;
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: 1.2px;
+  color: #fff;
+  text-shadow: none;
+}
+
+.go-btn-restart:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 20px rgba(34, 211, 238, .30);
+}
+
+@keyframes buttonAuraPulse {
+  0% {
+    background-position: 0% 50%;
+    opacity: .78;
+  }
+  50% {
+    background-position: 100% 50%;
+    opacity: 1;
+  }
+  100% {
+    background-position: 0% 50%;
+    opacity: .78;
+  }
+}
+
+
+.go-btn-share {
+  background: rgba(14, 116, 144, .18);
+  border-color: rgba(56, 189, 248, .30);
+  font-size: 13px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.go-btn-share:hover {
+  box-shadow: 0 0 20px rgba(56, 189, 248, .2);
+  transform: translateY(-2px);
+}
+
+.go-btn-share:disabled {
+  opacity: .7;
+  cursor: progress;
+  transform: none;
+  box-shadow: none;
+}
+
+.go-btn-menu {
+  background: rgba(255, 255, 255, .04);
+  border-color: rgba(255,255,255,.12);
+  color: rgba(255,255,255,.62);
+  font-size: 12px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.go-btn-menu:hover {
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
+  transform: translateY(-2px);
+  border-color: rgba(148, 163, 184, .42);
+  color: rgba(255,255,255,.8);
+}
+
+.go-lb-wrap {
+  width: 100%;
+  max-width: 440px;
+  margin-left: auto; margin-right: auto;
+  animation: fadeUp 0.8s ease 0.4s forwards;
+  opacity: 0;
+}
+
+.go-lb-notice {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(251, 191, 36, 0.28);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.go-lb-wrap .lb { margin-top: 0; max-width: 100%; }
+.go-lb-wrap .lb-list {
+  max-height: none;
+  overflow-y: visible;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -20,6 +20,7 @@ import '../css/background.css';
 import '../css/hero.css';
 import '../css/start-screen.css';
 import '../css/gameplay.css';
+import '../css/game-over.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
 

--- a/scripts/check-css-staged-sections.mjs
+++ b/scripts/check-css-staged-sections.mjs
@@ -11,6 +11,7 @@ const IMPORT_ORDER = [
   "import '../css/hero.css';",
   "import '../css/start-screen.css';",
   "import '../css/gameplay.css';",
+  "import '../css/game-over.css';",
   "import '../css/style.css';",
 ];
 
@@ -39,6 +40,12 @@ const SECTION_SPECS = [
     startMarker: '/* ===== GAME START ===== */',
     nextMarker: '/* ===== GAME OVER ===== */',
   },
+  {
+    name: 'game-over',
+    path: 'css/game-over.css',
+    startMarker: '/* ===== GAME OVER ===== */',
+    nextMarker: '/* ===== STORE ===== */',
+  },
 ];
 
 const START_SCREEN_SECTIONS = [
@@ -63,6 +70,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     startScreenPath: readArg('start-screen', 'css/start-screen.css'),
     leaderboardPath: readArg('leaderboard', 'css/leaderboard.css'),
     gameplayPath: readArg('gameplay', 'css/gameplay.css'),
+    gameOverPath: readArg('game-over', 'css/game-over.css'),
   };
 }
 
@@ -97,7 +105,7 @@ function assertImportOrder(mainSource) {
       throw new Error(`js/main.js must include ${statement}`);
     }
     if (index <= previousIndex) {
-      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, style');
+      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, style');
     }
     previousIndex = index;
   }
@@ -176,6 +184,7 @@ function analyzeCssStagedSections({
   startScreenSource,
   leaderboardSource,
   gameplaySource,
+  gameOverSource,
 }) {
   assertImportOrder(mainSource);
 
@@ -184,6 +193,7 @@ function analyzeCssStagedSections({
     hero: heroSource,
     leaderboard: leaderboardSource,
     gameplay: gameplaySource,
+    'game-over': gameOverSource,
   };
 
   const sections = {};
@@ -213,6 +223,7 @@ function runCssStagedSectionsCheck(options = parseArgs()) {
     startScreenSource: readFileSync(options.startScreenPath, 'utf8'),
     leaderboardSource: readFileSync(options.leaderboardPath, 'utf8'),
     gameplaySource: readFileSync(options.gameplayPath, 'utf8'),
+    gameOverSource: readFileSync(options.gameOverPath, 'utf8'),
   });
 
   console.log('CSS staged sections check');

--- a/scripts/css-staged-sections.test.mjs
+++ b/scripts/css-staged-sections.test.mjs
@@ -45,6 +45,9 @@ const GAMEPLAY = `/* ===== GAME START ===== */
 const GAME_OVER = `/* ===== GAME OVER ===== */
 #gameOver { display: none; }`;
 
+const STORE = `/* ===== STORE ===== */
+#storeScreen { display: none; }`;
+
 function styleSource() {
   return `${BACKGROUND}
 
@@ -59,6 +62,8 @@ ${LEADERBOARD}
 ${GAMEPLAY}
 
 ${GAME_OVER}
+
+${STORE}
 `;
 }
 
@@ -73,6 +78,7 @@ function stagedSources() {
     startScreenSource: `${LEADERBOARD_IMPORT}\n\n${TITLE}\n\n${HOOK}\n`,
     leaderboardSource: `${LEADERBOARD}\n`,
     gameplaySource: `${GAMEPLAY}\n`,
+    gameOverSource: `${GAME_OVER}\n`,
   };
 }
 
@@ -97,21 +103,22 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
     ...stagedSources(),
   });
 
-  assert.equal(result.stagedDuplicateCount, 5);
+  assert.equal(result.stagedDuplicateCount, 6);
   assert.equal(result.extractedCount, 0);
   assert.equal(result.sections.startScreen.state, 'staged-duplicate');
   assert.equal(result.sections.gameplay.state, 'staged-duplicate');
+  assert.equal(result.sections['game-over'].state, 'staged-duplicate');
 });
 
 test('analyzeCssStagedSections accepts sections after duplicate removal', () => {
   const result = analyzeCssStagedSections({
-    styleSource: GAME_OVER,
+    styleSource: STORE,
     mainSource: mainSource(),
     ...stagedSources(),
   });
 
   assert.equal(result.stagedDuplicateCount, 0);
-  assert.equal(result.extractedCount, 5);
+  assert.equal(result.extractedCount, 6);
 });
 
 test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
@@ -126,7 +133,7 @@ test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
 });
 
 test('analyzeCssStagedSections rejects a partial start-screen extraction', () => {
-  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n`;
+  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n`;
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: partialStyle,
@@ -137,7 +144,7 @@ test('analyzeCssStagedSections rejects a partial start-screen extraction', () =>
 
 test('analyzeCssStagedSections requires CSS import order', () => {
   const wrongOrder = [...IMPORT_ORDER];
-  [wrongOrder[3], wrongOrder[4]] = [wrongOrder[4], wrongOrder[3]];
+  [wrongOrder[4], wrongOrder[5]] = [wrongOrder[5], wrongOrder[4]];
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: styleSource(),

--- a/scripts/remove-css-staged-duplicates.mjs
+++ b/scripts/remove-css-staged-duplicates.mjs
@@ -53,6 +53,13 @@ const SECTION_SPECS = [
     nextMarker: '/* ===== GAME OVER ===== */',
     stagedMode: 'whole',
   },
+  {
+    name: 'game-over',
+    stagedPath: 'css/game-over.css',
+    startMarker: '/* ===== GAME OVER ===== */',
+    nextMarker: '/* ===== STORE ===== */',
+    stagedMode: 'whole',
+  },
 ];
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -68,6 +75,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     startScreenPath: readArg('start-screen', 'css/start-screen.css'),
     leaderboardPath: readArg('leaderboard', 'css/leaderboard.css'),
     gameplayPath: readArg('gameplay', 'css/gameplay.css'),
+    gameOverPath: readArg('game-over', 'css/game-over.css'),
   };
 }
 
@@ -132,6 +140,7 @@ function resolveSpecPaths(options) {
     'start-hook': options.startScreenPath,
     leaderboard: options.leaderboardPath,
     gameplay: options.gameplayPath,
+    'game-over': options.gameOverPath,
   };
 
   return SECTION_SPECS.map((spec) => ({

--- a/scripts/remove-css-staged-duplicates.test.mjs
+++ b/scripts/remove-css-staged-duplicates.test.mjs
@@ -20,6 +20,7 @@ const START_HOOK = '/* ===== START HOOK ===== */\n.start-hook { display: block; 
 const LEADERBOARD = '/* ===== LEADERBOARD ===== */\n.lb { display: block; }';
 const GAMEPLAY = '/* ===== GAME START ===== */\n#gameStart { display: flex; }\n\n/* ===== GAME CONTAINER ===== */\n#gameContainer { display: none; }';
 const GAME_OVER = '/* ===== GAME OVER ===== */\n#gameOver { display: none; }';
+const STORE = '/* ===== STORE ===== */\n#storeScreen { display: none; }';
 
 const SPECS = [
   { name: 'base', stagedPath: 'css/base.css', startMarker: '/* ===== TOKENS / BASE ===== */', nextMarker: '/* ===== WALLET CORNER ===== */', stagedMode: 'whole' },
@@ -29,10 +30,11 @@ const SPECS = [
   { name: 'start-hook', stagedPath: 'css/start-screen.css', startMarker: '/* ===== START HOOK ===== */', nextMarker: '/* ===== LEADERBOARD ===== */', stagedMode: 'to-end' },
   { name: 'leaderboard', stagedPath: 'css/leaderboard.css', startMarker: '/* ===== LEADERBOARD ===== */', nextMarker: '/* ===== GAME START ===== */', stagedMode: 'whole' },
   { name: 'gameplay', stagedPath: 'css/gameplay.css', startMarker: '/* ===== GAME START ===== */', nextMarker: '/* ===== GAME OVER ===== */', stagedMode: 'whole' },
+  { name: 'game-over', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER ===== */', nextMarker: '/* ===== STORE ===== */', stagedMode: 'whole' },
 ];
 
 function styleSource() {
-  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n`;
+  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n`;
 }
 
 function stagedSources(overrides = {}) {
@@ -43,6 +45,7 @@ function stagedSources(overrides = {}) {
     ['css/start-screen.css', `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`],
     ['css/leaderboard.css', `${LEADERBOARD}\n`],
     ['css/gameplay.css', `${GAMEPLAY}\n`],
+    ['css/game-over.css', `${GAME_OVER}\n`],
     ...Object.entries(overrides),
   ]);
 }
@@ -75,10 +78,11 @@ test('analyzeAndRemoveSections removes all staged duplicates atomically', () => 
     'start-hook',
     'leaderboard',
     'gameplay',
+    'game-over',
   ]);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
-  assert.match(result.styleSource, /\/\* ===== GAME OVER ===== \*\//);
-  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER/);
+  assert.match(result.styleSource, /\/\* ===== STORE ===== \*\//);
+  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER/);
 });
 
 test('analyzeAndRemoveSections rejects a staged mismatch before returning output', () => {
@@ -91,7 +95,7 @@ test('analyzeAndRemoveSections rejects a staged mismatch before returning output
 
 test('analyzeAndRemoveSections accepts already extracted sections', () => {
   const result = analyzeAndRemoveSections({
-    styleSource: `${WALLET}\n\n${GAME_OVER}\n`,
+    styleSource: `${WALLET}\n\n${STORE}\n`,
     stagedSources: stagedSources(),
     specs: SPECS,
   });
@@ -101,11 +105,11 @@ test('analyzeAndRemoveSections accepts already extracted sections', () => {
 });
 
 test('analyzeAndRemoveSections supports a partially extracted migration', () => {
-  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n`;
+  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n`;
   const result = analyzeAndRemoveSections({ styleSource: source, stagedSources: stagedSources(), specs: SPECS });
 
   assert.deepEqual(result.alreadyExtracted, ['base']);
-  assert.equal(result.removed.length, 6);
+  assert.equal(result.removed.length, 7);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
 });
 
@@ -120,6 +124,7 @@ test('CLI dry-run leaves style.css unchanged and reports removals', () => {
   writeFileSync(join(root, 'css/start-screen.css'), `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`);
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
+  writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath, '--dry-run'], {
@@ -143,6 +148,7 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   writeFileSync(join(root, 'css/start-screen.css'), `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`);
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
+  writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath], {
@@ -153,5 +159,5 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   assert.equal(result.status, 0, result.stderr);
   const nextStyle = readFileSync(join(root, 'css/style.css'), 'utf8');
   assert.match(nextStyle, /^\/\* ===== WALLET CORNER ===== \*\//);
-  assert.match(nextStyle, /\/\* ===== GAME OVER ===== \*\//);
+  assert.match(nextStyle, /\/\* ===== STORE ===== \*\//);
 });


### PR DESCRIPTION
## What changed
- added `css/game-over.css` with the complete marker-bounded `GAME OVER` → `STORE` section from `css/style.css`;
- imported it after `gameplay.css` and before `style.css`, preserving the current cascade;
- extended `check:css-staged-sections` to validate game-over parity and import order;
- extended the atomic staged duplicate-removal codemod for the game-over section;
- updated both guard fixture suites for staged and extracted states.

## Scope
The staged module covers the game-over screen, result hook/stats, action buttons, and game-over leaderboard wrapper. Responsive rules remain in `css/style.css` for the dedicated responsive extraction.

## Safety
- `css/style.css` is unchanged, so the monolith remains the final cascade layer;
- removal is allowed only when `css/game-over.css` matches the marker-bounded source section;
- the removal codemod stops on declaration drift rather than writing a partial extraction.

## Validation
- branch diff is limited to the staged stylesheet, one import, and parity/removal guard updates;
- focused fixture suites were updated; repository CI/Vercel validation is pending on this draft PR.

Refs #1788.
Refs #1791.