### PR TITLE
Re-run direct re-export API runtime cutover

### DIFF
--- a/.github/workflows/api-runtime-v2.yml
+++ b/.github/workflows/api-runtime-v2.yml
@@ -75,3 +75,5 @@ jobs:
           git add js/api.js js/api/account-share.js scripts/check-js-size-budget.mjs
           git commit -m 'Apply account and share API facade cutover'
           git push origin HEAD:agent/api-runtime-result-v2
+
+# Refreshed after dev2 db304a02f711f90f661a0e3db564f345ec562ca7


### PR DESCRIPTION
Disposable re-run on refreshed `agent/api-runtime-result-v2`, reset to current `dev2` commit `db304a02f711f90f661a0e3db564f345ec562ca7`. The custom workflow applies and validates the API cutover and pushes only the three approved runtime files. This sandbox PR will not be merged into `dev2`.