### PR TITLE
Fix physics progress cutover distance usage

### DIFF
--- a/scripts/check-physics-progress-step-staging.mjs
+++ b/scripts/check-physics-progress-step-staging.mjs
@@ -23,6 +23,8 @@ const LEGACY_SCORE_BLOCK = `  const basePointsPerMeter = 1;
     pointsPerMeter *= gameState.invertScoreMultiplier;
   }
   gameState.score += metersDelta * pointsPerMeter;`;
+const LEGACY_DISTANCE_USAGE = 'gameState.distance - metersDelta';
+const EXTRACTED_DISTANCE_USAGE = 'gameState.distance - progressStep.metersDelta';
 const LEGACY_BLOCKS = Object.freeze({
   speed: LEGACY_SPEED_BLOCK,
   distance: LEGACY_DISTANCE_BLOCK,
@@ -32,7 +34,8 @@ const EXTRACTED_TOKENS = [
   CALL_MARKER,
   'gameState.speed = progressStep.speed;',
   'gameState.distance += progressStep.metersDelta;',
-  'gameState.score += progressStep.scoreDelta;'
+  'gameState.score += progressStep.scoreDelta;',
+  EXTRACTED_DISTANCE_USAGE
 ];
 const REQUIRED_DOMAIN_TOKENS = [
   'function calculateProgressStep',
@@ -72,6 +75,7 @@ function analyzePhysicsProgressStepStaging({ physicsSource, domainSource }) {
   const source = normalizeSource(physicsSource);
   const legacyBlocks = inspectLegacyProgressBlocks(source);
   const legacyCount = Object.values(legacyBlocks).filter(Boolean).length;
+  const hasLegacyDistanceUsage = source.includes(LEGACY_DISTANCE_USAGE);
   const hasDomainImport = source.includes(DOMAIN_IMPORT);
   const extractedTokens = Object.fromEntries(
     EXTRACTED_TOKENS.map((token) => [token, source.includes(token)])
@@ -83,16 +87,23 @@ function analyzePhysicsProgressStepStaging({ physicsSource, domainSource }) {
   }
 
   if (legacyCount === Object.keys(LEGACY_BLOCKS).length) {
+    if (!hasLegacyDistanceUsage) {
+      throw new Error(`${PHYSICS_PATH} is missing the legacy metersDelta distance-threshold usage`);
+    }
     if (hasDomainImport || extractedCount > 0) {
       throw new Error(`${PHYSICS_PATH} has a partial progress-step extraction`);
     }
     return {
       state: 'staged-inline',
       hasDomainImport: false,
-      legacyBlocks
+      legacyBlocks,
+      hasLegacyDistanceUsage: true
     };
   }
 
+  if (hasLegacyDistanceUsage) {
+    throw new Error(`${PHYSICS_PATH} still references metersDelta after progress-step extraction`);
+  }
   if (!hasDomainImport) {
     throw new Error(`${PHYSICS_PATH} must import ${DOMAIN_PATH} after progress-step extraction`);
   }
@@ -129,9 +140,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 export {
   CALL_MARKER,
   DOMAIN_IMPORT,
+  EXTRACTED_DISTANCE_USAGE,
   EXTRACTED_TOKENS,
   LEGACY_BLOCKS,
   LEGACY_DISTANCE_BLOCK,
+  LEGACY_DISTANCE_USAGE,
   LEGACY_SCORE_BLOCK,
   LEGACY_SPEED_BLOCK,
   analyzePhysicsProgressStepStaging,

--- a/scripts/cutover-physics-progress-step.mjs
+++ b/scripts/cutover-physics-progress-step.mjs
@@ -3,7 +3,9 @@ import { pathToFileURL } from 'node:url';
 
 import {
   DOMAIN_IMPORT,
+  EXTRACTED_DISTANCE_USAGE,
   LEGACY_DISTANCE_BLOCK,
+  LEGACY_DISTANCE_USAGE,
   LEGACY_SCORE_BLOCK,
   LEGACY_SPEED_BLOCK,
   analyzePhysicsProgressStepStaging
@@ -75,6 +77,7 @@ function transformPhysics(physicsSource) {
   source = replaceExactlyOnce(source, LEGACY_SPEED_BLOCK, PROGRESS_CALL_BLOCK, 'Legacy speed block');
   source = replaceExactlyOnce(source, LEGACY_DISTANCE_BLOCK, DISTANCE_APPLICATION, 'Legacy distance block');
   source = replaceExactlyOnce(source, LEGACY_SCORE_BLOCK, SCORE_APPLICATION, 'Legacy score block');
+  source = replaceExactlyOnce(source, LEGACY_DISTANCE_USAGE, EXTRACTED_DISTANCE_USAGE, 'Legacy metersDelta distance-threshold usage');
 
   return { changed: true, source: `${source.trimEnd()}\n` };
 }

--- a/scripts/physics-progress-step-cutover.test.mjs
+++ b/scripts/physics-progress-step-cutover.test.mjs
@@ -3,7 +3,9 @@ import { test } from 'node:test';
 
 import {
   DOMAIN_IMPORT,
-  LEGACY_BLOCKS
+  EXTRACTED_DISTANCE_USAGE,
+  LEGACY_BLOCKS,
+  LEGACY_DISTANCE_USAGE
 } from './check-physics-progress-step-staging.mjs';
 import {
   DISTANCE_APPLICATION,
@@ -30,7 +32,7 @@ function calculateProgressStep({ distance, delta, speedStart, speedIncrementInte
 export { calculateProgressStep };
 `;
 
-function stagedPhysics({ includeAnchor = true } = {}) {
+function stagedPhysics({ includeAnchor = true, includeDistanceUsage = true } = {}) {
   return `import { CONFIG } from './config.js';
 ${includeAnchor ? `${IMPORT_ANCHOR}\n` : ''}function update(delta) {
 ${LEGACY_BLOCKS.speed}
@@ -39,11 +41,12 @@ ${LEGACY_BLOCKS.distance}
   const adaptiveProfile = getAdaptiveDifficultyProfile({ distance: gameState.distance });
   logger.debug(adaptiveProfile);
 ${LEGACY_BLOCKS.score}
+  ${includeDistanceUsage ? `if (Math.floor(gameState.distance / 100) > Math.floor((${LEGACY_DISTANCE_USAGE}) / 100)) queueCoinRingSpawn();` : ''}
   const coinSpacing = getSpacing('coin');
 }`;
 }
 
-test('cuts over speed, distance and score ownership atomically', () => {
+test('cuts over speed, distance, score and threshold usage atomically', () => {
   const result = analyzePhysicsProgressStepCutover({
     physicsSource: stagedPhysics(),
     domainSource: DOMAIN_SOURCE
@@ -56,6 +59,8 @@ test('cuts over speed, distance and score ownership atomically', () => {
   assert.ok(result.physicsSource.includes(PROGRESS_CALL_BLOCK));
   assert.ok(result.physicsSource.includes(DISTANCE_APPLICATION));
   assert.ok(result.physicsSource.includes(SCORE_APPLICATION));
+  assert.ok(result.physicsSource.includes(EXTRACTED_DISTANCE_USAGE));
+  assert.equal(result.physicsSource.includes(LEGACY_DISTANCE_USAGE), false);
   for (const block of Object.values(LEGACY_BLOCKS)) {
     assert.equal(result.physicsSource.includes(block), false);
   }
@@ -67,7 +72,8 @@ test('preserves tube-visual and adaptive-profile ordering around the extracted c
   assert.ok(source.indexOf('gameState.speed = progressStep.speed;') < source.indexOf('gameState.tubeVisualSpeed +='));
   assert.ok(source.indexOf(DISTANCE_APPLICATION) < source.indexOf('const adaptiveProfile ='));
   assert.ok(source.indexOf('logger.debug(adaptiveProfile);') < source.indexOf(SCORE_APPLICATION));
-  assert.ok(source.indexOf(SCORE_APPLICATION) < source.indexOf("getSpacing('coin')"));
+  assert.ok(source.indexOf(SCORE_APPLICATION) < source.indexOf(EXTRACTED_DISTANCE_USAGE));
+  assert.ok(source.indexOf(EXTRACTED_DISTANCE_USAGE) < source.indexOf("getSpacing('coin')"));
 });
 
 test('accepts an already extracted no-op', () => {
@@ -85,6 +91,13 @@ test('rejects partial legacy ownership before transforming', () => {
   }), /partial legacy progress calculation/);
 });
 
+test('rejects a missing legacy metersDelta threshold usage', () => {
+  assert.throws(() => analyzePhysicsProgressStepCutover({
+    physicsSource: stagedPhysics({ includeDistanceUsage: false }),
+    domainSource: DOMAIN_SOURCE
+  }), /missing the legacy metersDelta distance-threshold usage/);
+});
+
 test('rejects a missing import anchor', () => {
   assert.throws(() => transformPhysics(stagedPhysics({ includeAnchor: false })), /import anchor not found/);
 });
@@ -100,4 +113,9 @@ test('does not accept an extracted call without the domain import', () => {
     physicsSource: first.physicsSource.replace(`import { calculateProgressStep } ${DOMAIN_IMPORT};\n`, ''),
     domainSource: DOMAIN_SOURCE
   }), /must import/);
+});
+
+test('regression: transformed source has no bare metersDelta usage', () => {
+  const result = analyzePhysicsProgressStepCutover({ physicsSource: stagedPhysics(), domainSource: DOMAIN_SOURCE });
+  assert.equal(/(?<![.\w])metersDelta(?![\w])/.test(result.physicsSource), false);
 });

--- a/scripts/physics-progress-step-staging.test.mjs
+++ b/scripts/physics-progress-step-staging.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
-  CALL_MARKER,
   DOMAIN_IMPORT,
   EXTRACTED_TOKENS,
   LEGACY_BLOCKS,
+  LEGACY_DISTANCE_USAGE,
   analyzePhysicsProgressStepStaging,
   inspectLegacyProgressBlocks
 } from './check-physics-progress-step-staging.mjs';
@@ -24,7 +24,7 @@ function calculateProgressStep({ distance, delta, speedStart, speedIncrementInte
 export { calculateProgressStep };
 `;
 
-function stagedPhysics({ omit = null, importDomain = false } = {}) {
+function stagedPhysics({ omit = null, importDomain = false, includeDistanceUsage = true } = {}) {
   const blocks = Object.entries(LEGACY_BLOCKS)
     .filter(([name]) => name !== omit)
     .map(([, block]) => block);
@@ -34,6 +34,7 @@ ${blocks[0] || ''}
 ${blocks[1] || ''}
   const adaptiveProfile = getAdaptiveDifficultyProfile({ distance: gameState.distance });
 ${blocks[2] || ''}
+  ${includeDistanceUsage ? `if (gameState.distance - metersDelta > 100) queueCoinRingSpawn();` : ''}
 }`;
 }
 
@@ -46,13 +47,14 @@ function extractedPhysics({ importDomain = true, omitToken = null } = {}) {
 }`;
 }
 
-test('accepts the staged state only when all three legacy blocks remain', () => {
+test('accepts staged ownership only with all blocks and threshold usage', () => {
   const result = analyzePhysicsProgressStepStaging({
     physicsSource: stagedPhysics(),
     domainSource: DOMAIN_SOURCE
   });
   assert.equal(result.state, 'staged-inline');
   assert.deepEqual(result.legacyBlocks, { speed: true, distance: true, score: true });
+  assert.equal(result.hasLegacyDistanceUsage, true);
 });
 
 test('reports the three legacy ownership blocks independently', () => {
@@ -70,6 +72,13 @@ test('rejects partial removal of any legacy progress block', () => {
       domainSource: DOMAIN_SOURCE
     }), /partial legacy progress calculation/);
   }
+});
+
+test('rejects staged ownership without the metersDelta threshold usage', () => {
+  assert.throws(() => analyzePhysicsProgressStepStaging({
+    physicsSource: stagedPhysics({ includeDistanceUsage: false }),
+    domainSource: DOMAIN_SOURCE
+  }), /missing the legacy metersDelta distance-threshold usage/);
 });
 
 test('rejects an extracted import while legacy blocks remain', () => {
@@ -98,6 +107,13 @@ test('requires the import and every extracted application token', () => {
       domainSource: DOMAIN_SOURCE
     }), /incomplete extracted progress-step application/);
   }
+});
+
+test('rejects any remaining bare metersDelta reference after extraction', () => {
+  assert.throws(() => analyzePhysicsProgressStepStaging({
+    physicsSource: `${extractedPhysics()}\nif (${LEGACY_DISTANCE_USAGE}) queueCoinRingSpawn();`,
+    domainSource: DOMAIN_SOURCE
+  }), /still references metersDelta/);
 });
 
 test('rejects drift in the staged domain contract', () => {


### PR DESCRIPTION
## Fix
The final review of the transformed real `js/physics.js` found one downstream reference to the removed local `metersDelta` variable in the 100-meter coin-ring threshold check.

This PR:
- treats that threshold usage as part of the staged ownership contract;
- rewrites it to `progressStep.metersDelta` atomically with the other progress blocks;
- rejects extracted states with any remaining bare `metersDelta` reference;
- adds regression coverage for the real failure mode.

## Validation
- progress behavior/staging/cutover tests: 24/24 passed locally;
- combined collision + progress focused tests: 42/42 passed locally;
- the corrected transformed real physics file passes syntax and both extracted-state guards.

## Scope
Tooling/guards only. Runtime files are not changed in this PR.

Refs #1789.
Refs #1791.