### PR TITLE
Complete game over CSS ownership

### DIFF
--- a/css/game-over.css
+++ b/css/game-over.css
@@ -313,3 +313,14 @@
   max-height: none;
   overflow-y: visible;
 }
+
+/* ===== GAME OVER AUDIO NAV ===== */
+.go-audio-nav {
+  position: fixed;
+  left: 14px;
+  top: 24px;
+  z-index: 110;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/scripts/check-css-staged-sections.mjs
+++ b/scripts/check-css-staged-sections.mjs
@@ -19,36 +19,54 @@ const IMPORT_ORDER = [
 const SECTION_SPECS = [
   {
     name: 'background',
+    sourceName: 'background',
     path: 'css/background.css',
     startMarker: '/* ===== BACKGROUND ===== */',
     nextMarker: '/* ===== HERO / BEAR ===== */',
   },
   {
     name: 'hero',
+    sourceName: 'hero',
     path: 'css/hero.css',
     startMarker: '/* ===== HERO / BEAR ===== */',
     nextMarker: '/* ===== TITLE / BUTTONS ===== */',
   },
   {
     name: 'leaderboard',
+    sourceName: 'leaderboard',
     path: 'css/leaderboard.css',
     startMarker: '/* ===== LEADERBOARD ===== */',
     nextMarker: '/* ===== GAME START ===== */',
   },
   {
     name: 'gameplay',
+    sourceName: 'gameplay',
     path: 'css/gameplay.css',
     startMarker: '/* ===== GAME START ===== */',
     nextMarker: '/* ===== GAME OVER ===== */',
   },
   {
-    name: 'game-over',
+    name: 'game-over-screen',
+    sourceName: 'game-over',
     path: 'css/game-over.css',
     startMarker: '/* ===== GAME OVER ===== */',
     nextMarker: '/* ===== STORE ===== */',
+    featureMode: 'bounded',
+    featureNextMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
+    ownershipGroup: 'game-over',
+  },
+  {
+    name: 'game-over-audio',
+    sourceName: 'game-over',
+    path: 'css/game-over.css',
+    startMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
+    nextMarker: '/* ===== ANIMATIONS ===== */',
+    featureMode: 'to-end',
+    ownershipGroup: 'game-over',
   },
   {
     name: 'store',
+    sourceName: 'store',
     path: 'css/store.css',
     startMarker: '/* ===== STORE ===== */',
     nextMarker: '/* ===== DARK SCREEN ===== */',
@@ -103,6 +121,28 @@ function extractSection(styleSource, startMarker, nextMarker) {
   return source.slice(startIndex, nextIndex).trimEnd();
 }
 
+function extractFeatureSection(featureSource, spec) {
+  const source = String(featureSource || '').replace(/\r\n/g, '\n').trimEnd();
+  if (!spec.featureMode) return source;
+
+  const startIndex = source.indexOf(spec.startMarker);
+  if (startIndex < 0) {
+    throw new Error(`${spec.path} must contain ${spec.startMarker}`);
+  }
+
+  if (spec.featureMode === 'to-end') {
+    return source.slice(startIndex).trimEnd();
+  }
+
+  const nextMarker = spec.featureNextMarker || spec.nextMarker;
+  const nextIndex = source.indexOf(nextMarker, startIndex + spec.startMarker.length);
+  if (nextIndex < 0) {
+    throw new Error(`${spec.path} must contain ${nextMarker}`);
+  }
+
+  return source.slice(startIndex, nextIndex).trimEnd();
+}
+
 function assertImportOrder(mainSource) {
   const source = String(mainSource || '');
   let previousIndex = -1;
@@ -128,9 +168,10 @@ function stripLeaderboardImport(startScreenSource) {
   return source.slice(LEADERBOARD_IMPORT.length).replace(/^\s+/, '');
 }
 
-function analyzeSingleSection({ name, featureSource, styleSource, startMarker, nextMarker }) {
-  const styleSection = extractSection(styleSource, startMarker, nextMarker);
-  const featureLines = String(featureSource || '').replace(/\r\n/g, '\n').trimEnd().split('\n').length;
+function analyzeSingleSection(spec, featureSource, styleSource) {
+  const styleSection = extractSection(styleSource, spec.startMarker, spec.nextMarker);
+  const featureSection = extractFeatureSection(featureSource, spec);
+  const featureLines = featureSection.split('\n').length;
 
   if (styleSection === null) {
     return {
@@ -140,8 +181,8 @@ function analyzeSingleSection({ name, featureSource, styleSource, startMarker, n
     };
   }
 
-  if (normalizeCss(featureSource) !== normalizeCss(styleSection)) {
-    throw new Error(`css/${name}.css must match its staged section in css/style.css before duplicate removal`);
+  if (normalizeCss(featureSection) !== normalizeCss(styleSection)) {
+    throw new Error(`${spec.path} must match ${spec.name} in css/style.css before duplicate removal`);
   }
 
   return {
@@ -149,6 +190,23 @@ function analyzeSingleSection({ name, featureSource, styleSource, startMarker, n
     featureLines,
     hasStyleDuplicate: true,
   };
+}
+
+function assertOwnershipGroups(sections) {
+  const groupedNames = new Map();
+  for (const spec of SECTION_SPECS) {
+    if (!spec.ownershipGroup) continue;
+    const names = groupedNames.get(spec.ownershipGroup) || [];
+    names.push(spec.name);
+    groupedNames.set(spec.ownershipGroup, names);
+  }
+
+  for (const [group, names] of groupedNames) {
+    const states = new Set(names.map((name) => sections[name].state));
+    if (states.size > 1) {
+      throw new Error(`css/style.css has a partial ${group} extraction; ${names.join(' and ')} must move together`);
+    }
+  }
 }
 
 function analyzeStartScreen({ startScreenSource, styleSource }) {
@@ -208,12 +266,9 @@ function analyzeCssStagedSections({
 
   const sections = {};
   for (const spec of SECTION_SPECS) {
-    sections[spec.name] = analyzeSingleSection({
-      ...spec,
-      featureSource: sourceByName[spec.name],
-      styleSource,
-    });
+    sections[spec.name] = analyzeSingleSection(spec, sourceByName[spec.sourceName], styleSource);
   }
+  assertOwnershipGroups(sections);
   sections.startScreen = analyzeStartScreen({ startScreenSource, styleSource });
 
   return {
@@ -264,6 +319,8 @@ export {
   analyzeSingleSection,
   analyzeStartScreen,
   assertImportOrder,
+  assertOwnershipGroups,
+  extractFeatureSection,
   extractSection,
   normalizeCss,
   stripLeaderboardImport,

--- a/scripts/css-staged-sections.test.mjs
+++ b/scripts/css-staged-sections.test.mjs
@@ -51,6 +51,12 @@ const STORE = `/* ===== STORE ===== */
 const DARK_SCREEN = `/* ===== DARK SCREEN ===== */
 #darkScreen { display: none; }`;
 
+const GAME_OVER_AUDIO = `/* ===== GAME OVER AUDIO NAV ===== */
+.go-audio-nav { display: flex; }`;
+
+const ANIMATIONS = `/* ===== ANIMATIONS ===== */
+@keyframes fadeIn { to { opacity: 1; } }`;
+
 function styleSource() {
   return `${BACKGROUND}
 
@@ -69,6 +75,10 @@ ${GAME_OVER}
 ${STORE}
 
 ${DARK_SCREEN}
+
+${GAME_OVER_AUDIO}
+
+${ANIMATIONS}
 `;
 }
 
@@ -83,7 +93,7 @@ function stagedSources() {
     startScreenSource: `${LEADERBOARD_IMPORT}\n\n${TITLE}\n\n${HOOK}\n`,
     leaderboardSource: `${LEADERBOARD}\n`,
     gameplaySource: `${GAMEPLAY}\n`,
-    gameOverSource: `${GAME_OVER}\n`,
+    gameOverSource: `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`,
     storeSource: `${STORE}\n`,
   };
 }
@@ -109,23 +119,24 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
     ...stagedSources(),
   });
 
-  assert.equal(result.stagedDuplicateCount, 7);
+  assert.equal(result.stagedDuplicateCount, 8);
   assert.equal(result.extractedCount, 0);
   assert.equal(result.sections.startScreen.state, 'staged-duplicate');
   assert.equal(result.sections.gameplay.state, 'staged-duplicate');
-  assert.equal(result.sections['game-over'].state, 'staged-duplicate');
+  assert.equal(result.sections['game-over-screen'].state, 'staged-duplicate');
+  assert.equal(result.sections['game-over-audio'].state, 'staged-duplicate');
   assert.equal(result.sections.store.state, 'staged-duplicate');
 });
 
 test('analyzeCssStagedSections accepts sections after duplicate removal', () => {
   const result = analyzeCssStagedSections({
-    styleSource: DARK_SCREEN,
+    styleSource: `${DARK_SCREEN}\n\n${ANIMATIONS}\n`,
     mainSource: mainSource(),
     ...stagedSources(),
   });
 
   assert.equal(result.stagedDuplicateCount, 0);
-  assert.equal(result.extractedCount, 7);
+  assert.equal(result.extractedCount, 8);
 });
 
 test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
@@ -140,13 +151,23 @@ test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
 });
 
 test('analyzeCssStagedSections rejects a partial start-screen extraction', () => {
-  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n`;
+  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: partialStyle,
     mainSource: mainSource(),
     ...stagedSources(),
   }), /partial start-screen extraction/);
+});
+
+test('analyzeCssStagedSections rejects partial game-over ownership', () => {
+  const partialStyle = styleSource().replace(`${GAME_OVER_AUDIO}\n\n`, '');
+
+  assert.throws(() => analyzeCssStagedSections({
+    styleSource: partialStyle,
+    mainSource: mainSource(),
+    ...stagedSources(),
+  }), /partial game-over extraction/);
 });
 
 test('analyzeCssStagedSections requires CSS import order', () => {

--- a/scripts/remove-css-staged-duplicates.mjs
+++ b/scripts/remove-css-staged-duplicates.mjs
@@ -54,11 +54,21 @@ const SECTION_SPECS = [
     stagedMode: 'whole',
   },
   {
-    name: 'game-over',
+    name: 'game-over-screen',
     stagedPath: 'css/game-over.css',
     startMarker: '/* ===== GAME OVER ===== */',
     nextMarker: '/* ===== STORE ===== */',
-    stagedMode: 'whole',
+    stagedMode: 'bounded',
+    stagedNextMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
+    ownershipGroup: 'game-over',
+  },
+  {
+    name: 'game-over-audio',
+    stagedPath: 'css/game-over.css',
+    startMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
+    nextMarker: '/* ===== ANIMATIONS ===== */',
+    stagedMode: 'to-end',
+    ownershipGroup: 'game-over',
   },
   {
     name: 'store',
@@ -131,9 +141,10 @@ function extractStagedSection(stagedSource, spec) {
     return source.slice(startIndex).trimEnd();
   }
 
-  const nextIndex = source.indexOf(spec.nextMarker, startIndex + spec.startMarker.length);
+  const nextMarker = spec.stagedNextMarker || spec.nextMarker;
+  const nextIndex = source.indexOf(nextMarker, startIndex + spec.startMarker.length);
   if (nextIndex < 0) {
-    throw new Error(`${spec.stagedPath} must contain ${spec.nextMarker}`);
+    throw new Error(`${spec.stagedPath} must contain ${nextMarker}`);
   }
 
   return source.slice(startIndex, nextIndex).trimEnd();
@@ -148,7 +159,8 @@ function resolveSpecPaths(options) {
     'start-hook': options.startScreenPath,
     leaderboard: options.leaderboardPath,
     gameplay: options.gameplayPath,
-    'game-over': options.gameOverPath,
+    'game-over-screen': options.gameOverPath,
+    'game-over-audio': options.gameOverPath,
     store: options.storePath,
   };
 
@@ -158,10 +170,31 @@ function resolveSpecPaths(options) {
   }));
 }
 
+function assertOwnershipGroupsPresent(styleSource, specs) {
+  const source = String(styleSource || '');
+  const groups = new Map();
+
+  for (const spec of specs) {
+    if (!spec.ownershipGroup) continue;
+    const states = groups.get(spec.ownershipGroup) || [];
+    states.push({ name: spec.name, present: source.includes(spec.startMarker) });
+    groups.set(spec.ownershipGroup, states);
+  }
+
+  for (const [group, states] of groups) {
+    const presentCount = states.filter((state) => state.present).length;
+    if (presentCount > 0 && presentCount < states.length) {
+      throw new Error(`css/style.css has a partial ${group} extraction; ${states.map((state) => state.name).join(' and ')} must move together`);
+    }
+  }
+}
+
 function analyzeAndRemoveSections({ styleSource, stagedSources, specs = SECTION_SPECS }) {
   let nextStyle = String(styleSource || '').replace(/\r\n/g, '\n');
   const removed = [];
   const alreadyExtracted = [];
+
+  assertOwnershipGroupsPresent(nextStyle, specs);
 
   for (const spec of specs) {
     const current = extractBoundedSection(nextStyle, spec.startMarker, spec.nextMarker);
@@ -261,6 +294,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 export {
   SECTION_SPECS,
   analyzeAndRemoveSections,
+  assertOwnershipGroupsPresent,
   extractBoundedSection,
   extractStagedSection,
   normalizeCss,

--- a/scripts/remove-css-staged-duplicates.test.mjs
+++ b/scripts/remove-css-staged-duplicates.test.mjs
@@ -22,6 +22,8 @@ const GAMEPLAY = '/* ===== GAME START ===== */\n#gameStart { display: flex; }\n\
 const GAME_OVER = '/* ===== GAME OVER ===== */\n#gameOver { display: none; }';
 const STORE = '/* ===== STORE ===== */\n#storeScreen { display: none; }';
 const DARK_SCREEN = '/* ===== DARK SCREEN ===== */\n#darkScreen { display: none; }';
+const GAME_OVER_AUDIO = '/* ===== GAME OVER AUDIO NAV ===== */\n.go-audio-nav { display: flex; }';
+const ANIMATIONS = '/* ===== ANIMATIONS ===== */\n@keyframes fadeIn { to { opacity: 1; } }';
 
 const SPECS = [
   { name: 'base', stagedPath: 'css/base.css', startMarker: '/* ===== TOKENS / BASE ===== */', nextMarker: '/* ===== WALLET CORNER ===== */', stagedMode: 'whole' },
@@ -31,12 +33,13 @@ const SPECS = [
   { name: 'start-hook', stagedPath: 'css/start-screen.css', startMarker: '/* ===== START HOOK ===== */', nextMarker: '/* ===== LEADERBOARD ===== */', stagedMode: 'to-end' },
   { name: 'leaderboard', stagedPath: 'css/leaderboard.css', startMarker: '/* ===== LEADERBOARD ===== */', nextMarker: '/* ===== GAME START ===== */', stagedMode: 'whole' },
   { name: 'gameplay', stagedPath: 'css/gameplay.css', startMarker: '/* ===== GAME START ===== */', nextMarker: '/* ===== GAME OVER ===== */', stagedMode: 'whole' },
-  { name: 'game-over', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER ===== */', nextMarker: '/* ===== STORE ===== */', stagedMode: 'whole' },
+  { name: 'game-over-screen', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER ===== */', nextMarker: '/* ===== STORE ===== */', stagedMode: 'bounded', stagedNextMarker: '/* ===== GAME OVER AUDIO NAV ===== */', ownershipGroup: 'game-over' },
+  { name: 'game-over-audio', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER AUDIO NAV ===== */', nextMarker: '/* ===== ANIMATIONS ===== */', stagedMode: 'to-end', ownershipGroup: 'game-over' },
   { name: 'store', stagedPath: 'css/store.css', startMarker: '/* ===== STORE ===== */', nextMarker: '/* ===== DARK SCREEN ===== */', stagedMode: 'whole' },
 ];
 
 function styleSource() {
-  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n`;
+  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
 }
 
 function stagedSources(overrides = {}) {
@@ -47,7 +50,7 @@ function stagedSources(overrides = {}) {
     ['css/start-screen.css', `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`],
     ['css/leaderboard.css', `${LEADERBOARD}\n`],
     ['css/gameplay.css', `${GAMEPLAY}\n`],
-    ['css/game-over.css', `${GAME_OVER}\n`],
+    ['css/game-over.css', `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`],
     ['css/store.css', `${STORE}\n`],
     ...Object.entries(overrides),
   ]);
@@ -81,11 +84,13 @@ test('analyzeAndRemoveSections removes all staged duplicates atomically', () => 
     'start-hook',
     'leaderboard',
     'gameplay',
-    'game-over',
+    'game-over-screen',
+    'game-over-audio',
     'store',
   ]);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
   assert.match(result.styleSource, /\/\* ===== DARK SCREEN ===== \*\//);
+  assert.match(result.styleSource, /\/\* ===== ANIMATIONS ===== \*\//);
   assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER|STORE/);
 });
 
@@ -97,9 +102,19 @@ test('analyzeAndRemoveSections rejects a staged mismatch before returning output
   }), /hero section.*does not match/);
 });
 
+test('analyzeAndRemoveSections rejects partial game-over ownership', () => {
+  const partialStyle = styleSource().replace(`${GAME_OVER_AUDIO}\n\n`, '');
+
+  assert.throws(() => analyzeAndRemoveSections({
+    styleSource: partialStyle,
+    stagedSources: stagedSources(),
+    specs: SPECS,
+  }), /partial game-over extraction/);
+});
+
 test('analyzeAndRemoveSections accepts already extracted sections', () => {
   const result = analyzeAndRemoveSections({
-    styleSource: `${WALLET}\n\n${DARK_SCREEN}\n`,
+    styleSource: `${WALLET}\n\n${DARK_SCREEN}\n\n${ANIMATIONS}\n`,
     stagedSources: stagedSources(),
     specs: SPECS,
   });
@@ -109,11 +124,11 @@ test('analyzeAndRemoveSections accepts already extracted sections', () => {
 });
 
 test('analyzeAndRemoveSections supports a partially extracted migration', () => {
-  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n`;
+  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
   const result = analyzeAndRemoveSections({ styleSource: source, stagedSources: stagedSources(), specs: SPECS });
 
   assert.deepEqual(result.alreadyExtracted, ['base']);
-  assert.equal(result.removed.length, 8);
+  assert.equal(result.removed.length, 9);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
 });
 
@@ -128,7 +143,7 @@ test('CLI dry-run leaves style.css unchanged and reports removals', () => {
   writeFileSync(join(root, 'css/start-screen.css'), `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`);
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
-  writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n`);
+  writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`);
   writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
@@ -153,7 +168,7 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   writeFileSync(join(root, 'css/start-screen.css'), `@import './leaderboard.css';\n\n${TITLE}\n\n${START_HOOK}\n`);
   writeFileSync(join(root, 'css/leaderboard.css'), `${LEADERBOARD}\n`);
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
-  writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n`);
+  writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`);
   writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
@@ -166,4 +181,5 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   const nextStyle = readFileSync(join(root, 'css/style.css'), 'utf8');
   assert.match(nextStyle, /^\/\* ===== WALLET CORNER ===== \*\//);
   assert.match(nextStyle, /\/\* ===== DARK SCREEN ===== \*\//);
+  assert.match(nextStyle, /\/\* ===== ANIMATIONS ===== \*\//);
 });


### PR DESCRIPTION
## What changed
- moved the existing `GAME OVER AUDIO NAV` rules into the staged `css/game-over.css` module;
- kept `css/style.css` unchanged so the current cascade remains stable;
- split game-over parity into two marker-bounded components: screen and audio nav;
- added an ownership-group guard that rejects partial extraction of only one component;
- updated the atomic duplicate-removal codemod so both game-over components move together;
- added regression coverage for partial ownership in both parity and removal suites.

## Why
The Phase 2 extraction plan assigns game-over audio navigation to `game-over.css`. Before this change, the main game-over screen was staged but `.go-audio-nav` remained owned only by the monolith, so a later duplicate-removal pass would leave split feature ownership.

## Safety
- no selectors or declarations were changed;
- no import order or runtime code changed;
- the removal tool validates both marker-bounded blocks before writing and aborts on a partial state.

## Validation
- diff is limited to `game-over.css` and the existing parity/removal guards and tests;
- repository CI/Vercel validation is pending on this draft PR.

Refs #1788.
Refs #1791.