### PR TITLE
Stage store CSS module

### DIFF
--- a/css/store.css
+++ b/css/store.css
@@ -1,0 +1,297 @@
+/* ===== STORE ===== */
+#storeScreen {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 20px 20px 64px;
+  overflow-y: auto;
+  background: rgba(5, 3, 11, .96);
+  backdrop-filter: blur(10px);
+}
+
+#storeScreen.visible { display: flex; }
+
+.store-header {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.store-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 24px;
+  font-weight: 800;
+  background: var(--grad);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.store-coins {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
+.store-coin-display {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 6px 12px;
+  background: var(--glass);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+}
+
+.store-coin-display img { width: 18px; height: 18px; }
+.store-coin-display .store-gold-val { color: #fbbf24; }
+.store-coin-display .store-silver-val { color: #94a3b8; }
+
+/* Store fixed nav */
+.store-fixed-nav {
+  position: fixed;
+  left: 14px; top: 24px;
+  z-index: 110;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.store-nav-btn {
+  width: 44px; height: 44px;
+  display: flex;
+  align-items: center; justify-content: center;
+  font-size: 18px;
+  border-radius: 50%;
+  padding: 0; line-height: 1;
+}
+
+.store-nav-btn:hover {
+  box-shadow: 0 0 18px rgba(140, 80, 255, .3);
+  transform: scale(1.08);
+  border-color: rgba(140, 80, 255, .7);
+}
+
+.store-nav-btn:active { transform: scale(0.92); }
+
+.store-list {
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-left: 0;
+}
+
+.store-item,
+.donation-card {
+  background: linear-gradient(180deg, rgba(18, 18, 36, 0.92), rgba(14, 14, 30, 0.94));
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  border-radius: var(--radius);
+  box-shadow: 0 10px 30px rgba(3, 7, 28, 0.42), inset 0 0 0 1px rgba(147, 197, 253, 0.08);
+  transition: border-color .28s ease, box-shadow .28s ease, background .28s ease, transform .28s ease;
+}
+
+.store-item {
+  padding: 14px 16px;
+}
+
+.store-item:hover,
+.donation-card:hover {
+  border-color: rgba(96, 165, 250, 0.56);
+  box-shadow: 0 14px 36px rgba(30, 64, 175, 0.28), inset 0 0 0 1px rgba(125, 211, 252, 0.22);
+}
+
+.store-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.store-item-name {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, .9);
+}
+
+.store-item-currency {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  opacity: .95;
+  text-shadow: 0 0 10px rgba(255, 255, 255, .28);
+}
+
+.store-item-currency img {
+  width: 14px;
+  height: 14px;
+  filter: brightness(1.2) saturate(1.15);
+}
+
+.store-tiers { display: flex; gap: 8px; }
+
+.store-tier {
+  flex: 1;
+  padding: 8px 6px;
+  text-align: center;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 10px;
+  background: rgba(255, 255, 255, .03);
+  border: 1px solid rgba(255, 255, 255, .08);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: .3s;
+  color: rgba(255, 255, 255, .7);
+  line-height: 1.4;
+}
+
+.store-tier:hover {
+  border-color: var(--border-accent);
+  background: rgba(140, 80, 255, .08);
+}
+
+.store-tier:active { transform: scale(0.96); }
+
+.store-tier.available {
+  border-color: rgba(140, 80, 255, .72);
+  background: rgba(140, 80, 255, .14);
+  box-shadow: 0 0 16px rgba(140, 80, 255, .24);
+  color: rgba(255, 255, 255, .95);
+  cursor: pointer;
+}
+
+.store-tier.available .store-tier-label { color: #e5b7ff; }
+.store-tier.available .store-tier-price { opacity: .95; }
+
+.store-tier.available:hover {
+  transform: translateY(-2px);
+  border-color: rgba(140, 80, 255, .82);
+  background: linear-gradient(180deg, rgba(140, 80, 255, .22), rgba(96, 165, 250, .12));
+  box-shadow: 0 12px 24px rgba(140, 80, 255, .22);
+}
+
+.store-tier--highlight.available {
+  border-color: rgba(255, 172, 74, .86);
+  background: linear-gradient(180deg, rgba(255, 172, 74, .24), rgba(255, 132, 64, .16));
+  box-shadow: 0 0 18px rgba(255, 160, 69, .32), inset 0 0 12px rgba(255, 207, 126, .18);
+}
+
+.store-tier--highlight.available .store-tier-label {
+  color: #ffe1b0;
+  text-shadow: 0 0 12px rgba(255, 186, 91, .45);
+}
+
+.store-tier--highlight.available:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 180, 94, .95);
+  background: linear-gradient(180deg, rgba(255, 182, 92, .26), rgba(255, 146, 80, .18));
+  box-shadow: 0 12px 24px rgba(255, 171, 80, .28), inset 0 0 14px rgba(255, 218, 150, .2);
+}
+
+
+.store-tier.purchased {
+  border-color: rgba(76, 175, 80, .3);
+  background: rgba(76, 175, 80, .08);
+  cursor: default;
+  pointer-events: none;
+}
+
+.store-tier-label {
+  font-weight: 700;
+  font-size: 11px;
+  color: #c084fc;
+  margin-bottom: 3px;
+}
+
+.store-tier.purchased .store-tier-label { color: rgba(76, 175, 80, .8); }
+.store-tier.purchased .store-tier-price { text-decoration: line-through; opacity: 0.4; }
+
+.store-tier-price { font-size: 10px; opacity: .7; margin-top: 2px; }
+
+.store-tier.locked {
+  opacity: 0.25;
+  cursor: default;
+  pointer-events: none;
+  border-color: rgba(255, 255, 255, .04);
+}
+
+.store-tier.locked .store-tier-label { color: rgba(255, 255, 255, .3); }
+.store-tier.locked .store-tier-price { opacity: 0.3; }
+
+.store-tier.is-gift-free {
+  border-color: rgba(34, 197, 94, .9);
+  box-shadow: 0 0 18px rgba(34, 197, 94, .35);
+}
+.store-tier.is-gift-free .store-tier-price {
+  color: #86efac;
+  font-weight: 800;
+  letter-spacing: .04em;
+}
+
+.store-tier.is-gift-active {
+  opacity: .55;
+  filter: grayscale(.25);
+  pointer-events: none;
+  position: relative;
+}
+
+.store-tier.is-gift-active::after {
+  content: attr(data-gift-timer);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, .45);
+  color: #fff;
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: .05em;
+  border-radius: inherit;
+}
+
+
+.store-single-buy {
+  padding: 10px 16px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  background: rgba(251, 191, 36, .06);
+  border: 1px solid rgba(251, 191, 36, .25);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: .3s;
+  text-align: center;
+  width: 100%;
+}
+
+.store-single-buy:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(251, 191, 36, .16);
+  border-color: rgba(251, 191, 36, .52);
+  background: linear-gradient(180deg, rgba(251, 191, 36, .18), rgba(245, 158, 11, .12));
+}
+
+.store-single-buy:active { transform: scale(0.96); }
+
+.store-single-buy.purchased {
+  border-color: rgba(76, 175, 80, .3);
+  background: rgba(76, 175, 80, .06);
+  color: rgba(76, 175, 80, .7);
+  cursor: default;
+  pointer-events: none;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,7 @@ import '../css/hero.css';
 import '../css/start-screen.css';
 import '../css/gameplay.css';
 import '../css/game-over.css';
+import '../css/store.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
 

--- a/scripts/check-css-staged-sections.mjs
+++ b/scripts/check-css-staged-sections.mjs
@@ -12,6 +12,7 @@ const IMPORT_ORDER = [
   "import '../css/start-screen.css';",
   "import '../css/gameplay.css';",
   "import '../css/game-over.css';",
+  "import '../css/store.css';",
   "import '../css/style.css';",
 ];
 
@@ -46,6 +47,12 @@ const SECTION_SPECS = [
     startMarker: '/* ===== GAME OVER ===== */',
     nextMarker: '/* ===== STORE ===== */',
   },
+  {
+    name: 'store',
+    path: 'css/store.css',
+    startMarker: '/* ===== STORE ===== */',
+    nextMarker: '/* ===== DARK SCREEN ===== */',
+  },
 ];
 
 const START_SCREEN_SECTIONS = [
@@ -71,6 +78,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     leaderboardPath: readArg('leaderboard', 'css/leaderboard.css'),
     gameplayPath: readArg('gameplay', 'css/gameplay.css'),
     gameOverPath: readArg('game-over', 'css/game-over.css'),
+    storePath: readArg('store', 'css/store.css'),
   };
 }
 
@@ -105,7 +113,7 @@ function assertImportOrder(mainSource) {
       throw new Error(`js/main.js must include ${statement}`);
     }
     if (index <= previousIndex) {
-      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, style');
+      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, store, style');
     }
     previousIndex = index;
   }
@@ -185,6 +193,7 @@ function analyzeCssStagedSections({
   leaderboardSource,
   gameplaySource,
   gameOverSource,
+  storeSource,
 }) {
   assertImportOrder(mainSource);
 
@@ -194,6 +203,7 @@ function analyzeCssStagedSections({
     leaderboard: leaderboardSource,
     gameplay: gameplaySource,
     'game-over': gameOverSource,
+    store: storeSource,
   };
 
   const sections = {};
@@ -224,6 +234,7 @@ function runCssStagedSectionsCheck(options = parseArgs()) {
     leaderboardSource: readFileSync(options.leaderboardPath, 'utf8'),
     gameplaySource: readFileSync(options.gameplayPath, 'utf8'),
     gameOverSource: readFileSync(options.gameOverPath, 'utf8'),
+    storeSource: readFileSync(options.storePath, 'utf8'),
   });
 
   console.log('CSS staged sections check');

--- a/scripts/css-staged-sections.test.mjs
+++ b/scripts/css-staged-sections.test.mjs
@@ -48,6 +48,9 @@ const GAME_OVER = `/* ===== GAME OVER ===== */
 const STORE = `/* ===== STORE ===== */
 #storeScreen { display: none; }`;
 
+const DARK_SCREEN = `/* ===== DARK SCREEN ===== */
+#darkScreen { display: none; }`;
+
 function styleSource() {
   return `${BACKGROUND}
 
@@ -64,6 +67,8 @@ ${GAMEPLAY}
 ${GAME_OVER}
 
 ${STORE}
+
+${DARK_SCREEN}
 `;
 }
 
@@ -79,6 +84,7 @@ function stagedSources() {
     leaderboardSource: `${LEADERBOARD}\n`,
     gameplaySource: `${GAMEPLAY}\n`,
     gameOverSource: `${GAME_OVER}\n`,
+    storeSource: `${STORE}\n`,
   };
 }
 
@@ -103,22 +109,23 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
     ...stagedSources(),
   });
 
-  assert.equal(result.stagedDuplicateCount, 6);
+  assert.equal(result.stagedDuplicateCount, 7);
   assert.equal(result.extractedCount, 0);
   assert.equal(result.sections.startScreen.state, 'staged-duplicate');
   assert.equal(result.sections.gameplay.state, 'staged-duplicate');
   assert.equal(result.sections['game-over'].state, 'staged-duplicate');
+  assert.equal(result.sections.store.state, 'staged-duplicate');
 });
 
 test('analyzeCssStagedSections accepts sections after duplicate removal', () => {
   const result = analyzeCssStagedSections({
-    styleSource: STORE,
+    styleSource: DARK_SCREEN,
     mainSource: mainSource(),
     ...stagedSources(),
   });
 
   assert.equal(result.stagedDuplicateCount, 0);
-  assert.equal(result.extractedCount, 6);
+  assert.equal(result.extractedCount, 7);
 });
 
 test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
@@ -133,7 +140,7 @@ test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
 });
 
 test('analyzeCssStagedSections rejects a partial start-screen extraction', () => {
-  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n`;
+  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n`;
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: partialStyle,
@@ -144,7 +151,7 @@ test('analyzeCssStagedSections rejects a partial start-screen extraction', () =>
 
 test('analyzeCssStagedSections requires CSS import order', () => {
   const wrongOrder = [...IMPORT_ORDER];
-  [wrongOrder[4], wrongOrder[5]] = [wrongOrder[5], wrongOrder[4]];
+  [wrongOrder[5], wrongOrder[6]] = [wrongOrder[6], wrongOrder[5]];
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: styleSource(),

--- a/scripts/remove-css-staged-duplicates.mjs
+++ b/scripts/remove-css-staged-duplicates.mjs
@@ -60,6 +60,13 @@ const SECTION_SPECS = [
     nextMarker: '/* ===== STORE ===== */',
     stagedMode: 'whole',
   },
+  {
+    name: 'store',
+    stagedPath: 'css/store.css',
+    startMarker: '/* ===== STORE ===== */',
+    nextMarker: '/* ===== DARK SCREEN ===== */',
+    stagedMode: 'whole',
+  },
 ];
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -76,6 +83,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     leaderboardPath: readArg('leaderboard', 'css/leaderboard.css'),
     gameplayPath: readArg('gameplay', 'css/gameplay.css'),
     gameOverPath: readArg('game-over', 'css/game-over.css'),
+    storePath: readArg('store', 'css/store.css'),
   };
 }
 
@@ -141,6 +149,7 @@ function resolveSpecPaths(options) {
     leaderboard: options.leaderboardPath,
     gameplay: options.gameplayPath,
     'game-over': options.gameOverPath,
+    store: options.storePath,
   };
 
   return SECTION_SPECS.map((spec) => ({

--- a/scripts/remove-css-staged-duplicates.test.mjs
+++ b/scripts/remove-css-staged-duplicates.test.mjs
@@ -21,6 +21,7 @@ const LEADERBOARD = '/* ===== LEADERBOARD ===== */\n.lb { display: block; }';
 const GAMEPLAY = '/* ===== GAME START ===== */\n#gameStart { display: flex; }\n\n/* ===== GAME CONTAINER ===== */\n#gameContainer { display: none; }';
 const GAME_OVER = '/* ===== GAME OVER ===== */\n#gameOver { display: none; }';
 const STORE = '/* ===== STORE ===== */\n#storeScreen { display: none; }';
+const DARK_SCREEN = '/* ===== DARK SCREEN ===== */\n#darkScreen { display: none; }';
 
 const SPECS = [
   { name: 'base', stagedPath: 'css/base.css', startMarker: '/* ===== TOKENS / BASE ===== */', nextMarker: '/* ===== WALLET CORNER ===== */', stagedMode: 'whole' },
@@ -31,10 +32,11 @@ const SPECS = [
   { name: 'leaderboard', stagedPath: 'css/leaderboard.css', startMarker: '/* ===== LEADERBOARD ===== */', nextMarker: '/* ===== GAME START ===== */', stagedMode: 'whole' },
   { name: 'gameplay', stagedPath: 'css/gameplay.css', startMarker: '/* ===== GAME START ===== */', nextMarker: '/* ===== GAME OVER ===== */', stagedMode: 'whole' },
   { name: 'game-over', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER ===== */', nextMarker: '/* ===== STORE ===== */', stagedMode: 'whole' },
+  { name: 'store', stagedPath: 'css/store.css', startMarker: '/* ===== STORE ===== */', nextMarker: '/* ===== DARK SCREEN ===== */', stagedMode: 'whole' },
 ];
 
 function styleSource() {
-  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n`;
+  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n`;
 }
 
 function stagedSources(overrides = {}) {
@@ -46,6 +48,7 @@ function stagedSources(overrides = {}) {
     ['css/leaderboard.css', `${LEADERBOARD}\n`],
     ['css/gameplay.css', `${GAMEPLAY}\n`],
     ['css/game-over.css', `${GAME_OVER}\n`],
+    ['css/store.css', `${STORE}\n`],
     ...Object.entries(overrides),
   ]);
 }
@@ -79,10 +82,11 @@ test('analyzeAndRemoveSections removes all staged duplicates atomically', () => 
     'leaderboard',
     'gameplay',
     'game-over',
+    'store',
   ]);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
-  assert.match(result.styleSource, /\/\* ===== STORE ===== \*\//);
-  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER/);
+  assert.match(result.styleSource, /\/\* ===== DARK SCREEN ===== \*\//);
+  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER|STORE/);
 });
 
 test('analyzeAndRemoveSections rejects a staged mismatch before returning output', () => {
@@ -95,7 +99,7 @@ test('analyzeAndRemoveSections rejects a staged mismatch before returning output
 
 test('analyzeAndRemoveSections accepts already extracted sections', () => {
   const result = analyzeAndRemoveSections({
-    styleSource: `${WALLET}\n\n${STORE}\n`,
+    styleSource: `${WALLET}\n\n${DARK_SCREEN}\n`,
     stagedSources: stagedSources(),
     specs: SPECS,
   });
@@ -105,11 +109,11 @@ test('analyzeAndRemoveSections accepts already extracted sections', () => {
 });
 
 test('analyzeAndRemoveSections supports a partially extracted migration', () => {
-  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n`;
+  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n`;
   const result = analyzeAndRemoveSections({ styleSource: source, stagedSources: stagedSources(), specs: SPECS });
 
   assert.deepEqual(result.alreadyExtracted, ['base']);
-  assert.equal(result.removed.length, 7);
+  assert.equal(result.removed.length, 8);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
 });
 
@@ -125,6 +129,7 @@ test('CLI dry-run leaves style.css unchanged and reports removals', () => {
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
   writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n`);
+  writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath, '--dry-run'], {
@@ -149,6 +154,7 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
   writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n`);
+  writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath], {
@@ -159,5 +165,5 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   assert.equal(result.status, 0, result.stderr);
   const nextStyle = readFileSync(join(root, 'css/style.css'), 'utf8');
   assert.match(nextStyle, /^\/\* ===== WALLET CORNER ===== \*\//);
-  assert.match(nextStyle, /\/\* ===== STORE ===== \*\//);
+  assert.match(nextStyle, /\/\* ===== DARK SCREEN ===== \*\//);
 });


### PR DESCRIPTION
## What changed
- added `css/store.css` with the complete marker-bounded `STORE` → `DARK SCREEN` section from `css/style.css`;
- imported it after `game-over.css` and before `style.css`, preserving the current cascade;
- extended `check:css-staged-sections` to validate store parity and import order;
- extended the atomic staged duplicate-removal codemod for the store section;
- updated both guard fixture suites for staged and extracted states.

## Scope
The staged module covers the store screen, balances, navigation, item/tier states, gift states, and single-purchase controls. Responsive rules remain in `css/style.css` for the dedicated responsive extraction.

## Safety
- `css/style.css` is unchanged and remains the final cascade layer;
- store removal is allowed only after exact marker-bounded parity;
- the codemod aborts on declaration drift rather than writing a partial extraction.

## Validation
- stacked diff relative to #1849 is limited to `store.css`, one import, and parity/removal guard updates;
- repository CI/Vercel validation is pending on this draft PR.

Refs #1788.
Refs #1791.