### PR TITLE
Fix bootstrap profile/share parity range

### DIFF
--- a/js/game/bootstrap/profile-share-setup.js
+++ b/js/game/bootstrap/profile-share-setup.js
@@ -11,8 +11,6 @@ let profileCacheTimestamp = 0;
 const PROFILE_CACHE_TTL_MS = 30000;
 const ONBOARDING_GAME_OVER_RETRY_ATTEMPTS = 5;
 const ONBOARDING_GAME_OVER_RETRY_DELAY_MS = 500;
-let onboardingGameOverRetryTimer = null;
-let onboardingGameOverRetryJobId = 0;
 
 function enforceTelegramWalletUiHidden() {
   if (!(window.__URSASS_IS_TELEGRAM_RUNTIME__ || isTelegramMiniApp()) || typeof document === 'undefined') return;
@@ -33,6 +31,8 @@ function invalidateProfileCache() {
   cachedProfile = null;
   profileCacheTimestamp = 0;
 }
+let onboardingGameOverRetryTimer = null;
+let onboardingGameOverRetryJobId = 0;
 function cancelGameOverOnboardingRetries() {
   onboardingGameOverRetryJobId += 1;
   if (onboardingGameOverRetryTimer) {

--- a/scripts/bootstrap-profile-share-staging.test.mjs
+++ b/scripts/bootstrap-profile-share-staging.test.mjs
@@ -14,6 +14,7 @@ const ASYNC_FUNCTIONS = new Set([
   'refreshOnboardingAfterLeaderboardSaveSuccess',
   'updateGameOverShareButton'
 ]);
+const ONBOARDING_TIMER_STATE = 'let onboardingGameOverRetryTimer = null;\nlet onboardingGameOverRetryJobId = 0;';
 
 function declaration(name) {
   const prefix = ASYNC_FUNCTIONS.has(name) ? 'async ' : '';
@@ -22,6 +23,13 @@ function declaration(name) {
 
 function section(names = EXPECTED_FUNCTIONS) {
   return names.map(declaration).join('\n\n');
+}
+
+function sectionWithTimerState() {
+  return section().replace(
+    declaration('cancelGameOverOnboardingRetries'),
+    `${ONBOARDING_TIMER_STATE}\n${declaration('cancelGameOverOnboardingRetries')}`
+  );
 }
 
 function bootstrapSource(body = section(), importLine = '') {
@@ -52,6 +60,13 @@ test('rejects staged parity drift', () => {
   assert.throws(() => analyzeBootstrapProfileShareStaging({
     bootstrapSource: bootstrapSource(),
     domainSource: domainSource(section().replace("return 'checkXOAuthCallback'", "return 'changed'"))
+  }), /must match profile\/share setup/);
+});
+
+test('rejects timer state moved outside the owned section', () => {
+  assert.throws(() => analyzeBootstrapProfileShareStaging({
+    bootstrapSource: bootstrapSource(sectionWithTimerState()),
+    domainSource: `${ONBOARDING_TIMER_STATE}\n${domainSource()}`
   }), /must match profile\/share setup/);
 });
 


### PR DESCRIPTION
## Fix
The staged module placed `onboardingGameOverRetryTimer` and `onboardingGameOverRetryJobId` before the ownership start marker, while `bootstrap.js` keeps them inside the bounded profile/share section. That would make the parity guard fail once CI runs.

This PR:
- moves the two timer state declarations into the exact source position after `invalidateProfileCache()`;
- adds a regression fixture that rejects moving timer state outside the owned section.

## Validation
- actual bootstrap parity reports `staged-duplicate` with 113 lines;
- 8/8 staging fixtures pass;
- module syntax passes;
- diff is limited to the staged module and its fixture.

Refs #1789.
Refs #1791.