### PR TITLE
Fix physics effect timer reset guard

### DIFF
--- a/scripts/check-physics-effect-timers-staging.mjs
+++ b/scripts/check-physics-effect-timers-staging.mjs
@@ -70,7 +70,7 @@ function analyzePhysicsEffectTimersStaging({ physicsSource, domainSource }) {
     'player.magnetTimer -= delta',
     'player.invertTimer -= delta',
     'gameState.x2Timer -= delta',
-    'gameState.baseMultiplier = 1'
+    'if (gameState.x2Timer <= 0) gameState.baseMultiplier = 1;'
   ].filter((token) => source.includes(token));
   if (legacyFragments.length > 0) throw new Error(`${PHYSICS_PATH} has partial legacy effect-timer fragments: ${legacyFragments.join(', ')}`);
   if (!hasDomainImport) throw new Error(`${PHYSICS_PATH} must import ${DOMAIN_PATH} after effect-timers extraction`);

--- a/scripts/physics-effect-timers-staging.test.mjs
+++ b/scripts/physics-effect-timers-staging.test.mjs
@@ -33,9 +33,9 @@ ${block}
 }`;
 }
 
-function extractedPhysics({ importDomain = true, omitToken = null } = {}) {
+function extractedPhysics({ importDomain = true, omitToken = null, includeReset = false } = {}) {
   const body = EXTRACTED_TOKENS.filter((token) => token !== omitToken).join('\n  ');
-  return `${importDomain ? `import { calculateEffectTimersStep } ${DOMAIN_IMPORT};\n` : ''}function update(delta) {
+  return `${importDomain ? `import { calculateEffectTimersStep } ${DOMAIN_IMPORT};\n` : ''}${includeReset ? 'function resetSession() { gameState.baseMultiplier = 1; }\n' : ''}function update(delta) {
   updateSpin(delta);
   ${body}
   const p = projectPlayer(1);
@@ -50,6 +50,14 @@ test('accepts the complete staged timer block', () => {
 
 test('accepts the future extracted state', () => {
   const result = analyzePhysicsEffectTimersStaging({ physicsSource: extractedPhysics(), domainSource: DOMAIN_SOURCE });
+  assert.equal(result.state, 'extracted');
+});
+
+test('allows the independent session-reset base multiplier assignment', () => {
+  const result = analyzePhysicsEffectTimersStaging({
+    physicsSource: extractedPhysics({ includeReset: true }),
+    domainSource: DOMAIN_SOURCE
+  });
   assert.equal(result.state, 'extracted');
 });
 


### PR DESCRIPTION
## Fix
The extracted-state guard used the generic token `gameState.baseMultiplier = 1`, which also appears in `resetGameSessionState()`. That independent reset assignment caused a false partial-extraction failure after the real effect-timers cutover.

This PR:
- narrows the legacy fragment to the exact x2-expiry conditional;
- keeps the independent session-reset assignment valid;
- adds regression coverage for the real `resetGameSessionState()` shape.

## Validation
- effect-timers behavior, ownership and cutover tests: 21/21 passed locally;
- two-file guard/test diff only;
- no runtime changes.

Refs #1789.
Refs #1791.