### PR TITLE
Fix bootstrap cutover ordering validation

### DIFF
--- a/scripts/bootstrap-profile-share-staging.test.mjs
+++ b/scripts/bootstrap-profile-share-staging.test.mjs
@@ -15,6 +15,8 @@ const ASYNC_FUNCTIONS = new Set([
   'updateGameOverShareButton'
 ]);
 const ONBOARDING_TIMER_STATE = 'let onboardingGameOverRetryTimer = null;\nlet onboardingGameOverRetryJobId = 0;';
+const RANK_DOMAIN_IMPORT = "import { buildTakeBackSub, showRankLossToast } from './bootstrap/rank-feedback.js';";
+const START_HOOK_MARKER = '// ===== START HOOK =====';
 
 function declaration(name) {
   const prefix = ASYNC_FUNCTIONS.has(name) ? 'async ' : '';
@@ -54,6 +56,16 @@ test('accepts an exact staged profile/share duplicate', () => {
   assert.equal(result.hasDomainImport, false);
   assert.equal(result.lines > 1, true);
   assert.equal(section().startsWith(START_MARKER), true);
+});
+
+test('accepts staged profile/share ownership after rank feedback extraction', () => {
+  const result = analyzeBootstrapProfileShareStaging({
+    bootstrapSource: `${RANK_DOMAIN_IMPORT}\n${section()}\n\n${START_HOOK_MARKER}\nfunction updateStartHook() {}`,
+    domainSource: domainSource()
+  });
+
+  assert.equal(result.state, 'staged-duplicate');
+  assert.equal(result.hasDomainImport, false);
 });
 
 test('rejects staged parity drift', () => {

--- a/scripts/check-bootstrap-profile-share-staging.mjs
+++ b/scripts/check-bootstrap-profile-share-staging.mjs
@@ -5,6 +5,8 @@ const BOOTSTRAP_PATH = 'js/game/bootstrap.js';
 const DOMAIN_PATH = 'js/game/bootstrap/profile-share-setup.js';
 const START_MARKER = 'function enforceTelegramWalletUiHidden() {';
 const NEXT_MARKER = '// ===== RANK WATCHER =====';
+const RANK_EXTRACTED_NEXT_MARKER = '// ===== START HOOK =====';
+const RANK_DOMAIN_IMPORT = "from './bootstrap/rank-feedback.js'";
 const DOMAIN_IMPORT = "from './bootstrap/profile-share-setup.js'";
 const EXPORT_MARKER = '\nexport {';
 const EXPECTED_FUNCTIONS = [
@@ -30,8 +32,14 @@ function extractBootstrapSection(source) {
   const normalized = String(source || '').replace(/\r\n/g, '\n');
   const startIndex = normalized.indexOf(START_MARKER);
   if (startIndex < 0) return null;
-  const nextIndex = normalized.indexOf(NEXT_MARKER, startIndex + START_MARKER.length);
-  if (nextIndex < 0) throw new Error(`${BOOTSTRAP_PATH} contains ${START_MARKER} but no ${NEXT_MARKER}`);
+
+  let nextIndex = normalized.indexOf(NEXT_MARKER, startIndex + START_MARKER.length);
+  if (nextIndex < 0 && normalized.includes(RANK_DOMAIN_IMPORT)) {
+    nextIndex = normalized.indexOf(RANK_EXTRACTED_NEXT_MARKER, startIndex + START_MARKER.length);
+  }
+  if (nextIndex < 0) {
+    throw new Error(`${BOOTSTRAP_PATH} contains ${START_MARKER} but no ${NEXT_MARKER} or extracted-rank ${RANK_EXTRACTED_NEXT_MARKER}`);
+  }
   return normalized.slice(startIndex, nextIndex).trimEnd();
 }
 

--- a/scripts/startup-performance.test.mjs
+++ b/scripts/startup-performance.test.mjs
@@ -37,7 +37,7 @@ function mockBrowserRuntime() {
   analyticsTarget.dispatchEvent = analyticsTarget.dispatchEvent.bind(analyticsTarget);
   analyticsTarget.addEventListener = analyticsTarget.addEventListener.bind(analyticsTarget);
   analyticsTarget.removeEventListener = analyticsTarget.removeEventListener.bind(analyticsTarget);
-  analyticsTarget.Telegram = { WebApp: { platform: 'ios' } };
+  analyticsTarget.Telegram = { WebApp: { platform: 'ios', initData: 'query=1' } };
 
   globalThis.window = analyticsTarget;
   globalThis.document = {


### PR DESCRIPTION
## Fixes
- lets the profile/share ownership guard use `START HOOK` as its end boundary after rank-feedback has already been extracted;
- keeps the original `RANK WATCHER` boundary mandatory while rank feedback is still staged;
- adds a regression fixture for the sequential cutover order;
- makes the startup-performance Telegram fixture explicit with non-empty `initData`, matching the production runtime detector.

## Root causes
- rank cutover intentionally removes the local `RANK WATCHER` block and marker, so the neighboring profile/share guard could no longer find its old end marker;
- the startup test provided only a Telegram platform, while runtime detection requires init data, URL data/start parameters, or a Telegram user agent.

## Validation target
- rank cutover followed by profile/share staging validation;
- profile/share focused tests including startup-performance;
- no production runtime files changed.

Refs #1789.
Refs #1791.