### PR TITLE
Tighten CSS post-cutover budget

### DIFF
--- a/scripts/check-css-size-budget.mjs
+++ b/scripts/check-css-size-budget.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 
 const file = 'css/style.css';
-const maxLines = 2300;
+const maxLines = 1600;
 const lines = readFileSync(file, 'utf8').split('\n').length;
 
 console.log(`${file}: ${lines}/${maxLines} lines`);


### PR DESCRIPTION
## What changed
- reduced the `css/style.css` line budget from 2300 to 1600 after the Phase 2 cutover.

## Why
The remaining monolith is about 1558 source lines. The previous 2300-line ceiling would allow hundreds of feature declarations to return without failing CI. The new limit preserves a small maintenance headroom while protecting the split architecture.

## Scope
One constant changes; no CSS or runtime behavior changes.

## Validation
- one-file, one-line diff;
- Vercel and repository checks are pending on this draft PR.

Refs #1788.
Refs #1791.