### PR TITLE
Apply account and share API facade cutover

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -3,15 +3,26 @@ import { logger } from './logger.js';
 import { runRefreshPlayerStats } from './player-stats.js';
 // @ts-check
 import { BACKEND_URL, buildBackendUrl } from './config.js';
-import { request, requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ, REQUEST_PROFILE_AUTH_WRITE } from './request.js';
+import { request, requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ } from './request.js';
 import { DOM, getGameplayProgressSnapshot } from './state.js';
 import { WC } from './walletconnect.js';
 import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGameOverLeaderboardNotice, setGameOverPrompt } from './ui.js';
 import { validatePlayerInsights, getRankBucket } from './game/leaderboard-insights.js';
-import { isTelegramAuthMode, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot, isTelegramMiniApp } from './features/auth/index.js';
-import { authState, markAuthExpired } from './auth-state.js';
+import { isTelegramAuthMode, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot } from './features/auth/index.js';
 import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './features/store/index.js';
-import { updateCachedBalance } from './balance-cache.js';
+export {
+  applyReferralCode,
+  buildAuthHeaders,
+  confirmShare,
+  disconnectX,
+  fetchCoinHistory,
+  fetchMyProfile,
+  getXOAuthAuthorizeUrl,
+  handleUnauthorizedResponse,
+  setLeaderboardDisplay,
+  setNickname,
+  startShare
+} from './api/account-share.js';
 const SAVE_RESULT_STATUS = Object.freeze({
   SAVED: 'saved',
   SKIPPED: 'skipped',
@@ -463,167 +474,6 @@ async function fetchSharePayload(wallet) {
   return requestJsonResult(url, REQUEST_PROFILE_LEADERBOARD_READ);
 }
 
-/* ===== NEW PROFILE & REFERRAL & SHARE & X API HELPERS ===== */
-function buildAuthHeaders() {
-  const primaryId = getPrimaryAuthIdentifier();
-  const wallet = getSigningWalletAddress(); // real wallet address, if available
-  const headers = { 'Content-Type': 'application/json' };
-  const sessionToken = String(authState.sessionToken || '').trim();
-  if (sessionToken) headers.Authorization = `Bearer ${sessionToken}`;
-  if (primaryId) {
-    headers['X-Primary-Id'] = String(primaryId);
-    if (wallet) headers['X-Wallet'] = String(wallet);
-  }
-  // in Telegram Mini App also send initData
-  try {
-    if (isTelegramMiniApp() && window.Telegram?.WebApp?.initData) {
-      headers['X-Telegram-Init-Data'] = window.Telegram.WebApp.initData;
-    }
-  } catch (_e) {}
-  return headers;
-}
-
-function handleUnauthorizedResponse(status) {
-  if (status !== 401) return;
-  logger.warn('⚠️ Session token expired or missing. Re-auth required.');
-  markAuthExpired();
-}
-
-async function fetchMyProfile() {
-  try {
-    const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/account/me/profile`, {
-      ...REQUEST_PROFILE_LEADERBOARD_READ,
-      headers: buildAuthHeaders()
-    });
-    handleUnauthorizedResponse(status);
-    if (!ok) return null;
-    updateCachedBalance({
-      gold: data?.gold ?? data?.totalGoldCoins,
-      silver: data?.silver ?? data?.totalSilverCoins
-    });
-    return data;
-  } catch (e) {
-    logger.warn('⚠️ fetchMyProfile error:', e);
-    return null;
-  }
-}
-
-async function fetchCoinHistory(limit = 50) {
-  const url = `${BACKEND_URL}/api/account/me/coin-history?limit=${encodeURIComponent(limit)}`;
-  const { ok, status, data } = await requestJsonResult(url, {
-    ...REQUEST_PROFILE_LEADERBOARD_READ,
-    headers: buildAuthHeaders()
-  });
-  handleUnauthorizedResponse(status);
-  if (!ok) {
-    const error = new Error('Failed to fetch coin history');
-    error.status = data?.status;
-    throw error;
-  }
-  if (Array.isArray(data)) return data;
-  if (Array.isArray(data?.history)) return data.history;
-  if (Array.isArray(data?.items)) return data.items;
-  return [];
-}
-
-async function startShare() {
-  const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/share/start`, {
-    ...REQUEST_PROFILE_AUTH_WRITE,
-    method: 'POST',
-    headers: buildAuthHeaders(),
-    body: JSON.stringify({})
-  });
-  handleUnauthorizedResponse(status);
-  return { ok, status, data };
-}
-
-async function confirmShare(shareId) {
-  const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/share/confirm`, {
-    ...REQUEST_PROFILE_AUTH_WRITE,
-    method: 'POST',
-    headers: buildAuthHeaders(),
-    body: JSON.stringify({ shareId })
-  });
-  handleUnauthorizedResponse(status);
-  return { ok, status, data };
-}
-
-async function getXOAuthAuthorizeUrl() {
-  try {
-    const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/x/oauth/start?mode=json`, {
-      ...REQUEST_PROFILE_AUTH_WRITE,
-      headers: buildAuthHeaders()
-    });
-    handleUnauthorizedResponse(status);
-    return ok ? (data?.authorizeUrl || null) : null;
-  } catch (e) {
-    logger.warn('⚠️ getXOAuthAuthorizeUrl error:', e);
-    return null;
-  }
-}
-
-async function disconnectX() {
-  const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/x/disconnect`, {
-    ...REQUEST_PROFILE_AUTH_WRITE,
-    method: 'POST',
-    headers: buildAuthHeaders(),
-    body: JSON.stringify({})
-  });
-  handleUnauthorizedResponse(status);
-  return { ok, data };
-}
-
-async function getXStatus() {
-  try {
-    const { ok, status, data } = await requestJsonResult(`${BACKEND_URL}/api/x/status`, {
-      ...REQUEST_PROFILE_LEADERBOARD_READ,
-      headers: buildAuthHeaders()
-    });
-    handleUnauthorizedResponse(status);
-    if (!ok) return null;
-    updateCachedBalance({
-      gold: data?.gold ?? data?.totalGoldCoins,
-      silver: data?.silver ?? data?.totalSilverCoins
-    });
-    return data;
-  } catch (e) {
-    logger.warn('⚠️ getXStatus error:', e);
-    return null;
-  }
-}
-
-async function applyReferralCode(referralCode) {
-  const result = await requestJsonResult(`${BACKEND_URL}/api/referral/apply`, {
-    ...REQUEST_PROFILE_AUTH_WRITE,
-    method: 'POST',
-    headers: buildAuthHeaders(),
-    body: JSON.stringify({ referralCode })
-  });
-  handleUnauthorizedResponse(result.status);
-  return result;
-}
-
-async function setNickname(nickname) {
-  const result = await requestJsonResult(`${BACKEND_URL}/api/account/me/nickname`, {
-    ...REQUEST_PROFILE_AUTH_WRITE,
-    method: 'POST',
-    headers: buildAuthHeaders(),
-    body: JSON.stringify({ nickname })
-  });
-  handleUnauthorizedResponse(result.status);
-  return result;
-}
-
-async function setLeaderboardDisplay(mode) {
-  const result = await requestJsonResult(`${BACKEND_URL}/api/account/me/display-mode`, {
-    ...REQUEST_PROFILE_AUTH_WRITE,
-    method: 'POST',
-    headers: buildAuthHeaders(),
-    body: JSON.stringify({ mode })
-  });
-  handleUnauthorizedResponse(result.status);
-  return result;
-}
 export {
   isAuthenticated,
   getAuthIdentifier,
@@ -636,15 +486,4 @@ export {
   saveResultToLeaderboard,
   resetLeaderboardSaveGuards,
   fetchGameOverPreview,
-  fetchMyProfile,
-  fetchCoinHistory,
-  applyReferralCode,
-  startShare,
-  confirmShare,
-  getXOAuthAuthorizeUrl,
-  disconnectX,
-  setNickname,
-  setLeaderboardDisplay,
-  buildAuthHeaders,
-  handleUnauthorizedResponse
 };

--- a/js/api/account-share.js
+++ b/js/api/account-share.js
@@ -166,3 +166,17 @@ async function setLeaderboardDisplay(mode) {
   handleUnauthorizedResponse(result.status);
   return result;
 }
+
+export {
+  applyReferralCode,
+  buildAuthHeaders,
+  confirmShare,
+  disconnectX,
+  fetchCoinHistory,
+  fetchMyProfile,
+  getXOAuthAuthorizeUrl,
+  handleUnauthorizedResponse,
+  setLeaderboardDisplay,
+  setNickname,
+  startShare
+};

--- a/scripts/check-js-size-budget.mjs
+++ b/scripts/check-js-size-budget.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 
 const budgets = [
-  ['js/api.js', 700],
+  ['js/api.js', 490],
   ['js/game/bootstrap.js', 700],
   ['js/physics.js', 609],
 ];


### PR DESCRIPTION
## Runtime change
- removes the duplicated account/profile/referral/share/X implementations from `js/api.js`;
- keeps the existing public facade through direct ESM re-exports from `js/api/account-share.js`;
- keeps `getXStatus` private;
- reduces the `js/api.js` budget from 700 to 490 lines.

## Scope
Exactly three files:
- `js/api.js`
- `js/api/account-share.js`
- `scripts/check-js-size-budget.mjs`

## Validation
- extracted-state ownership is present on the branch;
- facade exports and domain exports were inspected;
- diff is 15 additions / 176 deletions in `api.js`, 14 export additions in the domain module, and the exact budget reduction;
- normal PR CI and Vercel are requested for final verification.

Refs #1789.
Refs #1791.