### PR TITLE
Stage rules CSS module

### DIFF
--- a/css/rules.css
+++ b/css/rules.css
@@ -1,0 +1,184 @@
+/* ===== FOOTER RULES LINK ===== */
+.footer-rules-link {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, .95);
+  cursor: pointer;
+  margin-bottom: 10px;
+  transition: color .2s ease, opacity .2s ease, box-shadow .2s ease, border-color .2s ease;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(192, 132, 252, .45);
+  background: rgba(192, 132, 252, .1);
+  box-shadow: 0 0 14px rgba(192, 132, 252, .2);
+}
+.footer-rules-link:hover {
+  color: #f3e8ff;
+  border-color: rgba(192, 132, 252, .9);
+  box-shadow: 0 0 18px rgba(192, 132, 252, .35);
+}
+.footer-legal-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: -2px;
+  margin-bottom: 10px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+}
+.footer-legal-link {
+  color: rgba(248, 250, 252, .75);
+  text-decoration: none;
+  transition: color .2s ease;
+}
+.footer-legal-link:hover { color: #c084fc; }
+.footer-legal-sep { color: rgba(248, 250, 252, .45); }
+
+/* ===== RULES OVERLAY ===== */
+#rulesScreen {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(5, 3, 11, .97);
+  overflow-y: auto;
+  padding: 80px 20px 40px;
+  flex-direction: column;
+  align-items: center;
+}
+#rulesScreen.visible {
+  display: flex;
+}
+
+.rules-fixed-nav {
+  position: fixed;
+  left: 14px; top: 24px;
+  z-index: 210;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.rules-header {
+  width: 100%;
+  max-width: 500px;
+  margin-bottom: 25px;
+  text-align: center;
+}
+
+.rules-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 28px;
+  font-weight: 800;
+  background: var(--grad);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.rules-content {
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 30px;
+}
+
+.rules-section {
+  background: var(--glass);
+  backdrop-filter: blur(14px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+}
+
+.rules-section-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: #c084fc;
+  margin-bottom: 10px;
+}
+
+.rules-section-text {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 12px;
+  line-height: 1.8;
+  color: rgba(255, 255, 255, .8);
+}
+
+.rules-section-text b {
+  color: #fff;
+}
+
+.rules-ai-section {
+  border: 1px solid rgba(192, 132, 252, 0.3);
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(20, 10, 30, 0.45);
+}
+
+.rules-ai-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.rules-ai-grid {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.rules-ai-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.rules-ai-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rules-ai-row {
+  display: flex;
+  align-items: end;
+  gap: 12px;
+}
+
+.rules-ai-label {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.85);
+  text-transform: uppercase;
+}
+
+.rules-ai-field input[type="text"] {
+  border: 1px solid rgba(192, 132, 252, 0.35);
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+  border-radius: 8px;
+  padding: 7px 10px;
+  font: inherit;
+}
+
+.rules-ai-priority {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 10px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 6px 10px;
+}
+
+.rules-ai-priority label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,7 @@ import '../css/start-screen.css';
 import '../css/gameplay.css';
 import '../css/game-over.css';
 import '../css/store.css';
+import '../css/rules.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
 

--- a/scripts/check-css-staged-sections.mjs
+++ b/scripts/check-css-staged-sections.mjs
@@ -13,6 +13,7 @@ const IMPORT_ORDER = [
   "import '../css/gameplay.css';",
   "import '../css/game-over.css';",
   "import '../css/store.css';",
+  "import '../css/rules.css';",
   "import '../css/style.css';",
 ];
 
@@ -71,6 +72,13 @@ const SECTION_SPECS = [
     startMarker: '/* ===== STORE ===== */',
     nextMarker: '/* ===== DARK SCREEN ===== */',
   },
+  {
+    name: 'rules',
+    sourceName: 'rules',
+    path: 'css/rules.css',
+    startMarker: '/* ===== FOOTER RULES LINK ===== */',
+    nextMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
+  },
 ];
 
 const START_SCREEN_SECTIONS = [
@@ -97,6 +105,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     gameplayPath: readArg('gameplay', 'css/gameplay.css'),
     gameOverPath: readArg('game-over', 'css/game-over.css'),
     storePath: readArg('store', 'css/store.css'),
+    rulesPath: readArg('rules', 'css/rules.css'),
   };
 }
 
@@ -153,7 +162,7 @@ function assertImportOrder(mainSource) {
       throw new Error(`js/main.js must include ${statement}`);
     }
     if (index <= previousIndex) {
-      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, store, style');
+      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, store, rules, style');
     }
     previousIndex = index;
   }
@@ -252,6 +261,7 @@ function analyzeCssStagedSections({
   gameplaySource,
   gameOverSource,
   storeSource,
+  rulesSource,
 }) {
   assertImportOrder(mainSource);
 
@@ -262,6 +272,7 @@ function analyzeCssStagedSections({
     gameplay: gameplaySource,
     'game-over': gameOverSource,
     store: storeSource,
+    rules: rulesSource,
   };
 
   const sections = {};
@@ -290,6 +301,7 @@ function runCssStagedSectionsCheck(options = parseArgs()) {
     gameplaySource: readFileSync(options.gameplayPath, 'utf8'),
     gameOverSource: readFileSync(options.gameOverPath, 'utf8'),
     storeSource: readFileSync(options.storePath, 'utf8'),
+    rulesSource: readFileSync(options.rulesPath, 'utf8'),
   });
 
   console.log('CSS staged sections check');

--- a/scripts/css-staged-sections.test.mjs
+++ b/scripts/css-staged-sections.test.mjs
@@ -51,6 +51,12 @@ const STORE = `/* ===== STORE ===== */
 const DARK_SCREEN = `/* ===== DARK SCREEN ===== */
 #darkScreen { display: none; }`;
 
+const RULES = `/* ===== FOOTER RULES LINK ===== */
+.footer-rules-link { display: inline-flex; }
+
+/* ===== RULES OVERLAY ===== */
+#rulesScreen { display: none; }`;
+
 const GAME_OVER_AUDIO = `/* ===== GAME OVER AUDIO NAV ===== */
 .go-audio-nav { display: flex; }`;
 
@@ -76,6 +82,8 @@ ${STORE}
 
 ${DARK_SCREEN}
 
+${RULES}
+
 ${GAME_OVER_AUDIO}
 
 ${ANIMATIONS}
@@ -95,6 +103,7 @@ function stagedSources() {
     gameplaySource: `${GAMEPLAY}\n`,
     gameOverSource: `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`,
     storeSource: `${STORE}\n`,
+    rulesSource: `${RULES}\n`,
   };
 }
 
@@ -119,13 +128,14 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
     ...stagedSources(),
   });
 
-  assert.equal(result.stagedDuplicateCount, 8);
+  assert.equal(result.stagedDuplicateCount, 9);
   assert.equal(result.extractedCount, 0);
   assert.equal(result.sections.startScreen.state, 'staged-duplicate');
   assert.equal(result.sections.gameplay.state, 'staged-duplicate');
   assert.equal(result.sections['game-over-screen'].state, 'staged-duplicate');
   assert.equal(result.sections['game-over-audio'].state, 'staged-duplicate');
   assert.equal(result.sections.store.state, 'staged-duplicate');
+  assert.equal(result.sections.rules.state, 'staged-duplicate');
 });
 
 test('analyzeCssStagedSections accepts sections after duplicate removal', () => {
@@ -136,7 +146,7 @@ test('analyzeCssStagedSections accepts sections after duplicate removal', () => 
   });
 
   assert.equal(result.stagedDuplicateCount, 0);
-  assert.equal(result.extractedCount, 8);
+  assert.equal(result.extractedCount, 9);
 });
 
 test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
@@ -151,7 +161,7 @@ test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
 });
 
 test('analyzeCssStagedSections rejects a partial start-screen extraction', () => {
-  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
+  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: partialStyle,
@@ -170,9 +180,20 @@ test('analyzeCssStagedSections rejects partial game-over ownership', () => {
   }), /partial game-over extraction/);
 });
 
+test('analyzeCssStagedSections rejects rules drift', () => {
+  const sources = stagedSources();
+  sources.rulesSource = `${RULES.replace('inline-flex', 'block')}\n`;
+
+  assert.throws(() => analyzeCssStagedSections({
+    styleSource: styleSource(),
+    mainSource: mainSource(),
+    ...sources,
+  }), /css\/rules\.css must match rules/);
+});
+
 test('analyzeCssStagedSections requires CSS import order', () => {
   const wrongOrder = [...IMPORT_ORDER];
-  [wrongOrder[5], wrongOrder[6]] = [wrongOrder[6], wrongOrder[5]];
+  [wrongOrder[6], wrongOrder[7]] = [wrongOrder[7], wrongOrder[6]];
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: styleSource(),

--- a/scripts/remove-css-staged-duplicates.mjs
+++ b/scripts/remove-css-staged-duplicates.mjs
@@ -63,19 +63,26 @@ const SECTION_SPECS = [
     ownershipGroup: 'game-over',
   },
   {
+    name: 'store',
+    stagedPath: 'css/store.css',
+    startMarker: '/* ===== STORE ===== */',
+    nextMarker: '/* ===== DARK SCREEN ===== */',
+    stagedMode: 'whole',
+  },
+  {
+    name: 'rules',
+    stagedPath: 'css/rules.css',
+    startMarker: '/* ===== FOOTER RULES LINK ===== */',
+    nextMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
+    stagedMode: 'whole',
+  },
+  {
     name: 'game-over-audio',
     stagedPath: 'css/game-over.css',
     startMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
     nextMarker: '/* ===== ANIMATIONS ===== */',
     stagedMode: 'to-end',
     ownershipGroup: 'game-over',
-  },
-  {
-    name: 'store',
-    stagedPath: 'css/store.css',
-    startMarker: '/* ===== STORE ===== */',
-    nextMarker: '/* ===== DARK SCREEN ===== */',
-    stagedMode: 'whole',
   },
 ];
 
@@ -94,6 +101,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     gameplayPath: readArg('gameplay', 'css/gameplay.css'),
     gameOverPath: readArg('game-over', 'css/game-over.css'),
     storePath: readArg('store', 'css/store.css'),
+    rulesPath: readArg('rules', 'css/rules.css'),
   };
 }
 
@@ -160,8 +168,9 @@ function resolveSpecPaths(options) {
     leaderboard: options.leaderboardPath,
     gameplay: options.gameplayPath,
     'game-over-screen': options.gameOverPath,
-    'game-over-audio': options.gameOverPath,
     store: options.storePath,
+    rules: options.rulesPath,
+    'game-over-audio': options.gameOverPath,
   };
 
   return SECTION_SPECS.map((spec) => ({

--- a/scripts/remove-css-staged-duplicates.test.mjs
+++ b/scripts/remove-css-staged-duplicates.test.mjs
@@ -22,6 +22,7 @@ const GAMEPLAY = '/* ===== GAME START ===== */\n#gameStart { display: flex; }\n\
 const GAME_OVER = '/* ===== GAME OVER ===== */\n#gameOver { display: none; }';
 const STORE = '/* ===== STORE ===== */\n#storeScreen { display: none; }';
 const DARK_SCREEN = '/* ===== DARK SCREEN ===== */\n#darkScreen { display: none; }';
+const RULES = '/* ===== FOOTER RULES LINK ===== */\n.footer-rules-link { display: inline-flex; }\n\n/* ===== RULES OVERLAY ===== */\n#rulesScreen { display: none; }';
 const GAME_OVER_AUDIO = '/* ===== GAME OVER AUDIO NAV ===== */\n.go-audio-nav { display: flex; }';
 const ANIMATIONS = '/* ===== ANIMATIONS ===== */\n@keyframes fadeIn { to { opacity: 1; } }';
 
@@ -34,12 +35,13 @@ const SPECS = [
   { name: 'leaderboard', stagedPath: 'css/leaderboard.css', startMarker: '/* ===== LEADERBOARD ===== */', nextMarker: '/* ===== GAME START ===== */', stagedMode: 'whole' },
   { name: 'gameplay', stagedPath: 'css/gameplay.css', startMarker: '/* ===== GAME START ===== */', nextMarker: '/* ===== GAME OVER ===== */', stagedMode: 'whole' },
   { name: 'game-over-screen', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER ===== */', nextMarker: '/* ===== STORE ===== */', stagedMode: 'bounded', stagedNextMarker: '/* ===== GAME OVER AUDIO NAV ===== */', ownershipGroup: 'game-over' },
-  { name: 'game-over-audio', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER AUDIO NAV ===== */', nextMarker: '/* ===== ANIMATIONS ===== */', stagedMode: 'to-end', ownershipGroup: 'game-over' },
   { name: 'store', stagedPath: 'css/store.css', startMarker: '/* ===== STORE ===== */', nextMarker: '/* ===== DARK SCREEN ===== */', stagedMode: 'whole' },
+  { name: 'rules', stagedPath: 'css/rules.css', startMarker: '/* ===== FOOTER RULES LINK ===== */', nextMarker: '/* ===== GAME OVER AUDIO NAV ===== */', stagedMode: 'whole' },
+  { name: 'game-over-audio', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER AUDIO NAV ===== */', nextMarker: '/* ===== ANIMATIONS ===== */', stagedMode: 'to-end', ownershipGroup: 'game-over' },
 ];
 
 function styleSource() {
-  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
+  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
 }
 
 function stagedSources(overrides = {}) {
@@ -52,6 +54,7 @@ function stagedSources(overrides = {}) {
     ['css/gameplay.css', `${GAMEPLAY}\n`],
     ['css/game-over.css', `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`],
     ['css/store.css', `${STORE}\n`],
+    ['css/rules.css', `${RULES}\n`],
     ...Object.entries(overrides),
   ]);
 }
@@ -85,13 +88,14 @@ test('analyzeAndRemoveSections removes all staged duplicates atomically', () => 
     'leaderboard',
     'gameplay',
     'game-over-screen',
-    'game-over-audio',
     'store',
+    'rules',
+    'game-over-audio',
   ]);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
   assert.match(result.styleSource, /\/\* ===== DARK SCREEN ===== \*\//);
   assert.match(result.styleSource, /\/\* ===== ANIMATIONS ===== \*\//);
-  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER|STORE/);
+  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER|STORE|FOOTER RULES LINK|RULES OVERLAY/);
 });
 
 test('analyzeAndRemoveSections rejects a staged mismatch before returning output', () => {
@@ -100,6 +104,14 @@ test('analyzeAndRemoveSections rejects a staged mismatch before returning output
     stagedSources: stagedSources({ 'css/hero.css': `${HERO.replace('block', 'none')}\n` }),
     specs: SPECS,
   }), /hero section.*does not match/);
+});
+
+test('analyzeAndRemoveSections rejects rules drift before writing', () => {
+  assert.throws(() => analyzeAndRemoveSections({
+    styleSource: styleSource(),
+    stagedSources: stagedSources({ 'css/rules.css': `${RULES.replace('inline-flex', 'block')}\n` }),
+    specs: SPECS,
+  }), /rules section.*does not match/);
 });
 
 test('analyzeAndRemoveSections rejects partial game-over ownership', () => {
@@ -124,11 +136,11 @@ test('analyzeAndRemoveSections accepts already extracted sections', () => {
 });
 
 test('analyzeAndRemoveSections supports a partially extracted migration', () => {
-  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
+  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
   const result = analyzeAndRemoveSections({ styleSource: source, stagedSources: stagedSources(), specs: SPECS });
 
   assert.deepEqual(result.alreadyExtracted, ['base']);
-  assert.equal(result.removed.length, 9);
+  assert.equal(result.removed.length, 10);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
 });
 
@@ -145,6 +157,7 @@ test('CLI dry-run leaves style.css unchanged and reports removals', () => {
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
   writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`);
   writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
+  writeFileSync(join(root, 'css/rules.css'), `${RULES}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath, '--dry-run'], {
@@ -170,6 +183,7 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   writeFileSync(join(root, 'css/gameplay.css'), `${GAMEPLAY}\n`);
   writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`);
   writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
+  writeFileSync(join(root, 'css/rules.css'), `${RULES}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath], {


### PR DESCRIPTION
## What changed
- added `css/rules.css` with the complete marker-bounded `FOOTER RULES LINK` → `GAME OVER AUDIO NAV` section from `css/style.css`;
- imported it after `store.css` and before `style.css`, preserving the current cascade;
- extended `check:css-staged-sections` to validate rules parity and import order;
- extended the atomic duplicate-removal codemod for rules ownership;
- ordered removal so rules are removed before the game-over audio marker that bounds them;
- updated parity and removal fixtures, including rules drift and dry-run coverage.

## Scope
The staged module owns the footer rules/legal links and the rules overlay. It intentionally excludes the shared footer block, game-over audio navigation, animations, and responsive overrides.

## Safety
- `css/style.css` is unchanged and remains the final cascade layer;
- selectors, declarations, order, and specificity are unchanged;
- removal aborts on rules drift and preserves dry-run no-write behavior.

## Validation
- branch diff is limited to `rules.css`, one import, and existing parity/removal guard updates;
- repository CI/Vercel validation is pending on this draft PR.

Refs #1788.
Refs #1791.