### PR TITLE
Ensure purchased upgrades load before gameplay

### DIFF
--- a/js/auth-lifecycle.js
+++ b/js/auth-lifecycle.js
@@ -1,4 +1,5 @@
 import { markAuthReady, markAuthFailed } from './app-loading.js';
+
 function initTelegramWalletCornerScrollBehavior() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
   if (window.__ursasTelegramWalletCornerScrollBound) return;
@@ -10,6 +11,18 @@ function initTelegramWalletCornerScrollBehavior() {
   // No scroll-reactive hiding in mini app mode.
   body.classList.remove('is-telegram-wallet-corner-hidden-by-scroll');
   window.__ursasTelegramWalletCornerScrollBound = true;
+}
+
+async function runRequiredPostAuthSync({ runPostAuthSync, logger, context }) {
+  try {
+    // Wallet/profile UI and purchased gameplay effects are required before Start is unlocked.
+    // Leaderboard loading stays non-blocking and is started separately by game bootstrap.
+    await runPostAuthSync({ withLeaderboard: false });
+    return { ok: true, error: null };
+  } catch (error) {
+    logger.warn(`⚠️ Required post-auth sync failed (${context})`, error);
+    return { ok: false, error };
+  }
 }
 
 async function initAuthFlow({
@@ -81,43 +94,57 @@ async function initAuthFlow({
         }
         logger.info('✅ Telegram auth OK:', authState.primaryId);
         updateAuthUI();
-        runPostAuthSync().catch(async (syncError) => {
-          if (isUnauthorizedError(syncError) && telegramInitData) {
-            logger.warn('⚠️ Post-auth sync returned 401; retrying Telegram auth once.');
-            applyAuthSession({
-              nextAuthMode: authState.authMode,
-              nextPrimaryId: authState.primaryId,
-              nextTelegramUser: authState.telegramUser,
-              nextLinkedTelegramId: authState.linkedTelegramId,
-              nextLinkedTelegramUsername: authState.linkedTelegramUsername,
-              nextLinkedWallet: authState.linkedWallet,
-              nextIsWalletConnected: authState.isWalletConnected,
-              nextUserWallet: authState.userWallet,
-              nextSessionToken: null,
-              nextAuthExpired: false,
-            });
-            const retry = await authenticateTelegram({
-              telegramId: authState.telegramUser.id,
-              firstName: authState.telegramUser.firstName,
-              username: authState.telegramUser.username,
-              telegramInitData,
-            });
-            if (retry.ok && retry.data?.success) {
-              applyAuthSession({
-                nextAuthMode: 'telegram',
-                nextPrimaryId: retry.data.primaryId || telegramIdentifier,
-                nextTelegramUser: authState.telegramUser,
-                nextLinkedTelegramId: retry.data.telegramId || authState.telegramUser?.id || null,
-                nextLinkedTelegramUsername: retry.data.telegramUsername || authState.telegramUser?.username || null,
-                nextLinkedWallet: retry.data.wallet,
-                nextIsWalletConnected: true,
-                nextUserWallet: String(retry.data.primaryId || telegramIdentifier || '').trim() || null,
-                nextSessionToken: retry.data.sessionToken || null,
-              });
-              updateAuthUI();
-            }
-          }
+
+        let syncResult = await runRequiredPostAuthSync({
+          runPostAuthSync,
+          logger,
+          context: 'telegram-initial'
         });
+
+        if (!syncResult.ok && isUnauthorizedError(syncResult.error) && telegramInitData) {
+          logger.warn('⚠️ Post-auth sync returned 401; retrying Telegram auth once.');
+          applyAuthSession({
+            nextAuthMode: authState.authMode,
+            nextPrimaryId: authState.primaryId,
+            nextTelegramUser: authState.telegramUser,
+            nextLinkedTelegramId: authState.linkedTelegramId,
+            nextLinkedTelegramUsername: authState.linkedTelegramUsername,
+            nextLinkedWallet: authState.linkedWallet,
+            nextIsWalletConnected: authState.isWalletConnected,
+            nextUserWallet: authState.userWallet,
+            nextSessionToken: null,
+            nextAuthExpired: false,
+          });
+          const retry = await authenticateTelegram({
+            telegramId: authState.telegramUser.id,
+            firstName: authState.telegramUser.firstName,
+            username: authState.telegramUser.username,
+            telegramInitData,
+          });
+          if (retry.ok && retry.data?.success) {
+            applyAuthSession({
+              nextAuthMode: 'telegram',
+              nextPrimaryId: retry.data.primaryId || telegramIdentifier,
+              nextTelegramUser: authState.telegramUser,
+              nextLinkedTelegramId: retry.data.telegramId || authState.telegramUser?.id || null,
+              nextLinkedTelegramUsername: retry.data.telegramUsername || authState.telegramUser?.username || null,
+              nextLinkedWallet: retry.data.wallet,
+              nextIsWalletConnected: true,
+              nextUserWallet: String(retry.data.primaryId || telegramIdentifier || '').trim() || null,
+              nextSessionToken: retry.data.sessionToken || null,
+            });
+            updateAuthUI();
+            syncResult = await runRequiredPostAuthSync({
+              runPostAuthSync,
+              logger,
+              context: 'telegram-retry'
+            });
+          }
+        }
+
+        if (!syncResult.ok) {
+          logger.warn('⚠️ Gameplay upgrade sync is unavailable; continuing with the authenticated session.');
+        }
         markAuthReady();
       } else {
         markAuthFailed('Telegram auth failed. Reopen app.');
@@ -137,8 +164,12 @@ async function initAuthFlow({
   if (authState.sessionToken && authState.primaryId) {
     logger.info('🌐 Browser mode — restored auth session');
     updateAuthUI();
+    await runRequiredPostAuthSync({
+      runPostAuthSync,
+      logger,
+      context: 'browser-restored'
+    });
     markAuthReady();
-    runPostAuthSync().catch((error) => logger.warn('Post-auth sync failed after restore', error));
     return;
   }
 

--- a/scripts/auth-callbacks.test.mjs
+++ b/scripts/auth-callbacks.test.mjs
@@ -158,3 +158,18 @@ test('desktop web menu collapses hidden Store and rides slots', () => {
   assert.match(css, /#gameStart \.start-btn-wrap \{ order: 2;/);
   assert.match(css, /#gameStart #storeBtn \{ order: 3;/);
 });
+
+test('restored and Telegram auth wait for gameplay upgrades before app-ready', () => {
+  const source = readFileSync(new URL('../js/auth-lifecycle.js', import.meta.url), 'utf8');
+  assert.match(source, /await runPostAuthSync\(\{ withLeaderboard: false \}\)/);
+
+  const telegramSyncIndex = source.indexOf("context: 'telegram-initial'");
+  const telegramReadyIndex = source.indexOf('markAuthReady();', telegramSyncIndex);
+  assert.ok(telegramSyncIndex >= 0, 'Telegram required sync must exist');
+  assert.ok(telegramReadyIndex > telegramSyncIndex, 'Telegram auth-ready must follow required gameplay sync');
+
+  const browserSyncIndex = source.indexOf("context: 'browser-restored'");
+  const browserReadyIndex = source.indexOf('markAuthReady();', browserSyncIndex);
+  assert.ok(browserSyncIndex >= 0, 'restored browser required sync must exist');
+  assert.ok(browserReadyIndex > browserSyncIndex, 'restored browser auth-ready must follow required gameplay sync');
+});

--- a/scripts/telegram-auth-lifecycle.test.mjs
+++ b/scripts/telegram-auth-lifecycle.test.mjs
@@ -80,11 +80,12 @@ test('telegram auth success without sessionToken still authenticates and logs wa
   restoreDocument();
 });
 
-test('initAuthFlow does not wait for post-auth sync before marking auth ready', async () => {
+test('initAuthFlow waits for required gameplay sync before marking Telegram auth ready', async () => {
   const restoreDocument = mockDom();
   const { initAuthFlow } = await import(`../js/auth-lifecycle.js?case=${Date.now() + 2}`);
   const authState = { sessionToken: null, telegramUser: null };
   let releaseSync;
+  let syncOptions = null;
   const syncBlocker = new Promise((resolve) => { releaseSync = resolve; });
 
   const previousWindow = globalThis.window;
@@ -100,18 +101,25 @@ test('initAuthFlow does not wait for post-auth sync before marking auth ready', 
     applyAuthSession: (next) => Object.assign(authState, { authMode: next.nextAuthMode, primaryId: next.nextPrimaryId, sessionToken: next.nextSessionToken }),
     logger: { info: () => {}, warn: () => {}, error: () => {} },
     updateAuthUI: () => {},
-    runPostAuthSync: async () => syncBlocker,
+    runPostAuthSync: async (options) => {
+      syncOptions = options;
+      await syncBlocker;
+    },
     clearAuthSessionState: () => {},
     authState,
   });
 
-  const result = await Promise.race([
+  const pendingResult = await Promise.race([
     initPromise.then(() => 'resolved'),
     new Promise((resolve) => setTimeout(() => resolve('timeout'), 50))
   ]);
-  assert.equal(result, 'resolved');
-  assert.equal(authState.authMode, 'telegram');
+  assert.equal(pendingResult, 'timeout');
+  assert.deepEqual(syncOptions, { withLeaderboard: false });
+
   releaseSync();
+  await initPromise;
+  assert.equal(authState.authMode, 'telegram');
+
   if (previousWindow === undefined) delete globalThis.window;
   else globalThis.window = previousWindow;
   restoreDocument();


### PR DESCRIPTION
Fixes a race where restored browser and Telegram sessions could become app-ready before purchased upgrade effects finished loading.

## Root cause
`runPostAuthSync()` was started in the background while `markAuthReady()` ran immediately. A fast Start click could create the first gameplay run with an empty upgrade snapshot.

## What changed
- await the required post-auth sync before marking restored browser and Telegram sessions ready
- keep leaderboard loading non-blocking via `withLeaderboard: false`
- rerun the required gameplay sync after a Telegram 401 re-auth retry
- preserve fail-open behavior if the required sync is unavailable, while removing the normal timing race
- replace the previous regression that explicitly expected auth to finish before gameplay sync
- add coverage that Telegram and restored browser auth-ready follow the required gameplay-state sync

## Validation
- ✅ full architecture check (`npm run check`)
- ✅ static checks and UI/asset guardrails
- ✅ node tests, including required gameplay-sync regressions
- ✅ production build
- ✅ e2e smoke
- ✅ security audit

Target: `dev2`.