### PR TITLE
Stabilize web start-screen scrollbar

### DIFF
--- a/css/web-scrollbar-stability.css
+++ b/css/web-scrollbar-stability.css
@@ -1,0 +1,12 @@
+/* Keep the web start screen scrollable without a flashing native scrollbar. */
+html:not(.telegram-runtime) #gameStart {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  overflow-anchor: none;
+}
+
+html:not(.telegram-runtime) #gameStart::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -27,6 +27,7 @@ import '../css/rules.css';
 import '../css/responsive.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
+import '../css/web-scrollbar-stability.css';
 
 
 if (typeof window !== 'undefined') {

--- a/scripts/player-ui-consistency.test.mjs
+++ b/scripts/player-ui-consistency.test.mjs
@@ -104,3 +104,11 @@ test('compact web menu stays in document flow and only scrolls its own viewport 
   assert.match(css, /#gameStart \.new-buttons\s*\{[\s\S]*position:\s*relative[\s\S]*inset:\s*auto/);
   assert.match(css, /#gameStart \.btn-new\.menu-hidden,[\s\S]*#ridesInfo:not\(\.visible\)[\s\S]*display:\s*none/);
 });
+
+test('web start screen keeps scrolling without exposing a flashing native scrollbar', () => {
+  const css = readFileSync(new URL('../css/web-scrollbar-stability.css', import.meta.url), 'utf8');
+  const main = readFileSync(new URL('../js/main.js', import.meta.url), 'utf8');
+  assert.match(css, /html:not\(\.telegram-runtime\) #gameStart\s*\{[\s\S]*scrollbar-width:\s*none[\s\S]*overflow-anchor:\s*none/);
+  assert.match(css, /#gameStart::\-webkit-scrollbar\s*\{[\s\S]*display:\s*none[\s\S]*width:\s*0[\s\S]*height:\s*0/);
+  assert.match(main, /import '\.\.\/css\/web-scrollbar-stability\.css';/);
+});


### PR DESCRIPTION
Fixes the main-page scrollbar that appeared and disappeared while the viewport size stayed unchanged.

## Root cause
The fixed `#gameStart` viewport uses `overflow-y: auto`; async font/content updates can move its scroll height across the overflow threshold by a few pixels, making the native scrollbar flash even when no meaningful scrolling is needed.

## What changed
- keep `#gameStart` internally scrollable for genuinely short viewports
- hide only its native scrollbar in web mode across Chromium/WebKit, Firefox, and legacy Edge/IE behavior
- disable scroll anchoring on the start screen so late UI updates do not shift the viewport
- leave player profile/history overlay scrollbars untouched
- add regression coverage and load the focused stylesheet through the normal Vite CSS pipeline

## Validation
- ✅ full architecture check (`npm run check`)
- ✅ static checks and UI/asset guardrails
- ✅ node tests, including the scrollbar stability regression
- ✅ production build
- ✅ e2e smoke
- ✅ security audit

Target: `dev2`.