### PR TITLE
Diagnose direct re-export API cutover

### DIFF
--- a/.github/workflows/api-runtime-v2.yml
+++ b/.github/workflows/api-runtime-v2.yml
@@ -1,4 +1,4 @@
-name: API runtime v2 executor
+name: API runtime diagnostic
 
 on:
   pull_request:
@@ -6,10 +6,10 @@ on:
       - sandbox/api-runtime-v2-base
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  cutover:
+  diagnose:
     if: github.event.pull_request.head.ref == 'sandbox/api-runtime-v2-exec'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -19,61 +19,21 @@ jobs:
           ref: agent/api-runtime-result-v2
           fetch-depth: 0
           show-progress: false
-          persist-credentials: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: npm ci --silent
-      - name: Apply direct re-export API cutover
-        run: node scripts/cutover-api-account-share.mjs
-      - name: Tighten API line budget
+      - name: Capture API cutover failure
+        shell: bash
         run: |
-          node --input-type=module <<'NODE'
-          import { readFileSync, writeFileSync } from 'node:fs';
-          const apiPath = 'js/api.js';
-          const budgetPath = 'scripts/check-js-size-budget.mjs';
-          const lines = readFileSync(apiPath, 'utf8').split('\n').length;
-          const source = readFileSync(budgetPath, 'utf8');
-          const next = source.replace(/\['js\/api\.js',\s*\d+\]/, `['js/api.js', ${lines}]`);
-          if (next === source) throw new Error('API budget entry was not updated');
-          writeFileSync(budgetPath, next);
-          console.log(`js/api.js cutover size: ${lines} lines`);
-          NODE
-      - name: Validate API facade and analysis
-        run: |
-          node --check js/api.js
-          node --check js/api/account-share.js
-          node scripts/check-api-account-share-staging.mjs
-          node scripts/check-api-domain-size-budget.mjs
-          node scripts/check-js-size-budget.mjs
-          node scripts/check-syntax.mjs
-          node scripts/check-static-analysis.mjs
-          node scripts/check-unused-code.mjs
-      - name: Run focused API tests
-        run: |
-          node --test \
-            scripts/unused-code-ast.test.mjs \
-            scripts/api-account-share-staging.test.mjs \
-            scripts/api-account-share-cutover.test.mjs \
-            scripts/api-domain-size-budget.test.mjs \
-            scripts/request.test.mjs \
-            scripts/auth-callbacks.test.mjs \
-            scripts/player-menu-history-web.test.mjs \
-            scripts/referral-code.test.mjs \
-            scripts/telegram-auth-lifecycle.test.mjs
-      - name: Verify and push clean result
-        run: |
-          git diff --check
-          expected=$(printf '%s\n' \
-            'js/api.js' \
-            'js/api/account-share.js' \
-            'scripts/check-js-size-budget.mjs' | sort)
-          actual=$(git status --short | sed 's/^...//' | sort)
-          test "$actual" = "$expected"
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add js/api.js js/api/account-share.js scripts/check-js-size-budget.mjs
-          git commit -m 'Apply account and share API facade cutover'
-          git push origin HEAD:agent/api-runtime-result-v2
-
-# Refreshed after dev2 db304a02f711f90f661a0e3db564f345ec562ca7
+          set +e
+          node scripts/cutover-api-account-share.mjs > api-diagnostic.log 2>&1
+          status=$?
+          printf '\nexit_status=%s\n' "$status" >> api-diagnostic.log
+          cat api-diagnostic.log
+          exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api-cutover-diagnostic
+          path: api-diagnostic.log
+          if-no-files-found: error


### PR DESCRIPTION
Disposable diagnostic PR. Captures only the account/share cutover error into an artifact; does not modify runtime target branches and must not be merged into dev2.