### PR TITLE
Apply account and share API facade cutover

### DIFF
--- a/.github/workflows/apply-api-account-share-cutover.yml
+++ b/.github/workflows/apply-api-account-share-cutover.yml
@@ -1,0 +1,65 @@
+name: Apply account share API cutover
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.github/workflows/apply-api-account-share-cutover.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: api-account-share-cutover-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out cutover branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply verified facade cutover
+        run: |
+          npm run cutover:api-account-share:dry-run
+          npm run cutover:api-account-share
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = 'scripts/check-js-size-budget.mjs';
+          const source = fs.readFileSync(path, 'utf8');
+          const next = source.replace("['js/api.js', 700]", "['js/api.js', 500]");
+          if (next === source) throw new Error('js/api.js budget anchor not found');
+          fs.writeFileSync(path, next);
+          NODE
+
+      - name: Validate extracted state
+        run: npm run check
+
+      - name: Remove one-shot workflow
+        run: rm .github/workflows/apply-api-account-share-cutover.yml
+
+      - name: Commit cutover result
+        run: |
+          if git diff --quiet; then
+            echo 'No cutover changes produced'
+            exit 1
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add js/api.js js/api/account-share.js scripts/check-js-size-budget.mjs .github/workflows/apply-api-account-share-cutover.yml
+          git commit -m 'Apply account and share API cutover'
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Purpose
Apply the staged and parity-guarded account/profile/referral/share/X extraction from `js/api.js`.

## One-shot execution
This PR initially contains a temporary PR-triggered workflow that:
- runs the cutover dry-run;
- applies the two-file facade/domain codemod;
- reduces the `js/api.js` size budget from 700 to 500 lines;
- runs the complete `npm run check` suite;
- removes the temporary workflow;
- commits only the resulting runtime cutover files.

## Expected final diff
- `js/api.js`: domain import plus removal of duplicate helpers and unused imports;
- `js/api/account-share.js`: public export block;
- `scripts/check-js-size-budget.mjs`: reduced `api.js` ceiling;
- no workflow file.

This remains draft until self-cleanup and the final diff are confirmed.

Refs #1789.
Refs #1791.