### PR TITLE
Use direct re-exports for API facade cutover

### DIFF
--- a/scripts/api-account-share-cutover.test.mjs
+++ b/scripts/api-account-share-cutover.test.mjs
@@ -4,9 +4,11 @@ import { test } from 'node:test';
 import { DOMAIN_MARKER, EXPECTED_FUNCTIONS } from './check-api-account-share-staging.mjs';
 import {
   DOMAIN_EXPORT_BLOCK,
-  DOMAIN_IMPORT_STATEMENT,
+  DOMAIN_PUBLIC_NAMES,
+  DOMAIN_REEXPORT_STATEMENT,
   IMPORT_REWRITES,
   analyzeApiAccountShareCutover,
+  removeDomainNamesFromFacadeExport,
   transformApiFacade,
   transformDomainModule
 } from './cutover-api-account-share.mjs';
@@ -26,8 +28,12 @@ function stagedSection() {
   return `${DOMAIN_MARKER}\n${EXPECTED_FUNCTIONS.map(declaration).join('\n\n')}`;
 }
 
+function facadeExportBlock() {
+  return `export {\n  localFacade,\n${DOMAIN_PUBLIC_NAMES.map((name) => `  ${name},`).join('\n')}\n};`;
+}
+
 function apiSource(section = stagedSection()) {
-  return `${REQUEST_IMPORT}\n${AUTH_IMPORT}\n${AUTH_STATE_IMPORT}\n${STORE_IMPORT}\n${BALANCE_IMPORT}\n\n${section}\n\nexport {\n  buildAuthHeaders,\n  fetchMyProfile,\n  startShare\n};\n`;
+  return `${REQUEST_IMPORT}\n${AUTH_IMPORT}\n${AUTH_STATE_IMPORT}\n${STORE_IMPORT}\n${BALANCE_IMPORT}\n\nfunction localFacade() { return true; }\n\n${section}\n\n${facadeExportBlock()}\n`;
 }
 
 function domainSource(section = stagedSection(), exportBlock = '') {
@@ -48,11 +54,40 @@ test('cuts over the staged account/share API atomically', () => {
   assert.equal(result.before.state, 'staged-duplicate');
   assert.equal(result.after.state, 'extracted');
   assert.equal(result.apiSource.includes(DOMAIN_MARKER), false);
-  assert.equal(result.apiSource.includes(DOMAIN_IMPORT_STATEMENT), true);
+  assert.equal(result.apiSource.includes(DOMAIN_REEXPORT_STATEMENT), true);
   assert.equal(result.apiSource.includes(REQUEST_IMPORT), false);
   assert.equal(result.apiSource.includes(AUTH_STATE_IMPORT), false);
   assert.equal(result.apiSource.includes(BALANCE_IMPORT), false);
   assert.equal(result.domainSource.includes(DOMAIN_EXPORT_BLOCK), true);
+});
+
+test('uses a direct ESM re-export instead of facade-only imports', () => {
+  const result = analyzeApiAccountShareCutover({
+    apiSource: apiSource(),
+    domainSource: domainSource()
+  });
+  assert.ok(result.apiSource.includes(`} from './api/account-share.js';`));
+  assert.equal(result.apiSource.includes("import { applyReferralCode"), false);
+
+  const localExport = result.apiSource.slice(result.apiSource.lastIndexOf('\nexport {'));
+  assert.ok(localExport.includes('localFacade'));
+  for (const name of DOMAIN_PUBLIC_NAMES) {
+    assert.equal(new RegExp(`^\\s*${name},?\\s*$`, 'm').test(localExport), false);
+  }
+});
+
+test('requires every staged public name in the facade export block', () => {
+  const incomplete = apiSource().replace('  startShare,\n', '');
+  assert.throws(() => transformApiFacade(incomplete), /missing staged domain export: startShare/);
+});
+
+test('removes only domain names from the local facade export block', () => {
+  const source = `function localFacade() {}\n${facadeExportBlock()}\n`;
+  const result = removeDomainNamesFromFacadeExport(source);
+  assert.ok(result.includes('localFacade'));
+  for (const name of DOMAIN_PUBLIC_NAMES) {
+    assert.equal(new RegExp(`^\\s*${name},?\\s*$`, 'm').test(result), false);
+  }
 });
 
 test('accepts an already extracted no-op', () => {

--- a/scripts/cutover-api-account-share.mjs
+++ b/scripts/cutover-api-account-share.mjs
@@ -10,7 +10,32 @@ import {
 const DEFAULT_API_PATH = 'js/api.js';
 const DEFAULT_DOMAIN_PATH = 'js/api/account-share.js';
 const EXPORT_MARKER = '\nexport {';
-const DOMAIN_IMPORT_STATEMENT = "import { applyReferralCode, buildAuthHeaders, confirmShare, disconnectX, fetchCoinHistory, fetchMyProfile, getXOAuthAuthorizeUrl, handleUnauthorizedResponse, setLeaderboardDisplay, setNickname, startShare } from './api/account-share.js';";
+const DOMAIN_PUBLIC_NAMES = Object.freeze([
+  'applyReferralCode',
+  'buildAuthHeaders',
+  'confirmShare',
+  'disconnectX',
+  'fetchCoinHistory',
+  'fetchMyProfile',
+  'getXOAuthAuthorizeUrl',
+  'handleUnauthorizedResponse',
+  'setLeaderboardDisplay',
+  'setNickname',
+  'startShare'
+]);
+const DOMAIN_REEXPORT_STATEMENT = `export {
+  applyReferralCode,
+  buildAuthHeaders,
+  confirmShare,
+  disconnectX,
+  fetchCoinHistory,
+  fetchMyProfile,
+  getXOAuthAuthorizeUrl,
+  handleUnauthorizedResponse,
+  setLeaderboardDisplay,
+  setNickname,
+  startShare
+} from './api/account-share.js';`;
 const DOMAIN_EXPORT_BLOCK = `export {
   applyReferralCode,
   buildAuthHeaders,
@@ -63,6 +88,32 @@ function applyRequiredRewrite(source, { before, after }) {
   return source.replace(before, after);
 }
 
+function removeDomainNamesFromFacadeExport(source) {
+  const exportIndex = source.lastIndexOf(EXPORT_MARKER);
+  if (exportIndex < 0) throw new Error(`${DEFAULT_API_PATH} has no facade export block after extraction`);
+  const exportEnd = source.indexOf('\n};', exportIndex);
+  if (exportEnd < 0) throw new Error(`${DEFAULT_API_PATH} facade export block is not terminated`);
+
+  const exportBlock = source.slice(exportIndex, exportEnd + 3);
+  const removed = new Set();
+  const publicNames = new Set(DOMAIN_PUBLIC_NAMES);
+  const nextBlock = exportBlock
+    .split('\n')
+    .filter((line) => {
+      const match = line.match(/^\s*([A-Za-z_$][\w$]*),?\s*$/);
+      if (!match || !publicNames.has(match[1])) return true;
+      removed.add(match[1]);
+      return false;
+    })
+    .join('\n');
+
+  for (const name of DOMAIN_PUBLIC_NAMES) {
+    if (!removed.has(name)) throw new Error(`${DEFAULT_API_PATH} facade export block is missing staged domain export: ${name}`);
+  }
+
+  return `${source.slice(0, exportIndex)}${nextBlock}${source.slice(exportEnd + 3)}`;
+}
+
 function transformApiFacade(apiSource) {
   let source = String(apiSource || '').replace(/\r\n/g, '\n');
   const startIndex = source.indexOf(DOMAIN_MARKER);
@@ -84,11 +135,12 @@ function transformApiFacade(apiSource) {
   if (!source.includes(DOMAIN_IMPORT_ANCHOR)) {
     throw new Error(`API domain import anchor not found: ${DOMAIN_IMPORT_ANCHOR}`);
   }
-  source = source.replace(DOMAIN_IMPORT_ANCHOR, `${DOMAIN_IMPORT_ANCHOR}\n${DOMAIN_IMPORT_STATEMENT}`);
+  source = source.replace(DOMAIN_IMPORT_ANCHOR, `${DOMAIN_IMPORT_ANCHOR}\n${DOMAIN_REEXPORT_STATEMENT}`);
 
   const updatedStartIndex = source.indexOf(DOMAIN_MARKER);
   const updatedExportIndex = source.indexOf(EXPORT_MARKER, updatedStartIndex + DOMAIN_MARKER.length);
-  source = `${source.slice(0, updatedStartIndex)}${source.slice(updatedExportIndex)}`
+  source = `${source.slice(0, updatedStartIndex)}${source.slice(updatedExportIndex)}`;
+  source = removeDomainNamesFromFacadeExport(source)
     .replace(/\n{3,}/g, '\n\n')
     .trimEnd();
 
@@ -102,8 +154,7 @@ function transformDomainModule(domainSource) {
   }
 
   if (source.includes(EXPORT_MARKER)) {
-    for (const name of DOMAIN_EXPORT_BLOCK.match(/[A-Za-z][A-Za-z0-9]*/g) || []) {
-      if (name === 'export') continue;
+    for (const name of DOMAIN_PUBLIC_NAMES) {
       if (!source.slice(source.lastIndexOf(EXPORT_MARKER)).includes(name)) {
         throw new Error(`${DEFAULT_DOMAIN_PATH} export block is incomplete: ${name}`);
       }
@@ -193,9 +244,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 
 export {
   DOMAIN_EXPORT_BLOCK,
-  DOMAIN_IMPORT_STATEMENT,
+  DOMAIN_PUBLIC_NAMES,
+  DOMAIN_REEXPORT_STATEMENT,
   IMPORT_REWRITES,
   analyzeApiAccountShareCutover,
+  removeDomainNamesFromFacadeExport,
   transformApiFacade,
   transformDomainModule
 };


### PR DESCRIPTION
## Fix
The account/share cutover previously imported domain functions into `api.js` only to export them again. This version uses a direct ESM re-export:

```js
export { ... } from './api/account-share.js';
```

It also:
- removes the eleven public domain names from the local facade export block;
- requires every staged public name before transformation;
- keeps `getXStatus` private because it was not part of the existing facade API;
- adds regression coverage for incomplete exports, direct re-export shape and preservation of unrelated facade exports.

## Scope
Tooling/tests only. Runtime files remain staged.

## Dependency
Stacked on #1889 so the AST unused-code analyzer understands direct re-exports correctly.

Refs #1789.
Refs #1791.