### PR TITLE
Fix compact web menu flow and dark profile select

### DIFF
--- a/public/css/web-menu-layout.css
+++ b/public/css/web-menu-layout.css
@@ -195,3 +195,138 @@ body.leaderboard-overlay-open #gameStart footer {
   font-size: 8px;
   letter-spacing: -.04em;
 }
+
+html:not(.telegram-runtime) #playerMenuOverlay #pmDisplaySelect {
+  color-scheme: dark;
+  background-color: #050507 !important;
+  color: #fff !important;
+  -webkit-text-fill-color: #fff;
+}
+
+html:not(.telegram-runtime) #playerMenuOverlay #pmDisplaySelect option,
+html:not(.telegram-runtime) #playerMenuOverlay #pmDisplaySelect optgroup {
+  background-color: #050507;
+  color: #fff;
+  -webkit-text-fill-color: #fff;
+}
+
+@media (max-width: 768px) {
+  html:not(.telegram-runtime),
+  html:not(.telegram-runtime) body {
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+    overflow: hidden;
+  }
+
+  html:not(.telegram-runtime) #gameStart {
+    height: 100dvh;
+    min-height: 100dvh;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0;
+    padding: max(72px, calc(env(safe-area-inset-top, 0px) + 56px)) 14px max(24px, env(safe-area-inset-bottom, 0px));
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: auto;
+  }
+
+  html:not(.telegram-runtime) #gameStart > :not(.bear-wrapper):not(.start-audio-nav) {
+    transform: none;
+  }
+
+  html:not(.telegram-runtime) #gameStart .bear-wrapper {
+    width: min(170vw, 720px);
+    height: min(170vw, 720px);
+    max-width: none;
+    max-height: none;
+    top: calc(env(safe-area-inset-top, 0px) - clamp(130px, 24vw, 180px));
+    margin: 0;
+  }
+
+  html:not(.telegram-runtime) #gameStart .new-title {
+    order: 1;
+    position: relative;
+    inset: auto;
+    width: min(92vw, 460px);
+    min-height: 0;
+    margin: clamp(220px, 44vw, 330px) auto 0;
+    font-size: clamp(24px, 6.2vw, 32px);
+    line-height: 1.18;
+  }
+
+  html:not(.telegram-runtime) #appLoadingStatus {
+    order: 2;
+    position: relative;
+    margin: 10px auto 0;
+  }
+
+  html:not(.telegram-runtime) #gameStart .new-buttons {
+    order: 3;
+    position: relative;
+    inset: auto;
+    width: min(86vw, 420px);
+    max-width: min(86vw, 420px);
+    min-height: 0;
+    margin: 18px auto 0;
+    padding: 0;
+    gap: 12px;
+  }
+
+  html:not(.telegram-runtime) #gameStart .start-btn-wrap {
+    order: 1;
+    width: 100%;
+  }
+
+  html:not(.telegram-runtime) #gameStart #storeBtn {
+    order: 2;
+    top: auto;
+    margin: 0;
+  }
+
+  html:not(.telegram-runtime) #gameStart #leaderboardBtn {
+    order: 3;
+    width: 100%;
+    min-width: 0;
+    margin: 0;
+  }
+
+  html:not(.telegram-runtime) #gameStart #ridesInfo {
+    order: 4;
+    width: 100%;
+    min-height: 30px;
+    margin: 2px 0 0;
+    padding: 0;
+  }
+
+  html:not(.telegram-runtime) #gameStart .btn-new.menu-hidden,
+  html:not(.telegram-runtime) #gameStart #ridesInfo:not(.visible) {
+    display: none;
+  }
+
+  html:not(.telegram-runtime) #gameStart #ridesInfo.visible {
+    display: flex;
+  }
+
+  html:not(.telegram-runtime) #gameStart .btn-new {
+    min-height: 50px;
+    padding: 13px 22px;
+  }
+
+  html:not(.telegram-runtime) #gameStart #startBtn {
+    min-height: 62px;
+    margin-top: 0;
+    padding: 16px 22px;
+  }
+
+  html:not(.telegram-runtime) #gameStart footer {
+    order: 5;
+    position: relative;
+    inset: auto;
+    width: min(90vw, 420px);
+    margin: 18px auto 0;
+    padding: 0 0 max(22px, env(safe-area-inset-bottom, 0px));
+    line-height: 1.45;
+  }
+}

--- a/scripts/player-ui-consistency.test.mjs
+++ b/scripts/player-ui-consistency.test.mjs
@@ -88,3 +88,19 @@ test('web overlay CSS fully isolates leaderboard and uses unified black player H
   assert.match(css, /\.pm-content::before[\s\S]*content:\s*none/);
   assert.match(css, /#pmConnectXBtn\[data-text-fit="tight"\][\s\S]*font-size:\s*8px/);
 });
+
+test('web player display select uses a dark native menu with readable text', () => {
+  const css = readFileSync(new URL('../public/css/web-menu-layout.css', import.meta.url), 'utf8');
+  assert.match(css, /#pmDisplaySelect\s*\{[\s\S]*color-scheme:\s*dark/);
+  assert.match(css, /#pmDisplaySelect\s*\{[\s\S]*background-color:\s*#050507\s*!important[\s\S]*color:\s*#fff\s*!important/);
+  assert.match(css, /#pmDisplaySelect option,[\s\S]*#pmDisplaySelect optgroup[\s\S]*background-color:\s*#050507[\s\S]*color:\s*#fff/);
+});
+
+test('compact web menu stays in document flow and only scrolls its own viewport when needed', () => {
+  const css = readFileSync(new URL('../public/css/web-menu-layout.css', import.meta.url), 'utf8');
+  assert.match(css, /@media \(max-width:\s*768px\)[\s\S]*html:not\(\.telegram-runtime\) body[\s\S]*overflow:\s*hidden/);
+  assert.match(css, /html:not\(\.telegram-runtime\) #gameStart\s*\{[\s\S]*height:\s*100dvh[\s\S]*overflow-y:\s*auto[\s\S]*scrollbar-gutter:\s*auto/);
+  assert.match(css, /#gameStart \.new-title\s*\{[\s\S]*position:\s*relative[\s\S]*margin:\s*clamp\(220px,\s*44vw,\s*330px\)/);
+  assert.match(css, /#gameStart \.new-buttons\s*\{[\s\S]*position:\s*relative[\s\S]*inset:\s*auto/);
+  assert.match(css, /#gameStart \.btn-new\.menu-hidden,[\s\S]*#ridesInfo:not\(\.visible\)[\s\S]*display:\s*none/);
+});


### PR DESCRIPTION
Fixes the compact web regressions shown in the latest screenshot.

## What changed
- player-menu leaderboard display select now opts into a dark native color scheme
- select and option backgrounds are black with white text
- the main document is locked to the viewport on the app page so an unnecessary body scrollbar cannot appear
- the compact web start screen now uses normal vertical flow instead of the legacy absolute `50%` positioning
- bear/title spacing is anchored to viewport width, so reducing window height does not pull the lower UI upward over the hero
- the start screen scrolls internally only when its content genuinely exceeds the viewport
- compact web button order remains START GAME → STORE → LEADERBOARD, with rides below
- hidden Store/rides elements no longer reserve blank space in compact web mode
- regression coverage added for dark select styling and compact viewport flow

## Validation
- ✅ full architecture check (`npm run check`)
- ✅ static checks and UI/asset guardrails
- ✅ node tests, including new compact-web regressions
- ✅ production build
- ✅ e2e smoke
- ✅ security audit

Target: `dev2`.