### PR TITLE
Execute bootstrap rank-feedback runtime cutover v3

### DIFF
--- a/.github/workflows/bootstrap-rank-runtime-v3.yml
+++ b/.github/workflows/bootstrap-rank-runtime-v3.yml
@@ -1,0 +1,81 @@
+name: Bootstrap rank runtime executor v3
+
+on:
+  pull_request:
+    branches:
+      - sandbox/bootstrap-rank-runtime-v3-base
+
+permissions:
+  contents: write
+
+jobs:
+  cutover:
+    if: github.event.pull_request.head.ref == 'sandbox/bootstrap-rank-runtime-v3-exec'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/bootstrap-rank-runtime-result-v3
+          fetch-depth: 0
+          show-progress: false
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci --silent
+      - name: Apply rank-feedback cutover
+        run: node scripts/cutover-bootstrap-rank-feedback.mjs
+      - name: Tighten bootstrap line budget
+        run: |
+          node --input-type=module <<'NODE'
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const bootstrapPath = 'js/game/bootstrap.js';
+          const budgetPath = 'scripts/check-js-size-budget.mjs';
+          const lines = readFileSync(bootstrapPath, 'utf8').split('\n').length;
+          const source = readFileSync(budgetPath, 'utf8');
+          const next = source.replace(/\['js\/game\/bootstrap\.js',\s*\d+\]/, `['js/game/bootstrap.js', ${lines}]`);
+          if (next === source) throw new Error('Bootstrap budget entry was not updated');
+          writeFileSync(budgetPath, next);
+          console.log(`js/game/bootstrap.js cutover size: ${lines} lines`);
+          NODE
+      - name: Validate ownership and analysis
+        run: |
+          node --check js/game/bootstrap.js
+          node --check js/game/bootstrap/rank-feedback.js
+          node scripts/check-bootstrap-rank-feedback-staging.mjs
+          node scripts/check-bootstrap-profile-share-staging.mjs
+          node scripts/check-api-account-share-staging.mjs
+          node scripts/check-api-leaderboard-display-staging.mjs
+          node scripts/check-api-domain-size-budget.mjs
+          node scripts/check-js-size-budget.mjs
+          node scripts/check-syntax.mjs
+          node scripts/check-static-analysis.mjs
+          node scripts/check-unused-code.mjs
+      - name: Run focused tests
+        run: |
+          node --test \
+            scripts/unused-code-ast.test.mjs \
+            scripts/bootstrap-rank-feedback-staging.test.mjs \
+            scripts/bootstrap-rank-feedback-cutover.test.mjs \
+            scripts/bootstrap-profile-share-staging.test.mjs \
+            scripts/bootstrap-profile-share-cutover.test.mjs \
+            scripts/api-leaderboard-display-staging.test.mjs \
+            scripts/api-leaderboard-display-cutover.test.mjs \
+            scripts/game-over-copy.test.mjs \
+            scripts/startup-performance.test.mjs \
+            scripts/auth-callbacks.test.mjs
+      - name: Verify and push clean result
+        run: |
+          git diff --check
+          expected=$(printf '%s\n' \
+            'js/game/bootstrap.js' \
+            'js/game/bootstrap/rank-feedback.js' \
+            'scripts/check-js-size-budget.mjs' | sort)
+          actual=$(git status --short | sed 's/^...//' | sort)
+          test "$actual" = "$expected"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add js/game/bootstrap.js js/game/bootstrap/rank-feedback.js scripts/check-js-size-budget.mjs
+          git commit -m 'Apply bootstrap rank feedback cutover'
+          git push origin HEAD:agent/bootstrap-rank-runtime-result-v3


### PR DESCRIPTION
Isolated execution PR from current `dev2` commit `a16aea2fe10b611b245e4e1de8fd03b390dcb091`. The custom job applies the rank-feedback cutover, tightens the bootstrap budget, validates both bootstrap ownership boundaries and both API guards, runs focused regression tests, and pushes only:

- `js/game/bootstrap.js`
- `js/game/bootstrap/rank-feedback.js`
- `scripts/check-js-size-budget.mjs`

Normal CI is disabled only on this disposable sandbox base. This PR will never be merged into `dev2`.

Refs #1789.
Refs #1791.