### PR TITLE
Unify player menu Back button with overlay navigation

### DIFF
--- a/css/overlay-navigation.css
+++ b/css/overlay-navigation.css
@@ -1,0 +1,35 @@
+/* Shared visual contract for Back controls across Store, Rules, Leaderboard, and Player overlays. */
+.store-nav-btn.app-back-btn,
+.player-menu-overlay .pm-back-btn {
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  line-height: 1;
+  aspect-ratio: 1 / 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, .18);
+  background: rgba(255, 255, 255, .05);
+  color: var(--text);
+  backdrop-filter: blur(12px);
+  font-family: 'Orbitron', sans-serif;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: .6px;
+}
+
+.store-nav-btn.app-back-btn:hover,
+.player-menu-overlay .pm-back-btn:hover {
+  box-shadow: 0 0 18px rgba(140, 80, 255, .3);
+  transform: scale(1.08);
+  border-color: rgba(140, 80, 255, .7);
+}
+
+.store-nav-btn.app-back-btn:active,
+.player-menu-overlay .pm-back-btn:active {
+  transform: scale(0.92);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -28,6 +28,7 @@ import '../css/responsive.css';
 import '../css/style.css';
 import '../css/menu-layout.css';
 import '../css/web-scrollbar-stability.css';
+import '../css/overlay-navigation.css';
 
 
 if (typeof window !== 'undefined') {

--- a/scripts/player-menu-history-web.test.mjs
+++ b/scripts/player-menu-history-web.test.mjs
@@ -5,6 +5,8 @@ import fs from 'node:fs/promises';
 const htmlPath = new URL('../index.html', import.meta.url);
 const cssPath = new URL('../css/style.css', import.meta.url);
 const webMenuCssPath = new URL('../public/css/web-menu-layout.css', import.meta.url);
+const overlayNavigationCssPath = new URL('../css/overlay-navigation.css', import.meta.url);
+const mainPath = new URL('../js/main.js', import.meta.url);
 const controllerPath = new URL('../js/player-menu/controller.js', import.meta.url);
 
 test('index.html includes player menu history section and body container', async () => {
@@ -28,6 +30,15 @@ test('desktop web player menu starts at the scroll origin and keeps Back visible
   assert.match(css, /#playerMenuOverlay\.visible,[\s\S]*#playerMenuOverlay:not\(\[hidden\]\)\s*\{\s*display:\s*block;/i);
   assert.match(css, /#playerMenuOverlay\s+\.pm-back-btn\s*\{[\s\S]*position:\s*fixed;[\s\S]*top:[\s\S]*left:[\s\S]*z-index:\s*151;/i);
   assert.doesNotMatch(css, /place-items:\s*center/i);
+});
+
+test('player menu Back uses the same final visual contract as other overlay Back buttons', async () => {
+  const css = await fs.readFile(overlayNavigationCssPath, 'utf8');
+  const main = await fs.readFile(mainPath, 'utf8');
+  assert.match(css, /\.store-nav-btn\.app-back-btn,\s*\.player-menu-overlay \.pm-back-btn\s*\{/i);
+  assert.match(css, /width:\s*44px;[\s\S]*height:\s*44px;[\s\S]*border:\s*1px solid rgba\(255, 255, 255, \.18\);[\s\S]*background:\s*rgba\(255, 255, 255, \.05\);/i);
+  assert.match(css, /\.store-nav-btn\.app-back-btn:hover,\s*\.player-menu-overlay \.pm-back-btn:hover/i);
+  assert.ok(main.indexOf("import '../css/overlay-navigation.css';") > main.indexOf("import '../css/style.css';"));
 });
 
 test('controller ensures history template and has resilient fallback render states', async () => {


### PR DESCRIPTION
Fixes the Player menu using a visually different Back control from Store, Rules, and Leaderboard.

## What changed
- added one final shared visual contract for overlay Back buttons
- Player menu Back now matches Store/Rules/Leaderboard size, border, fill, hover, and active states
- preserved the Player menu's fixed top-left positioning and scroll behavior
- added regression coverage that the shared CSS loads after legacy Player menu styles

## Validation
- full GitHub Actions CI required before merge

Target: `dev2`.