### PR TITLE
Stage responsive CSS module

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1,0 +1,315 @@
+/* ===== RESPONSIVE ===== */
+@media (max-width: 768px) {
+  #storeScreen:not(.visible) .store-fixed-nav,
+  #gameOver:not(.visible) .go-audio-nav {
+    display: none;
+  }
+
+  #gameStart .start-audio-nav {
+    position: fixed;
+    left: 10px;
+    top: max(8px, env(safe-area-inset-top));
+    z-index: 120;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  body.telegram-mini-app #gameStart .start-audio-nav {
+    position: absolute;
+    top: max(0px, env(safe-area-inset-top));
+  }
+
+  #gameStart {
+    justify-content: flex-start;
+    padding-top: max(72px, calc(env(safe-area-inset-top) + 56px));
+    padding-bottom: max(28px, env(safe-area-inset-bottom));
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  #walletCorner {
+    top: max(8px, env(safe-area-inset-top));
+    right: 14px;
+  }
+
+  body.telegram-mini-app #walletCorner {
+    position: fixed;
+    top: max(6px, env(safe-area-inset-top));
+  }
+
+  body.telegram-mini-app #walletCorner .wallet-btn-corner {
+    display: none;
+  }
+
+  body.telegram-mini-app #walletCorner .wallet-info .wallet-info-row-compact {
+    display: none;
+  }
+
+  .bear-wrapper {
+    width: min(220vw, 780px);
+    height: min(230vw, 820px);
+    margin: 0;
+    position: absolute;
+    top: calc(env(safe-area-inset-top) - 190px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 7;
+  }
+  .new-title {
+    font-size: 28px;
+    min-height: 38px;
+    position: absolute;
+    top: calc(50% - 168px);
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    transform: none;
+    width: min(92vw, 420px);
+    z-index: 12;
+    text-align: center;
+    text-shadow: 1px 0 0 rgba(255, 255, 255, .10), -1px 0 0 rgba(255, 255, 255, .10);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: geometricPrecision;
+  }
+
+  body.telegram-mini-app .new-title {
+    top: calc(50% - 68px);
+  }
+  .new-buttons {
+    max-width: min(90vw, 420px);
+    padding: 0 15px;
+    margin-top: 0;
+    gap: 12px;
+    position: absolute;
+    top: calc(50% - 20px);
+    left: 0;
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
+    transform: none;
+    z-index: 12;
+  }
+
+  #ridesInfo {
+    position: static;
+    transform: none;
+    margin-top: 4px;
+    width: 100%;
+    min-height: 56px;
+    padding-bottom: 8px;
+    text-align: center;
+  }
+
+  #ridesInfo > span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .btn-new { min-height: 50px; padding: 13px 25px; font-size: 13px; }
+  #startBtn { min-height: 65px; padding: 17px 25px; font-size: 16px; }
+  .lb {
+    max-width: 92%;
+    padding: 12px 14px 10px;
+    margin-top: 20px;
+  }
+  #startLeaderboardWrap {
+    margin-top: calc(50dvh + 200px);
+    position: relative;
+    left: auto;
+    transform: none;
+    bottom: auto;
+    width: min(94vw, 430px);
+    z-index: 14;
+  }
+  #startLeaderboardWrap .lb-list {
+    max-height: none;
+    overflow-y: visible;
+  }
+  .lb-title { font-size: 12px; }
+  .lb-row { font-size: 11px; padding: 8px 8px; }
+  .go-title { font-size: 30px; }
+  .go-reason { font-size: 13px; }
+  .go-stats { max-width: 90%; padding: 4px 0 0; }
+  .go-stat-row { font-size: 12px; padding: 8px 0; }
+  .go-btn { padding: 12px 25px; font-size: 12px; }
+  .store-title { font-size: 20px; }
+  .store-item-name { font-size: 12px; }
+  .store-tier { font-size: 9px; padding: 6px 4px; }
+  #gameStart footer {
+    position: relative;
+    margin-top: 20px;
+    left: 0;
+    right: 0;
+    opacity: .6;
+    pointer-events: auto;
+  }
+  .store-fixed-nav { left: 8px; top: 16px; gap: 8px; }
+  .store-nav-btn { width: 38px; height: 38px; font-size: 15px; }
+  #storeScreen .store-fixed-nav {
+    position: fixed;
+    top: max(12px, env(safe-area-inset-top));
+    left: 8px;
+    z-index: 120;
+    transform: translateZ(0);
+  }
+  .rules-title { font-size: 22px; }
+  .rules-section-title { font-size: 12px; }
+  .rules-section-text { font-size: 11px; }
+  .rules-fixed-nav { left: 8px; top: 16px; gap: 8px; }
+  #storeScreen { padding: 20px 15px 20px 52px; }
+  .game-audio-nav { right: 10px; bottom: 65px; gap: 6px; }
+  .game-audio-btn { width: 34px; height: 34px; font-size: 14px; }
+
+  /* Mobile/Telegram in-game HUD: enlarged for readability */
+  #gameContainer.active #uiTopLeft,
+  #gameContainer.active #uiTopRight {
+    transform: scale(0.8);
+  }
+
+  #gameContainer.active #uiTopLeft { transform-origin: top left; }
+  #gameContainer.active #uiTopRight {
+    transform: scale(0.7);
+    transform-origin: top right;
+  }
+  #gameContainer.active #uiTopLeft {
+    padding: 8px 12px 5px;
+  }
+
+  #gameContainer.active #uiBottomCenter {
+    transform: translateX(-50%) scale(0.8);
+    transform-origin: bottom center;
+  }
+
+  #gameContainer.active #uiBottomLeft {
+    transform: scale(0.8);
+    transform-origin: bottom left;
+  }
+
+  #gameStart.start-launching #bear3d {
+    top: calc(50% - 175px);
+    left: 50%;
+    margin: 0;
+    transform: translateX(-50%) scale(1.2);
+  }
+
+  #gameStart.start-launching .new-title {
+    margin-top: 0;
+    transform: none;
+  }
+}
+
+@media (max-width: 480px) {
+  #gameStart .start-audio-nav {
+    left: 8px;
+    gap: 6px;
+  }
+
+  body.telegram-mini-app #gameStart .start-audio-nav {
+    position: absolute;
+    top: max(0px, env(safe-area-inset-top));
+  }
+
+  .bear-wrapper {
+    width: min(250vw, 660px);
+    height: min(250vw, 660px);
+    top: calc(env(safe-area-inset-top) - 152px);
+  }
+  .new-title {
+    font-size: 24px;
+    min-height: 34px;
+    top: calc(50% - 154px);
+    text-shadow: 0.8px 0 0 rgba(255, 255, 255, .12), -0.8px 0 0 rgba(255, 255, 255, .12);
+  }
+  body.telegram-mini-app .new-title {
+    top: calc(50% - 54px);
+  }
+  .new-buttons {
+    margin-top: 0;
+    top: calc(50% - 30px);
+  } 
+  .btn-new { min-height: 46px; padding: 12px 20px; font-size: 12px; }
+  #startBtn { min-height: 60px; padding: 15px 20px; font-size: 15px; }
+  .lb { max-width: 95%; }
+  #startLeaderboardWrap {
+    margin-top: calc(50dvh + 186px);
+    width: min(96vw, 420px);
+  }
+  #startLeaderboardWrap .lb-list { max-height: none; }
+  .go-title { font-size: 24px; }
+  .go-btn { padding: 10px 20px; font-size: 11px; }
+  .store-title { font-size: 18px; }
+  .store-tiers { gap: 5px; }
+  .store-fixed-nav { left: 6px; top: 12px; gap: 6px; }
+  #storeScreen .store-fixed-nav {
+    top: max(10px, env(safe-area-inset-top));
+    left: 6px;
+  }
+  .store-nav-btn { width: 34px; height: 34px; font-size: 14px; }
+  #storeScreen { padding: 15px 10px 15px 46px; }
+  .game-audio-nav { right: 8px; bottom: 60px; }
+  .game-audio-btn { width: 30px; height: 30px; font-size: 12px; }
+  .rules-title { font-size: 18px; }
+  .rules-section-text { font-size: 10px; }
+  #storeScreen {
+    backdrop-filter: none;
+  }
+
+  #gameStart.start-launching #bear3d {
+    top: calc(50% - 160px);
+    transform: translateX(-50%) scale(1.26);
+  }
+}
+
+@media (max-width: 360px) {
+  #gameStart .start-audio-nav {
+    left: 6px;
+    gap: 5px;
+  }
+
+  body.telegram-mini-app #gameStart .start-audio-nav {
+    position: absolute;
+    top: max(0px, env(safe-area-inset-top));
+  }
+
+  .bear-wrapper {
+    width: min(270vw, 590px);
+    height: min(270vw, 590px);
+    top: calc(env(safe-area-inset-top) - 136px);
+  }
+  .new-title {
+    font-size: 20px;
+    min-height: 30px;
+     top: calc(50% - 142px);
+    text-shadow: 0.5px 0 0 rgba(255, 255, 255, .14), -0.5px 0 0 rgba(255, 255, 255, .14);
+  }
+  body.telegram-mini-app .new-title {
+    top: calc(50% - 42px);
+  }
+  .new-buttons {
+    margin-top: 0;
+    top: calc(50% - 36px);
+  }
+  .btn-new { min-height: 42px; padding: 10px 15px; font-size: 11px; }
+  #startBtn { min-height: 55px; padding: 13px 15px; font-size: 14px; }
+  #startLeaderboardWrap {
+    margin-top: calc(50dvh + 174px);
+  }
+  #startLeaderboardWrap .lb-list { max-height: none; }
+
+  #gameStart.start-launching #bear3d {
+    top: calc(50% - 150px);
+    transform: translateX(-50%) scale(1.3);
+  }
+}
+
+@supports (padding: max(0px)) {
+  body {
+    padding-left: max(0px, env(safe-area-inset-left));
+    padding-right: max(0px, env(safe-area-inset-right));
+    padding-top: max(0px, env(safe-area-inset-top));
+    padding-bottom: max(0px, env(safe-area-inset-bottom));
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -23,6 +23,7 @@ import '../css/gameplay.css';
 import '../css/game-over.css';
 import '../css/store.css';
 import '../css/rules.css';
+import '../css/responsive.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
 

--- a/scripts/check-css-staged-sections.mjs
+++ b/scripts/check-css-staged-sections.mjs
@@ -14,6 +14,7 @@ const IMPORT_ORDER = [
   "import '../css/game-over.css';",
   "import '../css/store.css';",
   "import '../css/rules.css';",
+  "import '../css/responsive.css';",
   "import '../css/style.css';",
 ];
 
@@ -79,6 +80,13 @@ const SECTION_SPECS = [
     startMarker: '/* ===== FOOTER RULES LINK ===== */',
     nextMarker: '/* ===== GAME OVER AUDIO NAV ===== */',
   },
+  {
+    name: 'responsive',
+    sourceName: 'responsive',
+    path: 'css/responsive.css',
+    startMarker: '/* ===== RESPONSIVE ===== */',
+    nextMarker: '/* ===== ICON ATLAS SPRITES ===== */',
+  },
 ];
 
 const START_SCREEN_SECTIONS = [
@@ -106,6 +114,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     gameOverPath: readArg('game-over', 'css/game-over.css'),
     storePath: readArg('store', 'css/store.css'),
     rulesPath: readArg('rules', 'css/rules.css'),
+    responsivePath: readArg('responsive', 'css/responsive.css'),
   };
 }
 
@@ -162,7 +171,7 @@ function assertImportOrder(mainSource) {
       throw new Error(`js/main.js must include ${statement}`);
     }
     if (index <= previousIndex) {
-      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, store, rules, style');
+      throw new Error('js/main.js CSS imports must remain ordered: base, background, hero, start-screen, gameplay, game-over, store, rules, responsive, style');
     }
     previousIndex = index;
   }
@@ -262,6 +271,7 @@ function analyzeCssStagedSections({
   gameOverSource,
   storeSource,
   rulesSource,
+  responsiveSource,
 }) {
   assertImportOrder(mainSource);
 
@@ -273,6 +283,7 @@ function analyzeCssStagedSections({
     'game-over': gameOverSource,
     store: storeSource,
     rules: rulesSource,
+    responsive: responsiveSource,
   };
 
   const sections = {};
@@ -302,6 +313,7 @@ function runCssStagedSectionsCheck(options = parseArgs()) {
     gameOverSource: readFileSync(options.gameOverPath, 'utf8'),
     storeSource: readFileSync(options.storePath, 'utf8'),
     rulesSource: readFileSync(options.rulesPath, 'utf8'),
+    responsiveSource: readFileSync(options.responsivePath, 'utf8'),
   });
 
   console.log('CSS staged sections check');

--- a/scripts/css-staged-sections.test.mjs
+++ b/scripts/css-staged-sections.test.mjs
@@ -63,6 +63,14 @@ const GAME_OVER_AUDIO = `/* ===== GAME OVER AUDIO NAV ===== */
 const ANIMATIONS = `/* ===== ANIMATIONS ===== */
 @keyframes fadeIn { to { opacity: 1; } }`;
 
+const RESPONSIVE = `/* ===== RESPONSIVE ===== */
+@media (max-width: 768px) {
+  #gameStart { padding-top: 72px; }
+}`;
+
+const ICON_ATLAS = `/* ===== ICON ATLAS SPRITES ===== */
+.icon-atlas { display: inline-block; }`;
+
 function styleSource() {
   return `${BACKGROUND}
 
@@ -87,6 +95,10 @@ ${RULES}
 ${GAME_OVER_AUDIO}
 
 ${ANIMATIONS}
+
+${RESPONSIVE}
+
+${ICON_ATLAS}
 `;
 }
 
@@ -104,6 +116,7 @@ function stagedSources() {
     gameOverSource: `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`,
     storeSource: `${STORE}\n`,
     rulesSource: `${RULES}\n`,
+    responsiveSource: `${RESPONSIVE}\n`,
   };
 }
 
@@ -128,7 +141,7 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
     ...stagedSources(),
   });
 
-  assert.equal(result.stagedDuplicateCount, 9);
+  assert.equal(result.stagedDuplicateCount, 10);
   assert.equal(result.extractedCount, 0);
   assert.equal(result.sections.startScreen.state, 'staged-duplicate');
   assert.equal(result.sections.gameplay.state, 'staged-duplicate');
@@ -136,17 +149,18 @@ test('analyzeCssStagedSections accepts matching staged duplicates', () => {
   assert.equal(result.sections['game-over-audio'].state, 'staged-duplicate');
   assert.equal(result.sections.store.state, 'staged-duplicate');
   assert.equal(result.sections.rules.state, 'staged-duplicate');
+  assert.equal(result.sections.responsive.state, 'staged-duplicate');
 });
 
 test('analyzeCssStagedSections accepts sections after duplicate removal', () => {
   const result = analyzeCssStagedSections({
-    styleSource: `${DARK_SCREEN}\n\n${ANIMATIONS}\n`,
+    styleSource: `${DARK_SCREEN}\n\n${ANIMATIONS}\n\n${ICON_ATLAS}\n`,
     mainSource: mainSource(),
     ...stagedSources(),
   });
 
   assert.equal(result.stagedDuplicateCount, 0);
-  assert.equal(result.extractedCount, 9);
+  assert.equal(result.extractedCount, 10);
 });
 
 test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
@@ -161,7 +175,7 @@ test('analyzeCssStagedSections rejects incomplete start-screen parity', () => {
 });
 
 test('analyzeCssStagedSections rejects a partial start-screen extraction', () => {
-  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
+  const partialStyle = `${HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n\n${RESPONSIVE}\n\n${ICON_ATLAS}\n`;
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: partialStyle,
@@ -191,9 +205,20 @@ test('analyzeCssStagedSections rejects rules drift', () => {
   }), /css\/rules\.css must match rules/);
 });
 
+test('analyzeCssStagedSections rejects responsive drift', () => {
+  const sources = stagedSources();
+  sources.responsiveSource = `${RESPONSIVE.replace('72px', '64px')}\n`;
+
+  assert.throws(() => analyzeCssStagedSections({
+    styleSource: styleSource(),
+    mainSource: mainSource(),
+    ...sources,
+  }), /css\/responsive\.css must match responsive/);
+});
+
 test('analyzeCssStagedSections requires CSS import order', () => {
   const wrongOrder = [...IMPORT_ORDER];
-  [wrongOrder[6], wrongOrder[7]] = [wrongOrder[7], wrongOrder[6]];
+  [wrongOrder[7], wrongOrder[8]] = [wrongOrder[8], wrongOrder[7]];
 
   assert.throws(() => analyzeCssStagedSections({
     styleSource: styleSource(),

--- a/scripts/remove-css-staged-duplicates.mjs
+++ b/scripts/remove-css-staged-duplicates.mjs
@@ -84,6 +84,13 @@ const SECTION_SPECS = [
     stagedMode: 'to-end',
     ownershipGroup: 'game-over',
   },
+  {
+    name: 'responsive',
+    stagedPath: 'css/responsive.css',
+    startMarker: '/* ===== RESPONSIVE ===== */',
+    nextMarker: '/* ===== ICON ATLAS SPRITES ===== */',
+    stagedMode: 'whole',
+  },
 ];
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -102,6 +109,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     gameOverPath: readArg('game-over', 'css/game-over.css'),
     storePath: readArg('store', 'css/store.css'),
     rulesPath: readArg('rules', 'css/rules.css'),
+    responsivePath: readArg('responsive', 'css/responsive.css'),
   };
 }
 
@@ -171,6 +179,7 @@ function resolveSpecPaths(options) {
     store: options.storePath,
     rules: options.rulesPath,
     'game-over-audio': options.gameOverPath,
+    responsive: options.responsivePath,
   };
 
   return SECTION_SPECS.map((spec) => ({

--- a/scripts/remove-css-staged-duplicates.test.mjs
+++ b/scripts/remove-css-staged-duplicates.test.mjs
@@ -25,6 +25,8 @@ const DARK_SCREEN = '/* ===== DARK SCREEN ===== */\n#darkScreen { display: none;
 const RULES = '/* ===== FOOTER RULES LINK ===== */\n.footer-rules-link { display: inline-flex; }\n\n/* ===== RULES OVERLAY ===== */\n#rulesScreen { display: none; }';
 const GAME_OVER_AUDIO = '/* ===== GAME OVER AUDIO NAV ===== */\n.go-audio-nav { display: flex; }';
 const ANIMATIONS = '/* ===== ANIMATIONS ===== */\n@keyframes fadeIn { to { opacity: 1; } }';
+const RESPONSIVE = '/* ===== RESPONSIVE ===== */\n@media (max-width: 768px) { #gameStart { padding-top: 72px; } }';
+const ICON_ATLAS = '/* ===== ICON ATLAS SPRITES ===== */\n.icon-atlas { display: inline-block; }';
 
 const SPECS = [
   { name: 'base', stagedPath: 'css/base.css', startMarker: '/* ===== TOKENS / BASE ===== */', nextMarker: '/* ===== WALLET CORNER ===== */', stagedMode: 'whole' },
@@ -38,10 +40,11 @@ const SPECS = [
   { name: 'store', stagedPath: 'css/store.css', startMarker: '/* ===== STORE ===== */', nextMarker: '/* ===== DARK SCREEN ===== */', stagedMode: 'whole' },
   { name: 'rules', stagedPath: 'css/rules.css', startMarker: '/* ===== FOOTER RULES LINK ===== */', nextMarker: '/* ===== GAME OVER AUDIO NAV ===== */', stagedMode: 'whole' },
   { name: 'game-over-audio', stagedPath: 'css/game-over.css', startMarker: '/* ===== GAME OVER AUDIO NAV ===== */', nextMarker: '/* ===== ANIMATIONS ===== */', stagedMode: 'to-end', ownershipGroup: 'game-over' },
+  { name: 'responsive', stagedPath: 'css/responsive.css', startMarker: '/* ===== RESPONSIVE ===== */', nextMarker: '/* ===== ICON ATLAS SPRITES ===== */', stagedMode: 'whole' },
 ];
 
 function styleSource() {
-  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
+  return `${BASE}\n\n${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n\n${RESPONSIVE}\n\n${ICON_ATLAS}\n`;
 }
 
 function stagedSources(overrides = {}) {
@@ -55,6 +58,7 @@ function stagedSources(overrides = {}) {
     ['css/game-over.css', `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`],
     ['css/store.css', `${STORE}\n`],
     ['css/rules.css', `${RULES}\n`],
+    ['css/responsive.css', `${RESPONSIVE}\n`],
     ...Object.entries(overrides),
   ]);
 }
@@ -91,11 +95,13 @@ test('analyzeAndRemoveSections removes all staged duplicates atomically', () => 
     'store',
     'rules',
     'game-over-audio',
+    'responsive',
   ]);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
   assert.match(result.styleSource, /\/\* ===== DARK SCREEN ===== \*\//);
   assert.match(result.styleSource, /\/\* ===== ANIMATIONS ===== \*\//);
-  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER|STORE|FOOTER RULES LINK|RULES OVERLAY/);
+  assert.match(result.styleSource, /\/\* ===== ICON ATLAS SPRITES ===== \*\//);
+  assert.doesNotMatch(result.styleSource, /TOKENS \/ BASE|BACKGROUND|HERO \/ BEAR|TITLE \/ BUTTONS|START HOOK|LEADERBOARD|GAME START|GAME CONTAINER|GAME OVER|STORE|FOOTER RULES LINK|RULES OVERLAY|RESPONSIVE/);
 });
 
 test('analyzeAndRemoveSections rejects a staged mismatch before returning output', () => {
@@ -114,6 +120,14 @@ test('analyzeAndRemoveSections rejects rules drift before writing', () => {
   }), /rules section.*does not match/);
 });
 
+test('analyzeAndRemoveSections rejects responsive drift before writing', () => {
+  assert.throws(() => analyzeAndRemoveSections({
+    styleSource: styleSource(),
+    stagedSources: stagedSources({ 'css/responsive.css': `${RESPONSIVE.replace('72px', '64px')}\n` }),
+    specs: SPECS,
+  }), /responsive section.*does not match/);
+});
+
 test('analyzeAndRemoveSections rejects partial game-over ownership', () => {
   const partialStyle = styleSource().replace(`${GAME_OVER_AUDIO}\n\n`, '');
 
@@ -126,7 +140,7 @@ test('analyzeAndRemoveSections rejects partial game-over ownership', () => {
 
 test('analyzeAndRemoveSections accepts already extracted sections', () => {
   const result = analyzeAndRemoveSections({
-    styleSource: `${WALLET}\n\n${DARK_SCREEN}\n\n${ANIMATIONS}\n`,
+    styleSource: `${WALLET}\n\n${DARK_SCREEN}\n\n${ANIMATIONS}\n\n${ICON_ATLAS}\n`,
     stagedSources: stagedSources(),
     specs: SPECS,
   });
@@ -136,11 +150,11 @@ test('analyzeAndRemoveSections accepts already extracted sections', () => {
 });
 
 test('analyzeAndRemoveSections supports a partially extracted migration', () => {
-  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n`;
+  const source = `${WALLET}\n\n${BACKGROUND}\n\n${HERO}\n\n${TITLE}\n\n${START_HOOK}\n\n${LEADERBOARD}\n\n${GAMEPLAY}\n\n${GAME_OVER}\n\n${STORE}\n\n${DARK_SCREEN}\n\n${RULES}\n\n${GAME_OVER_AUDIO}\n\n${ANIMATIONS}\n\n${RESPONSIVE}\n\n${ICON_ATLAS}\n`;
   const result = analyzeAndRemoveSections({ styleSource: source, stagedSources: stagedSources(), specs: SPECS });
 
   assert.deepEqual(result.alreadyExtracted, ['base']);
-  assert.equal(result.removed.length, 10);
+  assert.equal(result.removed.length, 11);
   assert.match(result.styleSource, /^\/\* ===== WALLET CORNER ===== \*\//);
 });
 
@@ -158,6 +172,7 @@ test('CLI dry-run leaves style.css unchanged and reports removals', () => {
   writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`);
   writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
   writeFileSync(join(root, 'css/rules.css'), `${RULES}\n`);
+  writeFileSync(join(root, 'css/responsive.css'), `${RESPONSIVE}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath, '--dry-run'], {
@@ -184,6 +199,7 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   writeFileSync(join(root, 'css/game-over.css'), `${GAME_OVER}\n\n${GAME_OVER_AUDIO}\n`);
   writeFileSync(join(root, 'css/store.css'), `${STORE}\n`);
   writeFileSync(join(root, 'css/rules.css'), `${RULES}\n`);
+  writeFileSync(join(root, 'css/responsive.css'), `${RESPONSIVE}\n`);
 
   const scriptPath = new URL('./remove-css-staged-duplicates.mjs', import.meta.url).pathname;
   const result = spawnSync(process.execPath, [scriptPath], {
@@ -196,4 +212,5 @@ test('CLI writes the extracted style when not in dry-run mode', () => {
   assert.match(nextStyle, /^\/\* ===== WALLET CORNER ===== \*\//);
   assert.match(nextStyle, /\/\* ===== DARK SCREEN ===== \*\//);
   assert.match(nextStyle, /\/\* ===== ANIMATIONS ===== \*\//);
+  assert.match(nextStyle, /\/\* ===== ICON ATLAS SPRITES ===== \*\//);
 });


### PR DESCRIPTION
## What changed
- added `css/responsive.css` with the complete marker-bounded `RESPONSIVE` → `ICON ATLAS SPRITES` section from `css/style.css`;
- imported it after `rules.css` and before `style.css`, preserving the current cascade;
- extended `check:css-staged-sections` to validate responsive parity and the final planned import order;
- extended the atomic duplicate-removal codemod for the responsive section;
- updated parity and removal fixtures for staged, extracted, drift, dry-run, and write states.

## Scope
The staged module owns the 768px, 480px, and 360px layout overrides plus safe-area support rules. This is the final target stylesheet in the Phase 2 extraction plan.

## Safety
- `css/style.css` is unchanged and remains the final cascade layer;
- selectors, media-query order, declarations, and specificity are unchanged;
- removal aborts if any mobile/Telegram override drifts from the marker-bounded source.

## Validation
- branch diff is limited to `responsive.css`, one import, and existing parity/removal guard updates;
- the staged module contains 315 lines copied from the current monolith;
- repository CI/Vercel validation is pending on this draft PR.

Refs #1788.
Refs #1791.