### PR TITLE
Accept the first startup performance gesture

### DIFF
--- a/js/startup-performance.js
+++ b/js/startup-performance.js
@@ -126,7 +126,7 @@ function resetRunMilestones() {
 
 function recordStartGameClick(metadata = {}) {
   const at = now();
-  if (at - state.lastStartGestureAt < 400) return state.currentRun;
+  if (state.lastStartGestureAt > 0 && at - state.lastStartGestureAt < 400) return state.currentRun;
 
   resetRunMilestones();
   state.runSequence += 1;


### PR DESCRIPTION
## Fix
- prevents the startup telemetry debounce from treating the very first start gesture as a duplicate when `performance.now()` is still below 400 ms;
- preserves the existing 400 ms duplicate suppression for subsequent pointer/click events.

## Root cause
`lastStartGestureAt` starts at `0`, so an immediate first tap produced `at - 0 < 400` and returned without recording a run. That dropped `source`, tap-to-frame and tap-to-simulation telemetry.

## Validation
The existing `startup-performance.test.mjs` reproduces the early-tap case and previously failed with `source: undefined`; this one-line guard makes that regression pass without changing the fixture.

Refs #1789.
Refs #1791.