### PR TITLE
Execute account and share API facade cutover

### DIFF
--- a/.github/workflows/phase3-api-runtime-cutover.yml
+++ b/.github/workflows/phase3-api-runtime-cutover.yml
@@ -44,16 +44,27 @@ jobs:
           console.log(`js/api.js cutover size: ${lines} lines`);
           NODE
 
-      - name: Validate API facade and budgets
+      - name: Validate API module syntax
         run: |
           node --check js/api.js
           node --check js/api/account-share.js
-          node scripts/check-api-account-share-staging.mjs
+
+      - name: Validate API ownership
+        run: node scripts/check-api-account-share-staging.mjs
+
+      - name: Validate API budgets
+        run: |
           node scripts/check-api-domain-size-budget.mjs
           node scripts/check-js-size-budget.mjs
-          node scripts/check-syntax.mjs
-          node scripts/check-static-analysis.mjs
-          node scripts/check-unused-code.mjs
+
+      - name: Validate repository syntax
+        run: node scripts/check-syntax.mjs
+
+      - name: Validate static analysis
+        run: node scripts/check-static-analysis.mjs
+
+      - name: Validate unused code
+        run: node scripts/check-unused-code.mjs
 
       - name: Run focused API tests
         run: |

--- a/.github/workflows/phase3-api-runtime-cutover.yml
+++ b/.github/workflows/phase3-api-runtime-cutover.yml
@@ -1,0 +1,89 @@
+name: Phase 3 API runtime cutover
+
+on:
+  pull_request:
+    branches:
+      - sandbox/phase3-api-runtime-base
+
+permissions:
+  contents: write
+
+jobs:
+  cutover:
+    if: github.event.pull_request.head.ref == 'sandbox/phase3-api-runtime-exec'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out execution branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Apply account/share facade cutover
+        run: node scripts/cutover-api-account-share.mjs
+
+      - name: Tighten API line budget
+        run: |
+          node --input-type=module <<'NODE'
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const apiPath = 'js/api.js';
+          const budgetPath = 'scripts/check-js-size-budget.mjs';
+          const lines = readFileSync(apiPath, 'utf8').split('\n').length;
+          const source = readFileSync(budgetPath, 'utf8');
+          const next = source.replace(/\['js\/api\.js',\s*\d+\]/, `['js/api.js', ${lines}]`);
+          if (next === source) throw new Error('API budget entry was not updated');
+          writeFileSync(budgetPath, next);
+          console.log(`js/api.js cutover size: ${lines} lines`);
+          NODE
+
+      - name: Validate API facade and budgets
+        run: |
+          node --check js/api.js
+          node --check js/api/account-share.js
+          node scripts/check-api-account-share-staging.mjs
+          node scripts/check-api-domain-size-budget.mjs
+          node scripts/check-js-size-budget.mjs
+          node scripts/check-syntax.mjs
+          node scripts/check-static-analysis.mjs
+          node scripts/check-unused-code.mjs
+
+      - name: Run focused API tests
+        run: |
+          node --test \
+            scripts/api-account-share-staging.test.mjs \
+            scripts/api-account-share-cutover.test.mjs \
+            scripts/api-domain-size-budget.test.mjs \
+            scripts/request.test.mjs \
+            scripts/auth-callbacks.test.mjs \
+            scripts/player-menu-history-web.test.mjs \
+            scripts/referral-code.test.mjs \
+            scripts/telegram-auth-lifecycle.test.mjs
+
+      - name: Verify isolated runtime diff
+        run: |
+          git diff --check
+          expected=$(printf '%s\n' \
+            'js/api.js' \
+            'js/api/account-share.js' \
+            'scripts/check-js-size-budget.mjs' | sort)
+          actual=$(git status --short | sed 's/^...//' | sort)
+          test "$actual" = "$expected"
+
+      - name: Commit clean runtime result
+        env:
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git rm .github/workflows/phase3-api-runtime-cutover.yml
+          git add js/api.js js/api/account-share.js scripts/check-js-size-budget.mjs
+          git commit -m 'Apply account and share API facade cutover'
+          git push origin "HEAD:${HEAD_BRANCH}"


### PR DESCRIPTION
Diagnostic API sandbox. The original import-and-reexport cutover passed transformation, syntax, ownership and budgets but static analysis rejected facade-only imports. The tooling is being replaced with direct ESM re-exports, and the runtime sandbox will be recreated after repository-wide stale export cleanup. Closed without merge.