### PR TITLE
Apply leaderboard display API runtime cutover

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -2,14 +2,14 @@ import { getInjectedEthereumProvider } from './ethereum-provider.js';
 import { logger } from './logger.js';
 import { runRefreshPlayerStats } from './player-stats.js';
 // @ts-check
-import { BACKEND_URL, buildBackendUrl } from './config.js';
+import { BACKEND_URL } from './config.js';
 import { request, requestJsonResult, REQUEST_PROFILE_LEADERBOARD_READ } from './request.js';
 import { DOM, getGameplayProgressSnapshot } from './state.js';
 import { WC } from './walletconnect.js';
-import { showBonusText, showLeaderboardSkeletons, displayLeaderboard, updateGameOverLeaderboardNotice, setGameOverPrompt } from './ui.js';
-import { validatePlayerInsights, getRankBucket } from './game/leaderboard-insights.js';
-import { isTelegramAuthMode, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier, getAuthStateSnapshot } from './features/auth/index.js';
+import { showBonusText, updateGameOverLeaderboardNotice, setGameOverPrompt } from './ui.js';
+import { isTelegramAuthMode, hasAuthenticatedSession, getPrimaryAuthIdentifier, getSigningWalletAddress as getSigningWalletAddressFromAuth, getTelegramAuthIdentifier } from './features/auth/index.js';
 import { canPersistProgress, isEligibleForLeaderboardFlow, isUnauthRuntimeMode } from './features/store/index.js';
+import { loadAndDisplayLeaderboard } from './api/leaderboard-display.js';
 export {
   applyReferralCode,
   buildAuthHeaders,
@@ -188,77 +188,6 @@ async function signMessage(message) {
   } catch (error) {
     logger.error("❌ Signature error:", error);
     return null;
-  }
-}
-
-function buildBackendApiUrl(pathname) {
-  return new URL(buildBackendUrl(pathname));
-}
-async function loadAndDisplayLeaderboard(options = {}) {
-  const runToken = options?.runToken ?? null;
-  const { userWallet = '' } = getAuthStateSnapshot();
-  showLeaderboardSkeletons();
-  try {
-    const normalizedWallet = String(userWallet || '').trim();
-    const leaderboardUrl = buildBackendApiUrl('/api/leaderboard/top');
-    if (normalizedWallet) {
-      leaderboardUrl.searchParams.set('wallet', normalizedWallet);
-      leaderboardUrl.searchParams.set('v', '2');
-    }
-
-    /** @type {{ ok: boolean, status: number, data: LeaderboardTopResponseV1|LeaderboardTopResponseV2 }} */
-    const { ok, data } = await requestJsonResult(leaderboardUrl.toString(), REQUEST_PROFILE_LEADERBOARD_READ);
-
-    let playerInsights = null;
-    let insightsReason = normalizedWallet ? 'no_data' : 'no_wallet';
-
-    if (ok) {
-      const topInsights = validatePlayerInsights(data?.playerInsights);
-      if (topInsights.ok) {
-        playerInsights = topInsights.data;
-        insightsReason = null;
-      } else if (normalizedWallet) {
-        try {
-          const insightsUrl = buildBackendApiUrl('/api/leaderboard/insights');
-          insightsUrl.searchParams.set('wallet', normalizedWallet);
-          const insightsResult = await requestJsonResult(insightsUrl.toString(), REQUEST_PROFILE_LEADERBOARD_READ);
-          if (insightsResult.ok) {
-            const fallbackInsights = validatePlayerInsights(insightsResult.data?.playerInsights ?? insightsResult.data);
-            if (fallbackInsights.ok) {
-              playerInsights = fallbackInsights.data;
-              insightsReason = null;
-            } else {
-              insightsReason = 'validation_error';
-            }
-          } else {
-            insightsReason = 'api_error';
-          }
-        } catch (error) {
-          logger.warn('⚠️ Leaderboard insights fallback error:', error);
-          insightsReason = 'api_error';
-        }
-      }
-
-      const rankBucket = getRankBucket(playerInsights?.rank ?? data?.playerPosition);
-      const gameOverPrompt = data?.gameOverPrompt && typeof data.gameOverPrompt === 'object' ? data.gameOverPrompt : null;
-      if (gameOverPrompt) setGameOverPrompt(gameOverPrompt, { source: 'save', runToken });
-      displayLeaderboard(data?.leaderboard, data?.playerPosition, {
-        playerInsights,
-        insightsReason,
-        rankBucket,
-        gameOverPrompt,
-        promptSource: 'save',
-        runToken
-      });
-      return { ok: true, playerInsights, insightsReason, rankBucket };
-    }
-
-    displayLeaderboard([], null, { insightsReason: normalizedWallet ? 'api_error' : 'no_wallet', rankBucket: 'unknown' });
-    return { ok: false, playerInsights: null, insightsReason: normalizedWallet ? 'api_error' : 'no_wallet', rankBucket: 'unknown' };
-  } catch (e) {
-    logger.warn("⚠️ Leaderboard unavailable:", e);
-    displayLeaderboard([], null, { insightsReason: 'api_error', rankBucket: 'unknown' });
-    return { ok: false, playerInsights: null, insightsReason: 'api_error', rankBucket: 'unknown' };
   }
 }
 

--- a/js/api/leaderboard-display.js
+++ b/js/api/leaderboard-display.js
@@ -75,3 +75,7 @@ async function loadAndDisplayLeaderboard(options = {}) {
     return { ok: false, playerInsights: null, insightsReason: 'api_error', rankBucket: 'unknown' };
   }
 }
+
+export {
+  loadAndDisplayLeaderboard
+};

--- a/scripts/check-js-size-budget.mjs
+++ b/scripts/check-js-size-budget.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 
 const budgets = [
-  ['js/api.js', 490],
+  ['js/api.js', 419],
   ['js/game/bootstrap.js', 700],
   ['js/physics.js', 609],
 ];


### PR DESCRIPTION
## Runtime change
- removes the duplicated leaderboard display implementation from `js/api.js`;
- imports `loadAndDisplayLeaderboard` from `js/api/leaderboard-display.js` while preserving the existing facade export;
- keeps `buildBackendApiUrl` private to the domain module;
- tightens the `js/api.js` line budget to the post-cutover size.

## Scope
Exactly three files:
- `js/api.js`
- `js/api/leaderboard-display.js`
- `scripts/check-js-size-budget.mjs`

## Validation
The isolated executor completed successfully:
- cutover applied;
- account/share and leaderboard ownership checks passed;
- syntax, static analysis, unused-code and API budgets passed;
- focused API/auth tests passed;
- clean-result allowlist passed before push.

Refs #1789.
Refs #1791.